### PR TITLE
Avoid depending on the type tree outside of node managers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,13 +13,13 @@ The following is a list of tasks, with progress indicated where relevant.
      - The web server is removed. Likely forever, a better solution is to use the `metrics` library to hook into the rust metrics ecosystem.
      - A smattering of TODO's, most are somehow blocked by other tasks.
  - Merge most recent PRs on the main repo, especially the one migrating away from OpenSSL.
- - Split the library into parts again.
+ - **100%** Split the library into parts again.
    - Initially into types, client, core, and server.
    - This is needed for other features.
- - Write a codegen/macro library. Initially this should just replace all the JS codegen, later on it will do _more_.
+ - **70%** Write a codegen/macro library. Initially this should just replace all the JS codegen, later on it will do _more_.
    - It would be best if this could be written in such a way that it can either be used as a core for a macro library, or as a standalone build.rs codegen module.
- - Implement sophisticated event support, using a macro to create event types.
- - Investigate decoding. There are several things that would be interesting to do here.
+ - **70%** Implement sophisticated event support, using a macro to create event types.
+ - **100%?** Investigate decoding. There are several things that would be interesting to do here.
    - Capture request-id/request-handle for error reporting during decoding. This will allow us to fatally fail much less often, but will require major changes to codegen.
    - See if there is a way to avoid needing to pass the ID when decoding ExtensionObjects. This info should be available, either in the object itself or as part of the type being decoded.
  - Flesh out the server and client SDK with tooling for ease if use.

--- a/lib/tests/integration/browse.rs
+++ b/lib/tests/integration/browse.rs
@@ -1,6 +1,7 @@
 use super::utils::setup;
 use opcua::{
     server::address_space::{ObjectBuilder, ReferenceDirection, VariableBuilder},
+    server::node_manager::TypeTree,
     types::{
         BrowseDescription, BrowseDirection, BrowsePath, BrowseResultMask, ByteString, DataTypeId,
         NodeClass, NodeClassMask, NodeId, ObjectId, ObjectTypeId, ReferenceTypeId, RelativePath,

--- a/lib/tests/integration/node_management.rs
+++ b/lib/tests/integration/node_management.rs
@@ -113,7 +113,7 @@ async fn add_delete_reference() {
         sp.find_references(
             &id1,
             None::<(NodeId, bool)>,
-            &type_tree,
+            &*type_tree,
             opcua::types::BrowseDirection::Forward,
         )
         .find(|r| {

--- a/lib/tests/utils/node_manager.rs
+++ b/lib/tests/utils/node_manager.rs
@@ -12,8 +12,8 @@ use opcua::{
                 InMemoryNodeManager, InMemoryNodeManagerBuilder, InMemoryNodeManagerImpl,
                 NamespaceMetadata,
             },
-            AddNodeItem, AddReferenceItem, DeleteNodeItem, DeleteReferenceItem, HistoryNode,
-            HistoryUpdateNode, MethodCall, MonitoredItemRef, MonitoredItemUpdateRef,
+            AddNodeItem, AddReferenceItem, DefaultTypeTree, DeleteNodeItem, DeleteReferenceItem,
+            HistoryNode, HistoryUpdateNode, MethodCall, MonitoredItemRef, MonitoredItemUpdateRef,
             NodeManagerBuilder, NodeManagersRef, ParsedReadValueId, RequestContext, ServerContext,
             TypeTree, TypeTreeNode, WriteNode,
         },
@@ -300,7 +300,8 @@ impl InMemoryNodeManagerImpl for TestNodeManagerImpl {
         let type_tree = trace_read_lock!(context.type_tree);
 
         for write in nodes_to_write {
-            let node = match address_space.validate_node_write(context, write.value(), &type_tree) {
+            let node = match address_space.validate_node_write(context, write.value(), &*type_tree)
+            {
                 Ok(v) => v,
                 Err(e) => {
                     write.set_status(e);
@@ -927,7 +928,7 @@ impl TestNodeManagerImpl {
     pub fn add_node<'a>(
         &self,
         address_space: &RwLock<AddressSpace>,
-        type_tree: &RwLock<TypeTree>,
+        type_tree: &RwLock<DefaultTypeTree>,
         node: NodeType,
         parent_id: &'a NodeId,
         reference_type_id: &'a NodeId,
@@ -971,7 +972,7 @@ impl TestNodeManagerImpl {
     fn insert_node_inner(
         &self,
         address_space: &mut AddressSpace,
-        type_tree: &mut TypeTree,
+        type_tree: &mut DefaultTypeTree,
         node: NodeType,
         parent_id: &NodeId,
         refs: Vec<(&NodeId, NodeId, ReferenceDirection)>,

--- a/opcua-server/src/address_space/utils.rs
+++ b/opcua-server/src/address_space/utils.rs
@@ -107,7 +107,7 @@ pub fn validate_node_read(
 pub fn validate_value_to_write(
     variable: &Variable,
     value: &Variant,
-    type_tree: &TypeTree,
+    type_tree: &dyn TypeTree,
 ) -> Result<(), StatusCode> {
     let value_rank = variable.value_rank();
     let node_data_type = variable.data_type();
@@ -154,7 +154,7 @@ pub fn validate_node_write(
     node: &NodeType,
     context: &RequestContext,
     node_to_write: &ParsedWriteValue,
-    type_tree: &TypeTree,
+    type_tree: &dyn TypeTree,
 ) -> Result<(), StatusCode> {
     is_writable(context, node, node_to_write.attribute_id)?;
 

--- a/opcua-server/src/events/evaluate.rs
+++ b/opcua-server/src/events/evaluate.rs
@@ -380,7 +380,7 @@ mod tests {
     use crate::{
         address_space::{AddressSpace, CoreNamespace, ObjectTypeBuilder, VariableBuilder},
         events::evaluate::like_to_regex,
-        node_manager::TypeTree,
+        node_manager::DefaultTypeTree,
         BaseEventType, Event, ParsedContentFilter,
     };
     use opcua_types::{
@@ -513,9 +513,9 @@ mod tests {
         }
     }
 
-    fn type_tree() -> TypeTree {
+    fn type_tree() -> DefaultTypeTree {
         let mut address_space = AddressSpace::new();
-        let mut type_tree = TypeTree::new();
+        let mut type_tree = DefaultTypeTree::new();
         address_space.import_node_set::<CoreNamespace>(type_tree.namespaces_mut());
         address_space.add_namespace(
             "my:namespace:uri",
@@ -540,7 +540,7 @@ mod tests {
         type_tree
     }
 
-    fn filter(elements: Vec<ContentFilterElement>, type_tree: &TypeTree) -> ParsedContentFilter {
+    fn filter(elements: Vec<ContentFilterElement>, type_tree: &DefaultTypeTree) -> ParsedContentFilter {
         let (_, f) = ParsedContentFilter::parse(
             ContentFilter {
                 elements: Some(elements),

--- a/opcua-server/src/events/evaluate.rs
+++ b/opcua-server/src/events/evaluate.rs
@@ -540,7 +540,10 @@ mod tests {
         type_tree
     }
 
-    fn filter(elements: Vec<ContentFilterElement>, type_tree: &DefaultTypeTree) -> ParsedContentFilter {
+    fn filter(
+        elements: Vec<ContentFilterElement>,
+        type_tree: &DefaultTypeTree,
+    ) -> ParsedContentFilter {
         let (_, f) = ParsedContentFilter::parse(
             ContentFilter {
                 elements: Some(elements),

--- a/opcua-server/src/info.rs
+++ b/opcua-server/src/info.rs
@@ -11,6 +11,7 @@ use arc_swap::ArcSwap;
 use log::{debug, error, warn};
 
 use crate::authenticator::Password;
+use crate::node_manager::TypeTreeForUser;
 use opcua_core::comms::url::{hostname_from_url, url_matches_except_host};
 use opcua_core::handle::AtomicHandle;
 use opcua_core::sync::RwLock;
@@ -36,7 +37,7 @@ use super::identity_token::{
     IdentityToken, POLICY_ID_ANONYMOUS, POLICY_ID_USER_PASS_NONE, POLICY_ID_USER_PASS_RSA_15,
     POLICY_ID_USER_PASS_RSA_OAEP, POLICY_ID_X509,
 };
-use super::node_manager::TypeTree;
+use super::node_manager::DefaultTypeTree;
 use super::{OperationalLimits, ServerCapabilities, SubscriptionCache, ANONYMOUS_USER_TOKEN_ID};
 
 /// Server state is any configuration associated with the server as a whole that individual sessions might
@@ -73,7 +74,9 @@ pub struct ServerInfo {
     /// Authenticator to use when verifying user identities, and checking for user access.
     pub authenticator: Arc<dyn AuthManager>,
     /// Structure containing type metadata shared by the entire server.
-    pub type_tree: Arc<RwLock<TypeTree>>,
+    pub type_tree: Arc<RwLock<DefaultTypeTree>>,
+    /// Wrapper to get a type tree for a specific user.
+    pub type_tree_getter: Arc<dyn TypeTreeForUser>,
     /// Generator for subscription IDs.
     pub subscription_id_handle: AtomicHandle,
     /// Generator for monitored item IDs.

--- a/opcua-server/src/node_manager/memory/diagnostics.rs
+++ b/opcua-server/src/node_manager/memory/diagnostics.rs
@@ -15,8 +15,8 @@ use crate::{
         build::NodeManagerBuilder,
         from_opaque_node_id,
         view::{AddReferenceResult, NodeMetadata},
-        BrowseNode, DynNodeManager, NodeManager, NodeManagersRef, ReadNode, RequestContext,
-        ServerContext, SyncSampler, TypeTree,
+        BrowseNode, DefaultTypeTree, DynNodeManager, NodeManager, NodeManagersRef, ReadNode,
+        RequestContext, ServerContext, SyncSampler,
     },
 };
 use opcua_types::{
@@ -133,7 +133,7 @@ impl DiagnosticsNodeManager {
     fn browse_namespaces(
         &self,
         node_to_browse: &mut BrowseNode,
-        type_tree: &TypeTree,
+        type_tree: &DefaultTypeTree,
         namespaces: &BTreeMap<String, NamespaceMetadata>,
     ) {
         // Only hierarchical references in this case, so we can check for that first.
@@ -179,7 +179,7 @@ impl DiagnosticsNodeManager {
     fn browse_namespace_metadata_node(
         &self,
         node_to_browse: &mut BrowseNode,
-        type_tree: &TypeTree,
+        type_tree: &DefaultTypeTree,
         meta: &NamespaceMetadata,
     ) {
         let mut cp = BrowseContinuationPoint::default();
@@ -271,7 +271,7 @@ impl DiagnosticsNodeManager {
     fn browse_namespace_property_node(
         &self,
         node_to_browse: &mut BrowseNode,
-        type_tree: &TypeTree,
+        type_tree: &DefaultTypeTree,
         meta: &NamespaceMetadata,
     ) {
         let mut cp = BrowseContinuationPoint::default();
@@ -322,7 +322,7 @@ impl DiagnosticsNodeManager {
     fn browse_namespace_node(
         &self,
         node_to_browse: &mut BrowseNode,
-        type_tree: &TypeTree,
+        type_tree: &DefaultTypeTree,
         namespaces: &BTreeMap<String, NamespaceMetadata>,
         ns_node: &NamespaceNode,
     ) {
@@ -564,7 +564,7 @@ impl NodeManager for DiagnosticsNodeManager {
         }]
     }
 
-    async fn init(&self, _type_tree: &mut TypeTree, context: ServerContext) {
+    async fn init(&self, _type_tree: &mut DefaultTypeTree, context: ServerContext) {
         let interval = context
             .info
             .config

--- a/opcua-server/src/node_manager/memory/simple.rs
+++ b/opcua-server/src/node_manager/memory/simple.rs
@@ -6,8 +6,8 @@ use opcua_core::{trace_read_lock, trace_write_lock};
 use crate::{
     address_space::{read_node_value, AddressSpace, NodeBase, NodeType},
     node_manager::{
-        MethodCall, MonitoredItemRef, MonitoredItemUpdateRef, NodeManagerBuilder, NodeManagersRef,
-        ParsedReadValueId, RequestContext, ServerContext, SyncSampler, TypeTree, WriteNode,
+        DefaultTypeTree, MethodCall, MonitoredItemRef, MonitoredItemUpdateRef, NodeManagerBuilder,
+        NodeManagersRef, ParsedReadValueId, RequestContext, ServerContext, SyncSampler, WriteNode,
     },
     CreateMonitoredItem,
 };
@@ -322,10 +322,10 @@ impl SimpleNodeManagerImpl {
         cbs: &HashMap<NodeId, WriteCB>,
         context: &RequestContext,
         address_space: &mut AddressSpace,
-        type_tree: &TypeTree,
+        type_tree: &DefaultTypeTree,
         write: &mut WriteNode,
     ) {
-        let node = match address_space.validate_node_write(context, write.value(), &type_tree) {
+        let node = match address_space.validate_node_write(context, write.value(), &*type_tree) {
             Ok(v) => v,
             Err(e) => {
                 write.set_status(e);

--- a/opcua-server/src/node_manager/view.rs
+++ b/opcua-server/src/node_manager/view.rs
@@ -263,7 +263,7 @@ impl BrowseNode {
     }
 
     /// Return `true` if nodes with the given reference type ID should be returned.
-    pub fn allows_reference_type(&self, ty: &NodeId, type_tree: &TypeTree) -> bool {
+    pub fn allows_reference_type(&self, ty: &NodeId, type_tree: &dyn TypeTree) -> bool {
         if self.reference_type_id.is_null() {
             return true;
         }
@@ -300,7 +300,11 @@ impl BrowseNode {
     }
 
     /// Return `true` if the given reference should be returned.
-    pub fn matches_filter(&self, type_tree: &TypeTree, reference: &ReferenceDescription) -> bool {
+    pub fn matches_filter(
+        &self,
+        type_tree: &dyn TypeTree,
+        reference: &ReferenceDescription,
+    ) -> bool {
         if reference.node_id.is_null() {
             warn!("Skipping reference with null NodeId");
             return false;
@@ -341,7 +345,7 @@ impl BrowseNode {
     /// This will clear any fields not required by ResultMask.
     pub fn add(
         &mut self,
-        type_tree: &TypeTree,
+        type_tree: &dyn TypeTree,
         mut reference: ReferenceDescription,
     ) -> AddReferenceResult {
         // First, validate that the reference is valid at all.
@@ -508,7 +512,7 @@ impl BrowseNode {
 
     pub(crate) fn resolve_external_references(
         &mut self,
-        type_tree: &TypeTree,
+        type_tree: &dyn TypeTree,
         resolved_nodes: &HashMap<&NodeId, &NodeMetadata>,
     ) {
         let mut cont_point = ExternalReferencesContPoint {

--- a/opcua-server/src/server_handle.rs
+++ b/opcua-server/src/server_handle.rs
@@ -7,7 +7,7 @@ use opcua_types::{AttributeId, DataValue, ServerState, VariableId};
 
 use super::{
     info::ServerInfo,
-    node_manager::{NodeManagers, TypeTree},
+    node_manager::{NodeManagers, DefaultTypeTree},
     session::manager::SessionManager,
     SubscriptionCache,
 };
@@ -21,7 +21,7 @@ pub struct ServerHandle {
     subscriptions: Arc<SubscriptionCache>,
     node_managers: NodeManagers,
     session_manager: Arc<RwLock<SessionManager>>,
-    type_tree: Arc<RwLock<TypeTree>>,
+    type_tree: Arc<RwLock<DefaultTypeTree>>,
     token: CancellationToken,
 }
 
@@ -32,7 +32,7 @@ impl ServerHandle {
         subscriptions: Arc<SubscriptionCache>,
         node_managers: NodeManagers,
         session_manager: Arc<RwLock<SessionManager>>,
-        type_tree: Arc<RwLock<TypeTree>>,
+        type_tree: Arc<RwLock<DefaultTypeTree>>,
         token: CancellationToken,
     ) -> Self {
         Self {
@@ -81,7 +81,7 @@ impl ServerHandle {
     }
 
     /// Get a reference to the type tree, containing shared information about types in the server.
-    pub fn type_tree(&self) -> &RwLock<TypeTree> {
+    pub fn type_tree(&self) -> &RwLock<DefaultTypeTree> {
         &self.type_tree
     }
 

--- a/opcua-server/src/server_handle.rs
+++ b/opcua-server/src/server_handle.rs
@@ -7,7 +7,7 @@ use opcua_types::{AttributeId, DataValue, ServerState, VariableId};
 
 use super::{
     info::ServerInfo,
-    node_manager::{NodeManagers, DefaultTypeTree},
+    node_manager::{DefaultTypeTree, NodeManagers},
     session::manager::SessionManager,
     SubscriptionCache,
 };

--- a/opcua-server/src/session/message_handler.rs
+++ b/opcua-server/src/session/message_handler.rs
@@ -125,6 +125,7 @@ impl<T> Request<T> {
             token: self.token.clone(),
             current_node_manager_index: 0,
             type_tree: self.info.type_tree.clone(),
+            type_tree_getter: self.info.type_tree_getter.clone(),
             subscriptions: self.subscriptions.clone(),
             session_id: self.session_id,
             info: self.info.clone(),
@@ -369,6 +370,7 @@ impl MessageHandler {
             type_tree: self.info.type_tree.clone(),
             subscriptions: self.subscriptions.clone(),
             info: self.info.clone(),
+            type_tree_getter: self.info.type_tree_getter.clone(),
         };
 
         // Ignore the result

--- a/opcua-server/src/session/services/query.rs
+++ b/opcua-server/src/session/services/query.rs
@@ -1,5 +1,5 @@
 use log::info;
-use opcua_core::{trace_read_lock, trace_write_lock};
+use opcua_core::trace_write_lock;
 
 use crate::{
     node_manager::{NodeManagers, ParsedNodeTypeDescription, QueryRequest},
@@ -53,8 +53,8 @@ pub async fn query_first(
     }
 
     let (filter_result, filter) = {
-        let type_tree = trace_read_lock!(request.info.type_tree);
-        ParsedContentFilter::parse(request.request.filter, &type_tree, false, false)
+        let type_tree = context.get_type_tree_for_user();
+        ParsedContentFilter::parse(request.request.filter, type_tree.get(), false, false)
     };
 
     let content_filter = match filter {

--- a/opcua-server/src/subscriptions/mod.rs
+++ b/opcua-server/src/subscriptions/mod.rs
@@ -28,12 +28,12 @@ use opcua_types::{
     TransferSubscriptionsResponse,
 };
 
+use crate::node_manager::TypeTree;
+
 use super::{
     authenticator::UserToken,
     info::ServerInfo,
-    node_manager::{
-        MonitoredItemRef, MonitoredItemUpdateRef, RequestContext, ServerContext, TypeTree,
-    },
+    node_manager::{MonitoredItemRef, MonitoredItemUpdateRef, RequestContext, ServerContext},
     session::instance::Session,
     Event, SubscriptionLimits,
 };
@@ -164,6 +164,7 @@ impl SubscriptionCache {
                 type_tree: context.type_tree.clone(),
                 subscriptions: context.subscriptions.clone(),
                 info: context.info.clone(),
+                type_tree_getter: context.type_tree_getter.clone(),
             };
 
             for mgr in context.node_managers.iter() {
@@ -490,7 +491,7 @@ impl SubscriptionCache {
         info: &ServerInfo,
         timestamps_to_return: TimestampsToReturn,
         requests: Vec<MonitoredItemModifyRequest>,
-        type_tree: &TypeTree,
+        type_tree: &dyn TypeTree,
     ) -> Result<Vec<MonitoredItemUpdateRef>, StatusCode> {
         let Some(cache) = ({
             let lck = trace_read_lock!(self.inner);

--- a/opcua-server/src/subscriptions/monitored_item.rs
+++ b/opcua-server/src/subscriptions/monitored_item.rs
@@ -48,7 +48,7 @@ impl FilterType {
     pub fn from_filter(
         filter: &ExtensionObject,
         decoding_options: &DecodingOptions,
-        type_tree: &TypeTree,
+        type_tree: &dyn TypeTree,
     ) -> (Option<EventFilterResult>, Result<FilterType, StatusCode>) {
         // Check if the filter is a supported filter type
         let filter_type_id = &filter.node_id;
@@ -157,7 +157,7 @@ impl CreateMonitoredItem {
         sub_id: u32,
         info: &ServerInfo,
         timestamps_to_return: TimestampsToReturn,
-        type_tree: &TypeTree,
+        type_tree: &dyn TypeTree,
     ) -> Self {
         let (filter_res, filter) = FilterType::from_filter(
             &req.requested_parameters.filter,
@@ -341,7 +341,7 @@ impl MonitoredItem {
         info: &ServerInfo,
         timestamps_to_return: TimestampsToReturn,
         request: &MonitoredItemModifyRequest,
-        type_tree: &TypeTree,
+        type_tree: &dyn TypeTree,
     ) -> (Option<EventFilterResult>, StatusCode) {
         self.timestamps_to_return = timestamps_to_return;
         let (filter_res, filter) = FilterType::from_filter(

--- a/opcua-server/src/subscriptions/session_subscriptions.rs
+++ b/opcua-server/src/subscriptions/session_subscriptions.rs
@@ -293,7 +293,7 @@ impl SessionSubscriptions {
         info: &ServerInfo,
         timestamps_to_return: TimestampsToReturn,
         requests: Vec<MonitoredItemModifyRequest>,
-        type_tree: &TypeTree,
+        type_tree: &dyn TypeTree,
     ) -> Result<Vec<MonitoredItemUpdateRef>, StatusCode> {
         let Some(sub) = self.subscriptions.get_mut(&subscription_id) else {
             return Err(StatusCode::BadSubscriptionIdInvalid);


### PR DESCRIPTION
This makes it possible to write servers with a dynamic type tree, which is potentially very powerful.