### PR TITLE
Move events and type trees to the nodes crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,8 +892,11 @@ name = "opcua-nodes"
 version = "0.13.0"
 dependencies = [
  "bitflags",
+ "hashbrown",
  "log",
+ "opcua-macros",
  "opcua-types",
+ "regex",
 ]
 
 [[package]]
@@ -912,7 +915,6 @@ dependencies = [
  "opcua-core",
  "opcua-core-namespace",
  "opcua-crypto",
- "opcua-macros",
  "opcua-nodes",
  "opcua-types",
  "parking_lot",

--- a/lib/tests/integration/browse.rs
+++ b/lib/tests/integration/browse.rs
@@ -1,7 +1,7 @@
 use super::utils::setup;
 use opcua::{
+    nodes::TypeTree,
     server::address_space::{ObjectBuilder, ReferenceDirection, VariableBuilder},
-    server::node_manager::TypeTree,
     types::{
         BrowseDescription, BrowseDirection, BrowsePath, BrowseResultMask, ByteString, DataTypeId,
         NodeClass, NodeClassMask, NodeId, ObjectId, ObjectTypeId, ReferenceTypeId, RelativePath,

--- a/lib/tests/utils/node_manager.rs
+++ b/lib/tests/utils/node_manager.rs
@@ -12,10 +12,10 @@ use opcua::{
                 InMemoryNodeManager, InMemoryNodeManagerBuilder, InMemoryNodeManagerImpl,
                 NamespaceMetadata,
             },
-            AddNodeItem, AddReferenceItem, DefaultTypeTree, DeleteNodeItem, DeleteReferenceItem,
-            HistoryNode, HistoryUpdateNode, MethodCall, MonitoredItemRef, MonitoredItemUpdateRef,
+            AddNodeItem, AddReferenceItem, DeleteNodeItem, DeleteReferenceItem, HistoryNode,
+            HistoryUpdateNode, MethodCall, MonitoredItemRef, MonitoredItemUpdateRef,
             NodeManagerBuilder, NodeManagersRef, ParsedReadValueId, RequestContext, ServerContext,
-            TypeTree, TypeTreeNode, WriteNode,
+            WriteNode,
         },
         ContinuationPoint, CreateMonitoredItem,
     },
@@ -27,6 +27,7 @@ use opcua::{
     },
 };
 use opcua_core::{trace_read_lock, trace_write_lock};
+use opcua_nodes::{DefaultTypeTree, TypeTree, TypeTreeNode};
 use opcua_server::address_space::add_namespaces;
 
 #[allow(unused)]

--- a/opcua-macros/src/events/field.rs
+++ b/opcua-macros/src/events/field.rs
@@ -64,7 +64,7 @@ pub fn generate_event_field_impls(event: EventFieldStruct) -> syn::Result<TokenS
     }
 
     Ok(quote! {
-        impl opcua::server::EventField for #ident {
+        impl opcua::nodes::EventField for #ident {
             fn get_value(
                 &self,
                 attribute_id: opcua::types::AttributeId,

--- a/opcua-macros/src/events/gen.rs
+++ b/opcua-macros/src/events/gen.rs
@@ -125,7 +125,7 @@ pub fn generate_event_impls(event: EventStruct) -> syn::Result<TokenStream> {
     }
 
     Ok(quote! {
-        impl opcua::server::Event for #ident {
+        impl opcua::nodes::Event for #ident {
             fn get_field(
                 &self,
                 type_definition_id: &opcua::types::NodeId,
@@ -133,7 +133,7 @@ pub fn generate_event_impls(event: EventStruct) -> syn::Result<TokenStream> {
                 index_range: opcua::types::NumericRange,
                 browse_path: &[opcua::types::QualifiedName],
             ) -> opcua::types::Variant {
-                use opcua::server::EventField;
+                use opcua::nodes::EventField;
 
                 if type_definition_id != &opcua::types::ObjectTypeId::BaseEventType && !{
                     #type_id_body
@@ -151,7 +151,7 @@ pub fn generate_event_impls(event: EventStruct) -> syn::Result<TokenStream> {
             }
         }
 
-        impl opcua::server::EventField for #ident {
+        impl opcua::nodes::EventField for #ident {
             fn get_value(
                 &self,
                 attribute_id: opcua::types::AttributeId,

--- a/opcua-nodes/Cargo.toml
+++ b/opcua-nodes/Cargo.toml
@@ -17,7 +17,10 @@ name = "opcua_nodes"
 
 [dependencies]
 bitflags = { workspace = true }
+hashbrown = { workspace = true }
 log = { workspace = true }
+regex = { workspace = true }
 
 opcua-types = { path = "../opcua-types" }
+opcua-macros = { path = "../opcua-macros" }
 

--- a/opcua-nodes/src/events/event.rs
+++ b/opcua-nodes/src/events/event.rs
@@ -1,4 +1,4 @@
-use opcua_nodes::NamespaceMap;
+use crate::NamespaceMap;
 use opcua_types::{
     event_field::EventField, AttributeId, ByteString, DateTime, LocalizedText, NodeId,
     NumericRange, ObjectTypeId, QualifiedName, TimeZoneDataType, UAString, Variant,
@@ -186,20 +186,17 @@ impl BaseEventType {
 
 #[cfg(test)]
 mod tests {
-    use opcua_crypto::random;
-    use opcua_macros::EventField;
-    use opcua_nodes::NamespaceMap;
+    use crate::NamespaceMap;
 
     mod opcua {
-        pub use crate as server;
-        pub use opcua_nodes as nodes;
+        pub use crate as nodes;
         pub use opcua_types as types;
     }
 
-    use crate::{BaseEventType, Event};
+    use crate::{BaseEventType, Event, EventField};
     use opcua_types::{
-        AttributeId, DecodingOptions, EUInformation, KeyValuePair, LocalizedText, NodeId,
-        NumericRange, ObjectTypeId, QualifiedName, StatusCode, UAString, Variant,
+        AttributeId, ByteString, DecodingOptions, EUInformation, KeyValuePair, LocalizedText,
+        NodeId, NumericRange, ObjectTypeId, QualifiedName, StatusCode, UAString, Variant,
     };
     #[derive(Event)]
     #[opcua(identifier = "s=myevent", namespace = "uri:my:namespace")]
@@ -243,7 +240,7 @@ mod tests {
         let namespaces = namespace_map();
         let mut evt = BasicValueEvent::new_event_now(
             BasicValueEvent::event_type_id(&namespaces),
-            random::byte_string(128),
+            ByteString::from_base64("dGVzdA==").unwrap(),
             "Some message",
             &namespaces,
         );
@@ -381,7 +378,7 @@ mod tests {
         let namespaces = namespace_map();
         let mut evt = NestedEvent::new_event_now(
             NestedEvent::event_type_id(&namespaces),
-            random::byte_string(128),
+            ByteString::from_base64("dGVzdA==").unwrap(),
             "Some message",
             &namespaces,
         );

--- a/opcua-nodes/src/events/mod.rs
+++ b/opcua-nodes/src/events/mod.rs
@@ -3,7 +3,9 @@ mod event;
 mod evaluate;
 mod validation;
 
+pub use evaluate::AttributeQueryable;
 pub use event::{BaseEventType, Event};
+pub use opcua_types::event_field::EventField;
 pub use validation::{
     ParsedAttributeOperand, ParsedContentFilter, ParsedContentFilterElement, ParsedEventFilter,
     ParsedOperand, ParsedSimpleAttributeOperand,

--- a/opcua-nodes/src/events/validation.rs
+++ b/opcua-nodes/src/events/validation.rs
@@ -9,7 +9,7 @@ use opcua_types::{
     StatusCode, UAString,
 };
 
-use crate::node_manager::TypeTree;
+use crate::TypeTree;
 
 #[derive(Debug, Clone)]
 pub struct ParsedAttributeOperand {
@@ -105,7 +105,7 @@ impl ParsedContentFilter {
         }
     }
 
-    pub(crate) fn parse(
+    pub fn parse(
         filter: ContentFilter,
         type_tree: &dyn TypeTree,
         allow_attribute_operand: bool,
@@ -437,7 +437,7 @@ fn has_cycles(
 
 #[cfg(test)]
 mod tests {
-    use crate::{events::validation::validate_where_clause, node_manager::DefaultTypeTree};
+    use crate::{events::validation::validate_where_clause, DefaultTypeTree};
     use opcua_types::{
         AttributeId, ContentFilter, ContentFilterElement, ContentFilterResult, FilterOperator,
         NodeClass, NodeId, ObjectTypeId, Operand, SimpleAttributeOperand, StatusCode,

--- a/opcua-nodes/src/lib.rs
+++ b/opcua-nodes/src/lib.rs
@@ -1,11 +1,14 @@
 use bitflags::bitflags;
 
+mod events;
 mod generic;
 mod import;
 mod namespaces;
+mod type_tree;
 
 pub use base::Base;
 pub use data_type::{DataType, DataTypeBuilder};
+pub use events::*;
 pub use generic::new_node_from_attributes;
 pub use import::{ImportedItem, ImportedReference, NodeSetImport, NodeSetNamespaceMapper};
 pub use method::{Method, MethodBuilder};
@@ -15,9 +18,14 @@ pub use object::{Object, ObjectBuilder};
 pub use object_type::{ObjectType, ObjectTypeBuilder};
 use opcua_types::NodeId;
 pub use reference_type::{ReferenceType, ReferenceTypeBuilder};
+pub use type_tree::{
+    DefaultTypeTree, TypeProperty, TypePropertyInverseRef, TypeTree, TypeTreeNode,
+};
 pub use variable::{Variable, VariableBuilder};
 pub use variable_type::{VariableType, VariableTypeBuilder};
 pub use view::{View, ViewBuilder};
+
+pub use opcua_macros::{Event, EventField};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ReferenceDirection {

--- a/opcua-nodes/src/type_tree.rs
+++ b/opcua-nodes/src/type_tree.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{HashMap, HashSet},
 };
 
-use opcua_nodes::NamespaceMap;
+use crate::NamespaceMap;
 use opcua_types::{
     DataTypeId, NodeClass, NodeId, ObjectTypeId, QualifiedName, ReferenceTypeId, VariableTypeId,
 };

--- a/opcua-server/Cargo.toml
+++ b/opcua-server/Cargo.toml
@@ -46,7 +46,6 @@ opcua-types = { path = "../opcua-types" }
 opcua-crypto = { path = "../opcua-crypto" }
 opcua-core = { path = "../opcua-core" }
 opcua-nodes = { path = "../opcua-nodes" }
-opcua-macros = { path = "../opcua-macros" }
 
 opcua-client = { path = "../opcua-client", optional = true }
 opcua-core-namespace = { path = "../opcua-core-namespace", optional = true }

--- a/opcua-server/src/address_space/address_space.rs
+++ b/opcua-server/src/address_space/address_space.rs
@@ -2,11 +2,9 @@ use std::collections::VecDeque;
 
 use hashbrown::{Equivalent, HashMap, HashSet};
 use log::{debug, error, info, warn};
-use opcua_nodes::{NamespaceMap, NodeInsertTarget, ReferenceDirection};
+use opcua_nodes::{DefaultTypeTree, NamespaceMap, NodeInsertTarget, ReferenceDirection, TypeTree};
 
-use crate::node_manager::{
-    DefaultTypeTree, ParsedReadValueId, ParsedWriteValue, RequestContext, TypeTree,
-};
+use crate::node_manager::{ParsedReadValueId, ParsedWriteValue, RequestContext};
 use opcua_types::{
     BrowseDirection, DataValue, LocalizedText, NodeClass, NodeId, QualifiedName, ReferenceTypeId,
     StatusCode, TimestampsToReturn,
@@ -852,14 +850,11 @@ impl NodeInsertTarget for AddressSpace {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        address_space::{
-            CoreNamespace, EventNotifier, MethodBuilder, NodeBase, NodeType, Object, ObjectBuilder,
-            ObjectTypeBuilder, Variable, VariableBuilder,
-        },
-        node_manager::{DefaultTypeTree, TypeTree},
+    use crate::address_space::{
+        CoreNamespace, EventNotifier, MethodBuilder, NodeBase, NodeType, Object, ObjectBuilder,
+        ObjectTypeBuilder, Variable, VariableBuilder,
     };
-    use opcua_nodes::NamespaceMap;
+    use opcua_nodes::{DefaultTypeTree, NamespaceMap, TypeTree};
     use opcua_types::{
         argument::Argument, Array, BrowseDirection, DataTypeId, DecodingOptions, LocalizedText,
         NodeClass, NodeId, NumericRange, ObjectId, ObjectTypeId, QualifiedName, ReferenceTypeId,

--- a/opcua-server/src/address_space/utils.rs
+++ b/opcua-server/src/address_space/utils.rs
@@ -1,7 +1,6 @@
-use crate::node_manager::{
-    ParsedReadValueId, ParsedWriteValue, RequestContext, ServerContext, TypeTree,
-};
+use crate::node_manager::{ParsedReadValueId, ParsedWriteValue, RequestContext, ServerContext};
 use log::debug;
+use opcua_nodes::TypeTree;
 use opcua_types::{
     AttributeId, DataTypeId, DataValue, NumericRange, QualifiedName, StatusCode,
     TimestampsToReturn, Variant, WriteMask,

--- a/opcua-server/src/info.rs
+++ b/opcua-server/src/info.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use log::{debug, error, warn};
+use opcua_nodes::DefaultTypeTree;
 
 use crate::authenticator::Password;
 use crate::node_manager::TypeTreeForUser;
@@ -37,7 +38,6 @@ use super::identity_token::{
     IdentityToken, POLICY_ID_ANONYMOUS, POLICY_ID_USER_PASS_NONE, POLICY_ID_USER_PASS_RSA_15,
     POLICY_ID_USER_PASS_RSA_OAEP, POLICY_ID_X509,
 };
-use super::node_manager::DefaultTypeTree;
 use super::{OperationalLimits, ServerCapabilities, ANONYMOUS_USER_TOKEN_ID};
 
 /// Server state is any configuration associated with the server as a whole that individual sessions might

--- a/opcua-server/src/lib.rs
+++ b/opcua-server/src/lib.rs
@@ -4,7 +4,6 @@ mod builder;
 mod config;
 #[cfg(feature = "discovery-server-registration")]
 mod discovery;
-pub mod events;
 mod identity_token;
 mod info;
 pub mod node_manager;
@@ -17,7 +16,6 @@ mod transport;
 
 pub use builder::ServerBuilder;
 pub use config::*;
-pub use events::*;
 pub use opcua_types::event_field::EventField;
 pub use server::Server;
 pub use server_handle::ServerHandle;
@@ -27,8 +25,6 @@ pub use subscriptions::{
     CreateMonitoredItem, MonitoredItem, MonitoredItemHandle, SessionSubscriptions, Subscription,
     SubscriptionCache, SubscriptionState,
 };
-
-pub use opcua_macros::{Event, EventField};
 
 /// Contains constaints for default configuration values.
 /// These are for the most part possible to override through server configuration.

--- a/opcua-server/src/node_manager/context.rs
+++ b/opcua-server/src/node_manager/context.rs
@@ -7,12 +7,13 @@ use crate::{
     SubscriptionCache,
 };
 use opcua_core::{sync::RwLock, trace_read_lock};
+use opcua_nodes::TypeTree;
 use opcua_types::{BrowseDescriptionResultMask, NodeId};
 use parking_lot::lock_api::{RawRwLock, RwLockReadGuard};
 
 use super::{
     view::{ExternalReferenceRequest, NodeMetadata},
-    DefaultTypeTree, NodeManagers, TypeTree,
+    DefaultTypeTree, NodeManagers,
 };
 
 /// Trait for providing a dynamic type tree for a user.

--- a/opcua-server/src/node_manager/mod.rs
+++ b/opcua-server/src/node_manager/mod.rs
@@ -7,6 +7,7 @@ use std::{
 use async_trait::async_trait;
 use memory::NamespaceMetadata;
 use opcua_core::sync::RwLock;
+use opcua_nodes::DefaultTypeTree;
 use opcua_types::{
     ExpandedNodeId, MonitoringMode, NodeId, ReadAnnotationDataDetails, ReadAtTimeDetails,
     ReadEventDetails, ReadProcessedDetails, ReadRawModifiedDetails, StatusCode, TimestampsToReturn,
@@ -22,7 +23,6 @@ mod method;
 mod monitored_items;
 mod node_management;
 mod query;
-mod type_tree;
 mod utils;
 mod view;
 
@@ -44,7 +44,6 @@ pub use {
     monitored_items::{MonitoredItemRef, MonitoredItemUpdateRef},
     node_management::{AddNodeItem, AddReferenceItem, DeleteNodeItem, DeleteReferenceItem},
     query::{ParsedNodeTypeDescription, ParsedQueryDataDescription, QueryRequest},
-    type_tree::{DefaultTypeTree, TypePropertyInverseRef, TypeTree, TypeTreeNode},
     utils::*,
     view::{BrowseNode, BrowsePathItem, RegisterNodeItem},
 };

--- a/opcua-server/src/node_manager/query.rs
+++ b/opcua-server/src/node_manager/query.rs
@@ -1,11 +1,9 @@
-use crate::{
-    session::{
-        continuation_points::{ContinuationPoint, EmptyContinuationPoint},
-        instance::Session,
-    },
-    ParsedContentFilter,
+use crate::session::{
+    continuation_points::{ContinuationPoint, EmptyContinuationPoint},
+    instance::Session,
 };
 use opcua_crypto::random;
+use opcua_nodes::ParsedContentFilter;
 use opcua_types::{
     AttributeId, ByteString, ExpandedNodeId, NodeTypeDescription, NumericRange, ParsingResult,
     QueryDataDescription, QueryDataSet, RelativePath, StatusCode,

--- a/opcua-server/src/node_manager/view.rs
+++ b/opcua-server/src/node_manager/view.rs
@@ -9,13 +9,12 @@ use crate::{
 };
 use log::warn;
 use opcua_crypto::random;
+use opcua_nodes::TypeTree;
 use opcua_types::{
     BrowseDescription, BrowseDescriptionResultMask, BrowseDirection, BrowsePath, BrowseResult,
     ByteString, ExpandedNodeId, LocalizedText, NodeClass, NodeClassMask, NodeId, QualifiedName,
     ReferenceDescription, RelativePathElement, StatusCode,
 };
-
-use super::type_tree::TypeTree;
 
 #[derive(Debug, Clone)]
 /// Object describing a node with sufficient context to construct

--- a/opcua-server/src/server.rs
+++ b/opcua-server/src/server.rs
@@ -12,6 +12,7 @@ use arc_swap::ArcSwap;
 use futures::{future::Either, never::Never, stream::FuturesUnordered, FutureExt, StreamExt};
 use log::{error, info, warn};
 use opcua_core::{sync::RwLock, trace_read_lock, trace_write_lock};
+use opcua_nodes::DefaultTypeTree;
 use tokio::{
     net::TcpListener,
     sync::Notify,
@@ -35,7 +36,7 @@ use super::{
     config::ServerConfig,
     discovery::periodic_discovery_server_registration,
     info::ServerInfo,
-    node_manager::{DefaultTypeTree, NodeManagers, NodeManagersRef},
+    node_manager::{NodeManagers, NodeManagersRef},
     server_handle::ServerHandle,
     session::{controller::ControllerCommand, manager::SessionManager},
     subscriptions::SubscriptionCache,

--- a/opcua-server/src/server_handle.rs
+++ b/opcua-server/src/server_handle.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use log::info;
+use opcua_nodes::DefaultTypeTree;
 use tokio_util::sync::CancellationToken;
 
 use opcua_core::sync::RwLock;
@@ -12,9 +13,7 @@ use opcua_types::{AttributeId, DataValue, LocalizedText, ServerState, VariableId
 use crate::ServerStatusWrapper;
 
 use super::{
-    info::ServerInfo,
-    node_manager::{DefaultTypeTree, NodeManagers},
-    session::manager::SessionManager,
+    info::ServerInfo, node_manager::NodeManagers, session::manager::SessionManager,
     SubscriptionCache,
 };
 

--- a/opcua-server/src/session/services/query.rs
+++ b/opcua-server/src/session/services/query.rs
@@ -1,10 +1,10 @@
 use log::info;
 use opcua_core::trace_write_lock;
+use opcua_nodes::ParsedContentFilter;
 
 use crate::{
     node_manager::{NodeManagers, ParsedNodeTypeDescription, QueryRequest},
     session::{controller::Response, message_handler::Request},
-    ParsedContentFilter,
 };
 use opcua_types::{
     ByteString, QueryFirstRequest, QueryFirstResponse, QueryNextRequest, QueryNextResponse,

--- a/opcua-server/src/subscriptions/mod.rs
+++ b/opcua-server/src/subscriptions/mod.rs
@@ -9,6 +9,7 @@ use hashbrown::{Equivalent, HashMap};
 use log::error;
 pub use monitored_item::{CreateMonitoredItem, MonitoredItem};
 use opcua_core::{trace_read_lock, trace_write_lock};
+use opcua_nodes::{Event, TypeTree};
 pub use session_subscriptions::SessionSubscriptions;
 use subscription::TickReason;
 pub use subscription::{MonitoredItemHandle, Subscription, SubscriptionState};
@@ -28,14 +29,12 @@ use opcua_types::{
     TransferSubscriptionsResponse,
 };
 
-use crate::node_manager::TypeTree;
-
 use super::{
     authenticator::UserToken,
     info::ServerInfo,
     node_manager::{MonitoredItemRef, MonitoredItemUpdateRef, RequestContext, ServerContext},
     session::instance::Session,
-    Event, SubscriptionLimits,
+    SubscriptionLimits,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/opcua-server/src/subscriptions/monitored_item.rs
+++ b/opcua-server/src/subscriptions/monitored_item.rs
@@ -1,14 +1,11 @@
 use std::collections::{BTreeSet, VecDeque};
 
 use log::error;
+use opcua_nodes::{Event, ParsedEventFilter, TypeTree};
 use serde::Serialize;
 
 use super::MonitoredItemHandle;
-use crate::{
-    info::ServerInfo,
-    node_manager::{ParsedReadValueId, TypeTree},
-    Event, ParsedEventFilter,
-};
+use crate::{info::ServerInfo, node_manager::ParsedReadValueId};
 use opcua_types::{
     DataChangeFilter, DataValue, DateTime, DecodingOptions, EventFieldList, EventFilter,
     EventFilterResult, ExtensionObject, MonitoredItemCreateRequest, MonitoredItemModifyRequest,

--- a/opcua-server/src/subscriptions/session_subscriptions.rs
+++ b/opcua-server/src/subscriptions/session_subscriptions.rs
@@ -10,12 +10,13 @@ use super::{
     CreateMonitoredItem, NonAckedPublish, PendingPublish, PersistentSessionKey,
 };
 use hashbrown::{HashMap, HashSet};
+use opcua_nodes::{Event, TypeTree};
 
 use crate::{
     info::ServerInfo,
-    node_manager::{MonitoredItemRef, MonitoredItemUpdateRef, TypeTree},
+    node_manager::{MonitoredItemRef, MonitoredItemUpdateRef},
     session::instance::Session,
-    Event, SubscriptionLimits,
+    SubscriptionLimits,
 };
 use opcua_core::sync::RwLock;
 use opcua_types::{

--- a/opcua-server/src/subscriptions/subscription.rs
+++ b/opcua-server/src/subscriptions/subscription.rs
@@ -3,10 +3,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::Event;
-
 use log::{debug, trace, warn};
 use opcua_core::handle::Handle;
+use opcua_nodes::Event;
 use opcua_types::{DataValue, DateTime, DateTimeUtc, NotificationMessage, StatusCode};
 
 use super::monitored_item::{MonitoredItem, Notification};

--- a/samples/demo-server/src/machine.rs
+++ b/samples/demo-server/src/machine.rs
@@ -12,16 +12,18 @@ use std::{
 
 use opcua::{
     crypto::random,
+    nodes::BaseEventType,
     server::{
         address_space::{
             AddressSpace, EventNotifier, ObjectBuilder, ObjectTypeBuilder, VariableBuilder,
         },
         node_manager::memory::SimpleNodeManager,
-        BaseEventType, Event, SubscriptionCache,
+        SubscriptionCache,
     },
     types::{
         DataTypeId, DataValue, DateTime, NodeId, ObjectId, ObjectTypeId, UAString, VariableTypeId,
     },
+    Event,
 };
 use rand;
 use tokio_util::sync::CancellationToken;
@@ -226,7 +228,9 @@ fn raise_machine_cycled_event(
 
     // create an event object in a folder with the
 
-    subscriptions.notify_events([(&event as &dyn Event, &ObjectId::Server.into())].into_iter());
+    subscriptions.notify_events(
+        [(&event as &dyn opcua::nodes::Event, &ObjectId::Server.into())].into_iter(),
+    );
 }
 
 fn increment_counter(


### PR DESCRIPTION
This is required in order to do codegen of events, which I want to try. We _could_ put the codegen in the server module, but I'd prefer to avoid putting generated code there.

Alternatively this could have been its own crate, but it didn't feel heavy/important enough to be its own thing.