### PR TITLE
Improve conversion to variants and event fields

### DIFF
--- a/opcua-codegen/src/types/base_constants.rs
+++ b/opcua-codegen/src/types/base_constants.rs
@@ -46,6 +46,8 @@ pub struct ExternalType {
     pub path: String,
     /// Whether this type has a default implementation.
     pub has_default: Option<bool>,
+    /// Base type, if any
+    pub base_type: Option<String>,
 }
 
 impl ExternalType {
@@ -53,6 +55,7 @@ impl ExternalType {
         Self {
             path: path.to_owned(),
             has_default: Some(has_default),
+            base_type: None,
         }
     }
 }

--- a/opcua-types/src/event_field.rs
+++ b/opcua-types/src/event_field.rs
@@ -1,7 +1,7 @@
 use crate::{
-    Array, AttributeId, BinaryEncoder, ByteString, DataValue, DateTime, DiagnosticInfo,
-    ExpandedNodeId, ExtensionObject, Guid, LocalizedText, MessageInfo, NodeId, NumericRange,
-    QualifiedName, StatusCode, UAString, Variant,
+    Array, AsVariantRef, AttributeId, ByteString, DataValue, DateTime, DiagnosticInfo,
+    ExpandedNodeId, ExtensionObject, Guid, LocalizedText, NodeId, NumericRange, QualifiedName,
+    StatusCode, UAString, Variant,
 };
 
 /// Trait implemented by any type that can be a field in an event.
@@ -23,7 +23,7 @@ pub trait EventField {
 
 impl<T> EventField for T
 where
-    T: BinaryEncoder + MessageInfo,
+    T: AsVariantRef,
 {
     fn get_value(
         &self,
@@ -37,7 +37,7 @@ where
         {
             return Variant::Empty;
         }
-        ExtensionObject::from_message(self).into()
+        self.as_variant()
     }
 }
 

--- a/opcua-types/src/impls.rs
+++ b/opcua-types/src/impls.rs
@@ -25,7 +25,7 @@ use crate::{
     variant::Variant,
 };
 
-use super::{EventFilter, PerformUpdateType, SecurityTokenRequestType};
+use super::{PerformUpdateType, SecurityTokenRequestType};
 
 /// Implemented by messages
 pub trait MessageInfo {
@@ -471,11 +471,5 @@ impl Default for SecurityTokenRequestType {
 impl Default for PerformUpdateType {
     fn default() -> Self {
         Self::Insert
-    }
-}
-
-impl MessageInfo for EventFilter {
-    fn object_id(&self) -> ObjectId {
-        ObjectId::EventFilter_Encoding_DefaultBinary
     }
 }

--- a/opcua-types/src/service_types/aggregate_filter.rs
+++ b/opcua-types/src/service_types/aggregate_filter.rs
@@ -14,6 +14,11 @@ pub struct AggregateFilter {
     pub processing_interval: f64,
     pub aggregate_configuration: super::aggregate_configuration::AggregateConfiguration,
 }
+impl opcua::types::MessageInfo for AggregateFilter {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::AggregateFilter_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for AggregateFilter {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/aggregate_filter_result.rs
+++ b/opcua-types/src/service_types/aggregate_filter_result.rs
@@ -13,6 +13,11 @@ pub struct AggregateFilterResult {
     pub revised_processing_interval: f64,
     pub revised_aggregate_configuration: super::aggregate_configuration::AggregateConfiguration,
 }
+impl opcua::types::MessageInfo for AggregateFilterResult {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::AggregateFilterResult_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for AggregateFilterResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/anonymous_identity_token.rs
+++ b/opcua-types/src/service_types/anonymous_identity_token.rs
@@ -10,6 +10,11 @@ mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
 pub struct AnonymousIdentityToken {
     pub policy_id: opcua::types::string::UAString,
 }
+impl opcua::types::MessageInfo for AnonymousIdentityToken {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::AnonymousIdentityToken_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for AnonymousIdentityToken {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/attribute_operand.rs
+++ b/opcua-types/src/service_types/attribute_operand.rs
@@ -15,6 +15,11 @@ pub struct AttributeOperand {
     pub attribute_id: u32,
     pub index_range: opcua::types::string::UAString,
 }
+impl opcua::types::MessageInfo for AttributeOperand {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::AttributeOperand_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for AttributeOperand {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/broker_connection_transport_data_type.rs
+++ b/opcua-types/src/service_types/broker_connection_transport_data_type.rs
@@ -12,6 +12,11 @@ pub struct BrokerConnectionTransportDataType {
     pub resource_uri: opcua::types::string::UAString,
     pub authentication_profile_uri: opcua::types::string::UAString,
 }
+impl opcua::types::MessageInfo for BrokerConnectionTransportDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::BrokerConnectionTransportDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for BrokerConnectionTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/broker_data_set_reader_transport_data_type.rs
+++ b/opcua-types/src/service_types/broker_data_set_reader_transport_data_type.rs
@@ -14,6 +14,11 @@ pub struct BrokerDataSetReaderTransportDataType {
     pub requested_delivery_guarantee: super::enums::BrokerTransportQualityOfService,
     pub meta_data_queue_name: opcua::types::string::UAString,
 }
+impl opcua::types::MessageInfo for BrokerDataSetReaderTransportDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::BrokerDataSetReaderTransportDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for BrokerDataSetReaderTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/broker_data_set_writer_transport_data_type.rs
+++ b/opcua-types/src/service_types/broker_data_set_writer_transport_data_type.rs
@@ -15,6 +15,11 @@ pub struct BrokerDataSetWriterTransportDataType {
     pub meta_data_queue_name: opcua::types::string::UAString,
     pub meta_data_update_time: f64,
 }
+impl opcua::types::MessageInfo for BrokerDataSetWriterTransportDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::BrokerDataSetWriterTransportDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for BrokerDataSetWriterTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/broker_writer_group_transport_data_type.rs
+++ b/opcua-types/src/service_types/broker_writer_group_transport_data_type.rs
@@ -13,6 +13,11 @@ pub struct BrokerWriterGroupTransportDataType {
     pub authentication_profile_uri: opcua::types::string::UAString,
     pub requested_delivery_guarantee: super::enums::BrokerTransportQualityOfService,
 }
+impl opcua::types::MessageInfo for BrokerWriterGroupTransportDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::BrokerWriterGroupTransportDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for BrokerWriterGroupTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/data_change_filter.rs
+++ b/opcua-types/src/service_types/data_change_filter.rs
@@ -14,6 +14,11 @@ pub struct DataChangeFilter {
     pub deadband_type: u32,
     pub deadband_value: f64,
 }
+impl opcua::types::MessageInfo for DataChangeFilter {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::DataChangeFilter_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for DataChangeFilter {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/data_change_notification.rs
+++ b/opcua-types/src/service_types/data_change_notification.rs
@@ -14,6 +14,11 @@ pub struct DataChangeNotification {
     >,
     pub diagnostic_infos: Option<Vec<opcua::types::diagnostic_info::DiagnosticInfo>>,
 }
+impl opcua::types::MessageInfo for DataChangeNotification {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::DataChangeNotification_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for DataChangeNotification {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/data_set_meta_data_type.rs
+++ b/opcua-types/src/service_types/data_set_meta_data_type.rs
@@ -25,6 +25,11 @@ pub struct DataSetMetaDataType {
     pub data_set_class_id: opcua::types::guid::Guid,
     pub configuration_version: super::configuration_version_data_type::ConfigurationVersionDataType,
 }
+impl opcua::types::MessageInfo for DataSetMetaDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::DataSetMetaDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for DataSetMetaDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/data_type_attributes.rs
+++ b/opcua-types/src/service_types/data_type_attributes.rs
@@ -16,6 +16,11 @@ pub struct DataTypeAttributes {
     pub user_write_mask: u32,
     pub is_abstract: bool,
 }
+impl opcua::types::MessageInfo for DataTypeAttributes {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::DataTypeAttributes_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for DataTypeAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/datagram_connection_transport_data_type.rs
+++ b/opcua-types/src/service_types/datagram_connection_transport_data_type.rs
@@ -11,6 +11,11 @@ mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
 pub struct DatagramConnectionTransportDataType {
     pub discovery_address: opcua::types::extension_object::ExtensionObject,
 }
+impl opcua::types::MessageInfo for DatagramConnectionTransportDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::DatagramConnectionTransportDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for DatagramConnectionTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/datagram_writer_group_transport_data_type.rs
+++ b/opcua-types/src/service_types/datagram_writer_group_transport_data_type.rs
@@ -12,6 +12,11 @@ pub struct DatagramWriterGroupTransportDataType {
     pub message_repeat_count: u8,
     pub message_repeat_delay: f64,
 }
+impl opcua::types::MessageInfo for DatagramWriterGroupTransportDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::DatagramWriterGroupTransportDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for DatagramWriterGroupTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/delete_at_time_details.rs
+++ b/opcua-types/src/service_types/delete_at_time_details.rs
@@ -12,6 +12,11 @@ pub struct DeleteAtTimeDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub req_times: Option<Vec<opcua::types::date_time::DateTime>>,
 }
+impl opcua::types::MessageInfo for DeleteAtTimeDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::DeleteAtTimeDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for DeleteAtTimeDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/delete_event_details.rs
+++ b/opcua-types/src/service_types/delete_event_details.rs
@@ -12,6 +12,11 @@ pub struct DeleteEventDetails {
     pub node_id: opcua::types::node_id::NodeId,
     pub event_ids: Option<Vec<opcua::types::byte_string::ByteString>>,
 }
+impl opcua::types::MessageInfo for DeleteEventDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::DeleteEventDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for DeleteEventDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/delete_raw_modified_details.rs
+++ b/opcua-types/src/service_types/delete_raw_modified_details.rs
@@ -14,6 +14,11 @@ pub struct DeleteRawModifiedDetails {
     pub start_time: opcua::types::date_time::DateTime,
     pub end_time: opcua::types::date_time::DateTime,
 }
+impl opcua::types::MessageInfo for DeleteRawModifiedDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::DeleteRawModifiedDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for DeleteRawModifiedDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/element_operand.rs
+++ b/opcua-types/src/service_types/element_operand.rs
@@ -11,6 +11,11 @@ mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
 pub struct ElementOperand {
     pub index: u32,
 }
+impl opcua::types::MessageInfo for ElementOperand {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ElementOperand_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ElementOperand {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/enum_description.rs
+++ b/opcua-types/src/service_types/enum_description.rs
@@ -16,6 +16,11 @@ pub struct EnumDescription {
     pub enum_definition: super::enum_definition::EnumDefinition,
     pub built_in_type: u8,
 }
+impl opcua::types::MessageInfo for EnumDescription {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::EnumDescription_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for EnumDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/enum_field.rs
+++ b/opcua-types/src/service_types/enum_field.rs
@@ -16,6 +16,11 @@ pub struct EnumField {
     pub description: opcua::types::localized_text::LocalizedText,
     pub name: opcua::types::string::UAString,
 }
+impl opcua::types::MessageInfo for EnumField {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::EnumField_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for EnumField {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/enums.rs
+++ b/opcua-types/src/service_types/enums.rs
@@ -36,6 +36,16 @@ impl Default for AccessLevelExType {
         Self::empty()
     }
 }
+impl From<AccessLevelExType> for opcua::types::Variant {
+    fn from(v: AccessLevelExType) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for AccessLevelExType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
+    }
+}
 impl<'de> serde::de::Deserialize<'de> for AccessLevelExType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -93,6 +103,16 @@ impl opcua::types::BinaryEncoder for AccessLevelType {
 impl Default for AccessLevelType {
     fn default() -> Self {
         Self::empty()
+    }
+}
+impl From<AccessLevelType> for opcua::types::Variant {
+    fn from(v: AccessLevelType) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for AccessLevelType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
     }
 }
 impl<'de> serde::de::Deserialize<'de> for AccessLevelType {
@@ -153,6 +173,16 @@ impl Default for AccessRestrictionType {
         Self::empty()
     }
 }
+impl From<AccessRestrictionType> for opcua::types::Variant {
+    fn from(v: AccessRestrictionType) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for AccessRestrictionType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
+    }
+}
 impl<'de> serde::de::Deserialize<'de> for AccessRestrictionType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -209,6 +239,21 @@ impl TryFrom<i32> for ApplicationType {
         )
     }
 }
+impl From<ApplicationType> for i32 {
+    fn from(value: ApplicationType) -> Self {
+        value as i32
+    }
+}
+impl From<ApplicationType> for opcua::types::Variant {
+    fn from(value: ApplicationType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for ApplicationType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for ApplicationType {
     fn byte_len(&self) -> usize {
         4usize
@@ -260,6 +305,16 @@ impl opcua::types::BinaryEncoder for AttributeWriteMask {
 impl Default for AttributeWriteMask {
     fn default() -> Self {
         Self::empty()
+    }
+}
+impl From<AttributeWriteMask> for opcua::types::Variant {
+    fn from(v: AttributeWriteMask) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for AttributeWriteMask {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
     }
 }
 impl<'de> serde::de::Deserialize<'de> for AttributeWriteMask {
@@ -318,6 +373,21 @@ impl TryFrom<i32> for AxisScaleEnumeration {
         )
     }
 }
+impl From<AxisScaleEnumeration> for i32 {
+    fn from(value: AxisScaleEnumeration) -> Self {
+        value as i32
+    }
+}
+impl From<AxisScaleEnumeration> for opcua::types::Variant {
+    fn from(value: AxisScaleEnumeration) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for AxisScaleEnumeration {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for AxisScaleEnumeration {
     fn byte_len(&self) -> usize {
         4usize
@@ -366,6 +436,21 @@ impl TryFrom<i32> for BrokerTransportQualityOfService {
         )
     }
 }
+impl From<BrokerTransportQualityOfService> for i32 {
+    fn from(value: BrokerTransportQualityOfService) -> Self {
+        value as i32
+    }
+}
+impl From<BrokerTransportQualityOfService> for opcua::types::Variant {
+    fn from(value: BrokerTransportQualityOfService) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for BrokerTransportQualityOfService {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for BrokerTransportQualityOfService {
     fn byte_len(&self) -> usize {
         4usize
@@ -410,6 +495,21 @@ impl TryFrom<i32> for BrowseDirection {
                 }
             },
         )
+    }
+}
+impl From<BrowseDirection> for i32 {
+    fn from(value: BrowseDirection) -> Self {
+        value as i32
+    }
+}
+impl From<BrowseDirection> for opcua::types::Variant {
+    fn from(value: BrowseDirection) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for BrowseDirection {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for BrowseDirection {
@@ -467,6 +567,21 @@ impl TryFrom<i32> for BrowseResultMask {
         )
     }
 }
+impl From<BrowseResultMask> for i32 {
+    fn from(value: BrowseResultMask) -> Self {
+        value as i32
+    }
+}
+impl From<BrowseResultMask> for opcua::types::Variant {
+    fn from(value: BrowseResultMask) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for BrowseResultMask {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for BrowseResultMask {
     fn byte_len(&self) -> usize {
         4usize
@@ -510,6 +625,21 @@ impl TryFrom<i32> for DataChangeTrigger {
                 }
             },
         )
+    }
+}
+impl From<DataChangeTrigger> for i32 {
+    fn from(value: DataChangeTrigger) -> Self {
+        value as i32
+    }
+}
+impl From<DataChangeTrigger> for opcua::types::Variant {
+    fn from(value: DataChangeTrigger) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for DataChangeTrigger {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for DataChangeTrigger {
@@ -556,6 +686,16 @@ impl opcua::types::BinaryEncoder for DataSetFieldContentMask {
 impl Default for DataSetFieldContentMask {
     fn default() -> Self {
         Self::empty()
+    }
+}
+impl From<DataSetFieldContentMask> for opcua::types::Variant {
+    fn from(v: DataSetFieldContentMask) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for DataSetFieldContentMask {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
     }
 }
 impl<'de> serde::de::Deserialize<'de> for DataSetFieldContentMask {
@@ -615,6 +755,16 @@ impl Default for DataSetFieldFlags {
         Self::empty()
     }
 }
+impl From<DataSetFieldFlags> for opcua::types::Variant {
+    fn from(v: DataSetFieldFlags) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for DataSetFieldFlags {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
+    }
+}
 impl<'de> serde::de::Deserialize<'de> for DataSetFieldFlags {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -671,6 +821,21 @@ impl TryFrom<i32> for DataSetOrderingType {
         )
     }
 }
+impl From<DataSetOrderingType> for i32 {
+    fn from(value: DataSetOrderingType) -> Self {
+        value as i32
+    }
+}
+impl From<DataSetOrderingType> for opcua::types::Variant {
+    fn from(value: DataSetOrderingType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for DataSetOrderingType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for DataSetOrderingType {
     fn byte_len(&self) -> usize {
         4usize
@@ -710,6 +875,21 @@ impl TryFrom<i32> for DeadbandType {
                 }
             },
         )
+    }
+}
+impl From<DeadbandType> for i32 {
+    fn from(value: DeadbandType) -> Self {
+        value as i32
+    }
+}
+impl From<DeadbandType> for opcua::types::Variant {
+    fn from(value: DeadbandType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for DeadbandType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for DeadbandType {
@@ -757,6 +937,21 @@ impl TryFrom<i32> for DiagnosticsLevel {
         )
     }
 }
+impl From<DiagnosticsLevel> for i32 {
+    fn from(value: DiagnosticsLevel) -> Self {
+        value as i32
+    }
+}
+impl From<DiagnosticsLevel> for opcua::types::Variant {
+    fn from(value: DiagnosticsLevel) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for DiagnosticsLevel {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for DiagnosticsLevel {
     fn byte_len(&self) -> usize {
         4usize
@@ -800,6 +995,16 @@ impl opcua::types::BinaryEncoder for EventNotifierType {
 impl Default for EventNotifierType {
     fn default() -> Self {
         Self::empty()
+    }
+}
+impl From<EventNotifierType> for opcua::types::Variant {
+    fn from(v: EventNotifierType) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for EventNotifierType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
     }
 }
 impl<'de> serde::de::Deserialize<'de> for EventNotifierType {
@@ -860,6 +1065,21 @@ impl TryFrom<i32> for ExceptionDeviationFormat {
                 }
             },
         )
+    }
+}
+impl From<ExceptionDeviationFormat> for i32 {
+    fn from(value: ExceptionDeviationFormat) -> Self {
+        value as i32
+    }
+}
+impl From<ExceptionDeviationFormat> for opcua::types::Variant {
+    fn from(value: ExceptionDeviationFormat) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for ExceptionDeviationFormat {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for ExceptionDeviationFormat {
@@ -935,6 +1155,21 @@ impl TryFrom<i32> for FilterOperator {
         )
     }
 }
+impl From<FilterOperator> for i32 {
+    fn from(value: FilterOperator) -> Self {
+        value as i32
+    }
+}
+impl From<FilterOperator> for opcua::types::Variant {
+    fn from(value: FilterOperator) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for FilterOperator {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for FilterOperator {
     fn byte_len(&self) -> usize {
         4usize
@@ -978,6 +1213,21 @@ impl TryFrom<i32> for HistoryUpdateType {
                 }
             },
         )
+    }
+}
+impl From<HistoryUpdateType> for i32 {
+    fn from(value: HistoryUpdateType) -> Self {
+        value as i32
+    }
+}
+impl From<HistoryUpdateType> for opcua::types::Variant {
+    fn from(value: HistoryUpdateType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for HistoryUpdateType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for HistoryUpdateType {
@@ -1029,6 +1279,21 @@ impl TryFrom<i32> for IdentityCriteriaType {
         )
     }
 }
+impl From<IdentityCriteriaType> for i32 {
+    fn from(value: IdentityCriteriaType) -> Self {
+        value as i32
+    }
+}
+impl From<IdentityCriteriaType> for opcua::types::Variant {
+    fn from(value: IdentityCriteriaType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for IdentityCriteriaType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for IdentityCriteriaType {
     fn byte_len(&self) -> usize {
         4usize
@@ -1070,6 +1335,21 @@ impl TryFrom<i32> for IdType {
                 }
             },
         )
+    }
+}
+impl From<IdType> for i32 {
+    fn from(value: IdType) -> Self {
+        value as i32
+    }
+}
+impl From<IdType> for opcua::types::Variant {
+    fn from(value: IdType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for IdType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for IdType {
@@ -1115,6 +1395,16 @@ impl opcua::types::BinaryEncoder for JsonDataSetMessageContentMask {
 impl Default for JsonDataSetMessageContentMask {
     fn default() -> Self {
         Self::empty()
+    }
+}
+impl From<JsonDataSetMessageContentMask> for opcua::types::Variant {
+    fn from(v: JsonDataSetMessageContentMask) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for JsonDataSetMessageContentMask {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
     }
 }
 impl<'de> serde::de::Deserialize<'de> for JsonDataSetMessageContentMask {
@@ -1176,6 +1466,16 @@ impl Default for JsonNetworkMessageContentMask {
         Self::empty()
     }
 }
+impl From<JsonNetworkMessageContentMask> for opcua::types::Variant {
+    fn from(v: JsonNetworkMessageContentMask) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for JsonNetworkMessageContentMask {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
+    }
+}
 impl<'de> serde::de::Deserialize<'de> for JsonNetworkMessageContentMask {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1235,6 +1535,21 @@ impl TryFrom<i32> for MessageSecurityMode {
         )
     }
 }
+impl From<MessageSecurityMode> for i32 {
+    fn from(value: MessageSecurityMode) -> Self {
+        value as i32
+    }
+}
+impl From<MessageSecurityMode> for opcua::types::Variant {
+    fn from(value: MessageSecurityMode) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for MessageSecurityMode {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for MessageSecurityMode {
     fn byte_len(&self) -> usize {
         4usize
@@ -1283,6 +1598,21 @@ impl TryFrom<i32> for ModelChangeStructureVerbMask {
         )
     }
 }
+impl From<ModelChangeStructureVerbMask> for i32 {
+    fn from(value: ModelChangeStructureVerbMask) -> Self {
+        value as i32
+    }
+}
+impl From<ModelChangeStructureVerbMask> for opcua::types::Variant {
+    fn from(value: ModelChangeStructureVerbMask) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for ModelChangeStructureVerbMask {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for ModelChangeStructureVerbMask {
     fn byte_len(&self) -> usize {
         4usize
@@ -1326,6 +1656,21 @@ impl TryFrom<i32> for MonitoringMode {
         )
     }
 }
+impl From<MonitoringMode> for i32 {
+    fn from(value: MonitoringMode) -> Self {
+        value as i32
+    }
+}
+impl From<MonitoringMode> for opcua::types::Variant {
+    fn from(value: MonitoringMode) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for MonitoringMode {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for MonitoringMode {
     fn byte_len(&self) -> usize {
         4usize
@@ -1365,6 +1710,21 @@ impl TryFrom<i32> for NamingRuleType {
                 }
             },
         )
+    }
+}
+impl From<NamingRuleType> for i32 {
+    fn from(value: NamingRuleType) -> Self {
+        value as i32
+    }
+}
+impl From<NamingRuleType> for opcua::types::Variant {
+    fn from(value: NamingRuleType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for NamingRuleType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for NamingRuleType {
@@ -1474,6 +1834,21 @@ impl TryFrom<i32> for NodeAttributesMask {
         )
     }
 }
+impl From<NodeAttributesMask> for i32 {
+    fn from(value: NodeAttributesMask) -> Self {
+        value as i32
+    }
+}
+impl From<NodeAttributesMask> for opcua::types::Variant {
+    fn from(value: NodeAttributesMask) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for NodeAttributesMask {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for NodeAttributesMask {
     fn byte_len(&self) -> usize {
         4usize
@@ -1527,6 +1902,21 @@ impl TryFrom<i32> for NodeClass {
         )
     }
 }
+impl From<NodeClass> for i32 {
+    fn from(value: NodeClass) -> Self {
+        value as i32
+    }
+}
+impl From<NodeClass> for opcua::types::Variant {
+    fn from(value: NodeClass) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for NodeClass {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for NodeClass {
     fn byte_len(&self) -> usize {
         4usize
@@ -1575,6 +1965,21 @@ impl TryFrom<u8> for NodeIdType {
         )
     }
 }
+impl From<NodeIdType> for u8 {
+    fn from(value: NodeIdType) -> Self {
+        value as u8
+    }
+}
+impl From<NodeIdType> for opcua::types::Variant {
+    fn from(value: NodeIdType) -> Self {
+        Self::from(value as u8)
+    }
+}
+impl opcua::types::AsVariantRef for NodeIdType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as u8).into()
+    }
+}
 impl opcua::types::BinaryEncoder for NodeIdType {
     fn byte_len(&self) -> usize {
         1usize
@@ -1616,6 +2021,21 @@ impl TryFrom<i32> for OpenFileMode {
                 }
             },
         )
+    }
+}
+impl From<OpenFileMode> for i32 {
+    fn from(value: OpenFileMode) -> Self {
+        value as i32
+    }
+}
+impl From<OpenFileMode> for opcua::types::Variant {
+    fn from(value: OpenFileMode) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for OpenFileMode {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for OpenFileMode {
@@ -1661,6 +2081,21 @@ impl TryFrom<i32> for OverrideValueHandling {
         )
     }
 }
+impl From<OverrideValueHandling> for i32 {
+    fn from(value: OverrideValueHandling) -> Self {
+        value as i32
+    }
+}
+impl From<OverrideValueHandling> for opcua::types::Variant {
+    fn from(value: OverrideValueHandling) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for OverrideValueHandling {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for OverrideValueHandling {
     fn byte_len(&self) -> usize {
         4usize
@@ -1704,6 +2139,21 @@ impl TryFrom<i32> for PerformUpdateType {
                 }
             },
         )
+    }
+}
+impl From<PerformUpdateType> for i32 {
+    fn from(value: PerformUpdateType) -> Self {
+        value as i32
+    }
+}
+impl From<PerformUpdateType> for opcua::types::Variant {
+    fn from(value: PerformUpdateType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for PerformUpdateType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for PerformUpdateType {
@@ -1753,6 +2203,16 @@ impl opcua::types::BinaryEncoder for PermissionType {
 impl Default for PermissionType {
     fn default() -> Self {
         Self::empty()
+    }
+}
+impl From<PermissionType> for opcua::types::Variant {
+    fn from(v: PermissionType) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for PermissionType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
     }
 }
 impl<'de> serde::de::Deserialize<'de> for PermissionType {
@@ -1810,6 +2270,21 @@ impl TryFrom<i32> for PubSubDiagnosticsCounterClassification {
         )
     }
 }
+impl From<PubSubDiagnosticsCounterClassification> for i32 {
+    fn from(value: PubSubDiagnosticsCounterClassification) -> Self {
+        value as i32
+    }
+}
+impl From<PubSubDiagnosticsCounterClassification> for opcua::types::Variant {
+    fn from(value: PubSubDiagnosticsCounterClassification) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for PubSubDiagnosticsCounterClassification {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for PubSubDiagnosticsCounterClassification {
     fn byte_len(&self) -> usize {
         4usize
@@ -1851,6 +2326,21 @@ impl TryFrom<i32> for PubSubState {
                 }
             },
         )
+    }
+}
+impl From<PubSubState> for i32 {
+    fn from(value: PubSubState) -> Self {
+        value as i32
+    }
+}
+impl From<PubSubState> for opcua::types::Variant {
+    fn from(value: PubSubState) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for PubSubState {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for PubSubState {
@@ -1902,6 +2392,21 @@ impl TryFrom<i32> for RedundancySupport {
         )
     }
 }
+impl From<RedundancySupport> for i32 {
+    fn from(value: RedundancySupport) -> Self {
+        value as i32
+    }
+}
+impl From<RedundancySupport> for opcua::types::Variant {
+    fn from(value: RedundancySupport) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for RedundancySupport {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for RedundancySupport {
     fn byte_len(&self) -> usize {
         4usize
@@ -1941,6 +2446,21 @@ impl TryFrom<i32> for SecurityTokenRequestType {
                 }
             },
         )
+    }
+}
+impl From<SecurityTokenRequestType> for i32 {
+    fn from(value: SecurityTokenRequestType) -> Self {
+        value as i32
+    }
+}
+impl From<SecurityTokenRequestType> for opcua::types::Variant {
+    fn from(value: SecurityTokenRequestType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for SecurityTokenRequestType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for SecurityTokenRequestType {
@@ -1994,6 +2514,21 @@ impl TryFrom<i32> for ServerState {
         )
     }
 }
+impl From<ServerState> for i32 {
+    fn from(value: ServerState) -> Self {
+        value as i32
+    }
+}
+impl From<ServerState> for opcua::types::Variant {
+    fn from(value: ServerState) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for ServerState {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for ServerState {
     fn byte_len(&self) -> usize {
         4usize
@@ -2035,6 +2570,21 @@ impl TryFrom<i32> for StructureType {
                 }
             },
         )
+    }
+}
+impl From<StructureType> for i32 {
+    fn from(value: StructureType) -> Self {
+        value as i32
+    }
+}
+impl From<StructureType> for opcua::types::Variant {
+    fn from(value: StructureType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for StructureType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for StructureType {
@@ -2087,6 +2637,21 @@ impl TryFrom<i32> for TimestampsToReturn {
         )
     }
 }
+impl From<TimestampsToReturn> for i32 {
+    fn from(value: TimestampsToReturn) -> Self {
+        value as i32
+    }
+}
+impl From<TimestampsToReturn> for opcua::types::Variant {
+    fn from(value: TimestampsToReturn) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for TimestampsToReturn {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for TimestampsToReturn {
     fn byte_len(&self) -> usize {
         4usize
@@ -2134,6 +2699,21 @@ impl TryFrom<i32> for TrustListMasks {
         )
     }
 }
+impl From<TrustListMasks> for i32 {
+    fn from(value: TrustListMasks) -> Self {
+        value as i32
+    }
+}
+impl From<TrustListMasks> for opcua::types::Variant {
+    fn from(value: TrustListMasks) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for TrustListMasks {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
+    }
+}
 impl opcua::types::BinaryEncoder for TrustListMasks {
     fn byte_len(&self) -> usize {
         4usize
@@ -2178,6 +2758,16 @@ impl opcua::types::BinaryEncoder for UadpDataSetMessageContentMask {
 impl Default for UadpDataSetMessageContentMask {
     fn default() -> Self {
         Self::empty()
+    }
+}
+impl From<UadpDataSetMessageContentMask> for opcua::types::Variant {
+    fn from(v: UadpDataSetMessageContentMask) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for UadpDataSetMessageContentMask {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
     }
 }
 impl<'de> serde::de::Deserialize<'de> for UadpDataSetMessageContentMask {
@@ -2241,6 +2831,16 @@ impl Default for UadpNetworkMessageContentMask {
         Self::empty()
     }
 }
+impl From<UadpNetworkMessageContentMask> for opcua::types::Variant {
+    fn from(v: UadpNetworkMessageContentMask) -> Self {
+        Self::from(v.bits())
+    }
+}
+impl opcua::types::AsVariantRef for UadpNetworkMessageContentMask {
+    fn as_variant(&self) -> opcua::types::Variant {
+        self.bits().into()
+    }
+}
 impl<'de> serde::de::Deserialize<'de> for UadpNetworkMessageContentMask {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -2295,6 +2895,21 @@ impl TryFrom<i32> for UserTokenType {
                 }
             },
         )
+    }
+}
+impl From<UserTokenType> for i32 {
+    fn from(value: UserTokenType) -> Self {
+        value as i32
+    }
+}
+impl From<UserTokenType> for opcua::types::Variant {
+    fn from(value: UserTokenType) -> Self {
+        Self::from(value as i32)
+    }
+}
+impl opcua::types::AsVariantRef for UserTokenType {
+    fn as_variant(&self) -> opcua::types::Variant {
+        (*self as i32).into()
     }
 }
 impl opcua::types::BinaryEncoder for UserTokenType {

--- a/opcua-types/src/service_types/event_filter.rs
+++ b/opcua-types/src/service_types/event_filter.rs
@@ -16,6 +16,11 @@ pub struct EventFilter {
     >,
     pub where_clause: super::content_filter::ContentFilter,
 }
+impl opcua::types::MessageInfo for EventFilter {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::EventFilter_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for EventFilter {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/event_filter_result.rs
+++ b/opcua-types/src/service_types/event_filter_result.rs
@@ -15,6 +15,11 @@ pub struct EventFilterResult {
     >,
     pub where_clause_result: super::content_filter_result::ContentFilterResult,
 }
+impl opcua::types::MessageInfo for EventFilterResult {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::EventFilterResult_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for EventFilterResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/event_notification_list.rs
+++ b/opcua-types/src/service_types/event_notification_list.rs
@@ -11,6 +11,11 @@ mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
 pub struct EventNotificationList {
     pub events: Option<Vec<super::event_field_list::EventFieldList>>,
 }
+impl opcua::types::MessageInfo for EventNotificationList {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::EventNotificationList_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for EventNotificationList {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/generic_attributes.rs
+++ b/opcua-types/src/service_types/generic_attributes.rs
@@ -18,6 +18,11 @@ pub struct GenericAttributes {
         Vec<super::generic_attribute_value::GenericAttributeValue>,
     >,
 }
+impl opcua::types::MessageInfo for GenericAttributes {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::GenericAttributes_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for GenericAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/history_modified_data.rs
+++ b/opcua-types/src/service_types/history_modified_data.rs
@@ -12,6 +12,11 @@ pub struct HistoryModifiedData {
     pub data_values: Option<Vec<opcua::types::data_value::DataValue>>,
     pub modification_infos: Option<Vec<super::modification_info::ModificationInfo>>,
 }
+impl opcua::types::MessageInfo for HistoryModifiedData {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::HistoryModifiedData_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for HistoryModifiedData {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/issued_identity_token.rs
+++ b/opcua-types/src/service_types/issued_identity_token.rs
@@ -13,6 +13,11 @@ pub struct IssuedIdentityToken {
     pub token_data: opcua::types::byte_string::ByteString,
     pub encryption_algorithm: opcua::types::string::UAString,
 }
+impl opcua::types::MessageInfo for IssuedIdentityToken {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::IssuedIdentityToken_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for IssuedIdentityToken {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/json_data_set_reader_message_data_type.rs
+++ b/opcua-types/src/service_types/json_data_set_reader_message_data_type.rs
@@ -12,6 +12,11 @@ pub struct JsonDataSetReaderMessageDataType {
     pub network_message_content_mask: super::enums::JsonNetworkMessageContentMask,
     pub data_set_message_content_mask: super::enums::JsonDataSetMessageContentMask,
 }
+impl opcua::types::MessageInfo for JsonDataSetReaderMessageDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::JsonDataSetReaderMessageDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for JsonDataSetReaderMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/json_data_set_writer_message_data_type.rs
+++ b/opcua-types/src/service_types/json_data_set_writer_message_data_type.rs
@@ -11,6 +11,11 @@ mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
 pub struct JsonDataSetWriterMessageDataType {
     pub data_set_message_content_mask: super::enums::JsonDataSetMessageContentMask,
 }
+impl opcua::types::MessageInfo for JsonDataSetWriterMessageDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::JsonDataSetWriterMessageDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for JsonDataSetWriterMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/json_writer_group_message_data_type.rs
+++ b/opcua-types/src/service_types/json_writer_group_message_data_type.rs
@@ -11,6 +11,11 @@ mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
 pub struct JsonWriterGroupMessageDataType {
     pub network_message_content_mask: super::enums::JsonNetworkMessageContentMask,
 }
+impl opcua::types::MessageInfo for JsonWriterGroupMessageDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::JsonWriterGroupMessageDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for JsonWriterGroupMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/literal_operand.rs
+++ b/opcua-types/src/service_types/literal_operand.rs
@@ -11,6 +11,11 @@ mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
 pub struct LiteralOperand {
     pub value: opcua::types::variant::Variant,
 }
+impl opcua::types::MessageInfo for LiteralOperand {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::LiteralOperand_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for LiteralOperand {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/mdns_discovery_configuration.rs
+++ b/opcua-types/src/service_types/mdns_discovery_configuration.rs
@@ -12,6 +12,11 @@ pub struct MdnsDiscoveryConfiguration {
     pub mdns_server_name: opcua::types::string::UAString,
     pub server_capabilities: Option<Vec<opcua::types::string::UAString>>,
 }
+impl opcua::types::MessageInfo for MdnsDiscoveryConfiguration {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::MdnsDiscoveryConfiguration_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for MdnsDiscoveryConfiguration {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/method_attributes.rs
+++ b/opcua-types/src/service_types/method_attributes.rs
@@ -17,6 +17,11 @@ pub struct MethodAttributes {
     pub executable: bool,
     pub user_executable: bool,
 }
+impl opcua::types::MessageInfo for MethodAttributes {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::MethodAttributes_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for MethodAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/network_address_url_data_type.rs
+++ b/opcua-types/src/service_types/network_address_url_data_type.rs
@@ -12,6 +12,11 @@ pub struct NetworkAddressUrlDataType {
     pub network_interface: opcua::types::string::UAString,
     pub url: opcua::types::string::UAString,
 }
+impl opcua::types::MessageInfo for NetworkAddressUrlDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::NetworkAddressUrlDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for NetworkAddressUrlDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/object_attributes.rs
+++ b/opcua-types/src/service_types/object_attributes.rs
@@ -16,6 +16,11 @@ pub struct ObjectAttributes {
     pub user_write_mask: u32,
     pub event_notifier: u8,
 }
+impl opcua::types::MessageInfo for ObjectAttributes {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ObjectAttributes_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ObjectAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/object_type_attributes.rs
+++ b/opcua-types/src/service_types/object_type_attributes.rs
@@ -16,6 +16,11 @@ pub struct ObjectTypeAttributes {
     pub user_write_mask: u32,
     pub is_abstract: bool,
 }
+impl opcua::types::MessageInfo for ObjectTypeAttributes {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ObjectTypeAttributes_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ObjectTypeAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/published_data_items_data_type.rs
+++ b/opcua-types/src/service_types/published_data_items_data_type.rs
@@ -13,6 +13,11 @@ pub struct PublishedDataItemsDataType {
         Vec<super::published_variable_data_type::PublishedVariableDataType>,
     >,
 }
+impl opcua::types::MessageInfo for PublishedDataItemsDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::PublishedDataItemsDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for PublishedDataItemsDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/published_events_data_type.rs
+++ b/opcua-types/src/service_types/published_events_data_type.rs
@@ -15,6 +15,11 @@ pub struct PublishedEventsDataType {
     >,
     pub filter: super::content_filter::ContentFilter,
 }
+impl opcua::types::MessageInfo for PublishedEventsDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::PublishedEventsDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for PublishedEventsDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/read_annotation_data_details.rs
+++ b/opcua-types/src/service_types/read_annotation_data_details.rs
@@ -11,6 +11,11 @@ mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
 pub struct ReadAnnotationDataDetails {
     pub req_times: Option<Vec<opcua::types::date_time::DateTime>>,
 }
+impl opcua::types::MessageInfo for ReadAnnotationDataDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ReadAnnotationDataDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ReadAnnotationDataDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/read_at_time_details.rs
+++ b/opcua-types/src/service_types/read_at_time_details.rs
@@ -12,6 +12,11 @@ pub struct ReadAtTimeDetails {
     pub req_times: Option<Vec<opcua::types::date_time::DateTime>>,
     pub use_simple_bounds: bool,
 }
+impl opcua::types::MessageInfo for ReadAtTimeDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ReadAtTimeDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ReadAtTimeDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/read_event_details.rs
+++ b/opcua-types/src/service_types/read_event_details.rs
@@ -14,6 +14,11 @@ pub struct ReadEventDetails {
     pub end_time: opcua::types::date_time::DateTime,
     pub filter: super::event_filter::EventFilter,
 }
+impl opcua::types::MessageInfo for ReadEventDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ReadEventDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ReadEventDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/read_processed_details.rs
+++ b/opcua-types/src/service_types/read_processed_details.rs
@@ -15,6 +15,11 @@ pub struct ReadProcessedDetails {
     pub aggregate_type: Option<Vec<opcua::types::node_id::NodeId>>,
     pub aggregate_configuration: super::aggregate_configuration::AggregateConfiguration,
 }
+impl opcua::types::MessageInfo for ReadProcessedDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ReadProcessedDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ReadProcessedDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/read_raw_modified_details.rs
+++ b/opcua-types/src/service_types/read_raw_modified_details.rs
@@ -15,6 +15,11 @@ pub struct ReadRawModifiedDetails {
     pub num_values_per_node: u32,
     pub return_bounds: bool,
 }
+impl opcua::types::MessageInfo for ReadRawModifiedDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ReadRawModifiedDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ReadRawModifiedDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/reader_group_data_type.rs
+++ b/opcua-types/src/service_types/reader_group_data_type.rs
@@ -23,6 +23,11 @@ pub struct ReaderGroupDataType {
         Vec<super::data_set_reader_data_type::DataSetReaderDataType>,
     >,
 }
+impl opcua::types::MessageInfo for ReaderGroupDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ReaderGroupDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ReaderGroupDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/reference_type_attributes.rs
+++ b/opcua-types/src/service_types/reference_type_attributes.rs
@@ -18,6 +18,11 @@ pub struct ReferenceTypeAttributes {
     pub symmetric: bool,
     pub inverse_name: opcua::types::localized_text::LocalizedText,
 }
+impl opcua::types::MessageInfo for ReferenceTypeAttributes {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ReferenceTypeAttributes_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ReferenceTypeAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/simple_attribute_operand.rs
+++ b/opcua-types/src/service_types/simple_attribute_operand.rs
@@ -16,6 +16,11 @@ pub struct SimpleAttributeOperand {
     pub attribute_id: u32,
     pub index_range: opcua::types::string::UAString,
 }
+impl opcua::types::MessageInfo for SimpleAttributeOperand {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::SimpleAttributeOperand_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for SimpleAttributeOperand {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/simple_type_description.rs
+++ b/opcua-types/src/service_types/simple_type_description.rs
@@ -16,6 +16,11 @@ pub struct SimpleTypeDescription {
     pub base_data_type: opcua::types::node_id::NodeId,
     pub built_in_type: u8,
 }
+impl opcua::types::MessageInfo for SimpleTypeDescription {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::SimpleTypeDescription_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for SimpleTypeDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/status_change_notification.rs
+++ b/opcua-types/src/service_types/status_change_notification.rs
@@ -12,6 +12,11 @@ pub struct StatusChangeNotification {
     pub status: opcua::types::status_code::StatusCode,
     pub diagnostic_info: opcua::types::diagnostic_info::DiagnosticInfo,
 }
+impl opcua::types::MessageInfo for StatusChangeNotification {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::StatusChangeNotification_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for StatusChangeNotification {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/structure_description.rs
+++ b/opcua-types/src/service_types/structure_description.rs
@@ -14,6 +14,11 @@ pub struct StructureDescription {
     pub name: opcua::types::qualified_name::QualifiedName,
     pub structure_definition: super::structure_definition::StructureDefinition,
 }
+impl opcua::types::MessageInfo for StructureDescription {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::StructureDescription_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for StructureDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/subscribed_data_set_mirror_data_type.rs
+++ b/opcua-types/src/service_types/subscribed_data_set_mirror_data_type.rs
@@ -12,6 +12,11 @@ pub struct SubscribedDataSetMirrorDataType {
     pub parent_node_name: opcua::types::string::UAString,
     pub role_permissions: Option<Vec<super::role_permission_type::RolePermissionType>>,
 }
+impl opcua::types::MessageInfo for SubscribedDataSetMirrorDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::SubscribedDataSetMirrorDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for SubscribedDataSetMirrorDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/target_variables_data_type.rs
+++ b/opcua-types/src/service_types/target_variables_data_type.rs
@@ -13,6 +13,11 @@ pub struct TargetVariablesDataType {
         Vec<super::field_target_data_type::FieldTargetDataType>,
     >,
 }
+impl opcua::types::MessageInfo for TargetVariablesDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::TargetVariablesDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for TargetVariablesDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/three_d_cartesian_coordinates.rs
+++ b/opcua-types/src/service_types/three_d_cartesian_coordinates.rs
@@ -13,6 +13,11 @@ pub struct ThreeDCartesianCoordinates {
     pub y: f64,
     pub z: f64,
 }
+impl opcua::types::MessageInfo for ThreeDCartesianCoordinates {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ThreeDCartesianCoordinates_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ThreeDCartesianCoordinates {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/three_d_frame.rs
+++ b/opcua-types/src/service_types/three_d_frame.rs
@@ -12,6 +12,11 @@ pub struct ThreeDFrame {
     pub cartesian_coordinates: super::three_d_cartesian_coordinates::ThreeDCartesianCoordinates,
     pub orientation: super::three_d_orientation::ThreeDOrientation,
 }
+impl opcua::types::MessageInfo for ThreeDFrame {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ThreeDFrame_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ThreeDFrame {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/three_d_orientation.rs
+++ b/opcua-types/src/service_types/three_d_orientation.rs
@@ -13,6 +13,11 @@ pub struct ThreeDOrientation {
     pub b: f64,
     pub c: f64,
 }
+impl opcua::types::MessageInfo for ThreeDOrientation {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ThreeDOrientation_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ThreeDOrientation {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/three_d_vector.rs
+++ b/opcua-types/src/service_types/three_d_vector.rs
@@ -13,6 +13,11 @@ pub struct ThreeDVector {
     pub y: f64,
     pub z: f64,
 }
+impl opcua::types::MessageInfo for ThreeDVector {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ThreeDVector_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ThreeDVector {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/ua_binary_file_data_type.rs
+++ b/opcua-types/src/service_types/ua_binary_file_data_type.rs
@@ -21,6 +21,11 @@ pub struct UABinaryFileDataType {
     pub file_header: Option<Vec<super::key_value_pair::KeyValuePair>>,
     pub body: opcua::types::variant::Variant,
 }
+impl opcua::types::MessageInfo for UABinaryFileDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::UABinaryFileDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for UABinaryFileDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/uadp_data_set_reader_message_data_type.rs
+++ b/opcua-types/src/service_types/uadp_data_set_reader_message_data_type.rs
@@ -19,6 +19,11 @@ pub struct UadpDataSetReaderMessageDataType {
     pub receive_offset: f64,
     pub processing_offset: f64,
 }
+impl opcua::types::MessageInfo for UadpDataSetReaderMessageDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::UadpDataSetReaderMessageDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for UadpDataSetReaderMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/uadp_data_set_writer_message_data_type.rs
+++ b/opcua-types/src/service_types/uadp_data_set_writer_message_data_type.rs
@@ -14,6 +14,11 @@ pub struct UadpDataSetWriterMessageDataType {
     pub network_message_number: u16,
     pub data_set_offset: u16,
 }
+impl opcua::types::MessageInfo for UadpDataSetWriterMessageDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::UadpDataSetWriterMessageDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for UadpDataSetWriterMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/uadp_writer_group_message_data_type.rs
+++ b/opcua-types/src/service_types/uadp_writer_group_message_data_type.rs
@@ -14,6 +14,11 @@ pub struct UadpWriterGroupMessageDataType {
     pub sampling_offset: f64,
     pub publishing_offset: Option<Vec<f64>>,
 }
+impl opcua::types::MessageInfo for UadpWriterGroupMessageDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::UadpWriterGroupMessageDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for UadpWriterGroupMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/update_data_details.rs
+++ b/opcua-types/src/service_types/update_data_details.rs
@@ -12,6 +12,11 @@ pub struct UpdateDataDetails {
     pub perform_insert_replace: super::enums::PerformUpdateType,
     pub update_values: Option<Vec<opcua::types::data_value::DataValue>>,
 }
+impl opcua::types::MessageInfo for UpdateDataDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::UpdateDataDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for UpdateDataDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/update_event_details.rs
+++ b/opcua-types/src/service_types/update_event_details.rs
@@ -13,6 +13,11 @@ pub struct UpdateEventDetails {
     pub filter: super::event_filter::EventFilter,
     pub event_data: Option<Vec<super::history_event_field_list::HistoryEventFieldList>>,
 }
+impl opcua::types::MessageInfo for UpdateEventDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::UpdateEventDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for UpdateEventDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/update_structure_data_details.rs
+++ b/opcua-types/src/service_types/update_structure_data_details.rs
@@ -12,6 +12,11 @@ pub struct UpdateStructureDataDetails {
     pub perform_insert_replace: super::enums::PerformUpdateType,
     pub update_values: Option<Vec<opcua::types::data_value::DataValue>>,
 }
+impl opcua::types::MessageInfo for UpdateStructureDataDetails {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::UpdateStructureDataDetails_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for UpdateStructureDataDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/user_name_identity_token.rs
+++ b/opcua-types/src/service_types/user_name_identity_token.rs
@@ -14,6 +14,11 @@ pub struct UserNameIdentityToken {
     pub password: opcua::types::byte_string::ByteString,
     pub encryption_algorithm: opcua::types::string::UAString,
 }
+impl opcua::types::MessageInfo for UserNameIdentityToken {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::UserNameIdentityToken_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for UserNameIdentityToken {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/variable_attributes.rs
+++ b/opcua-types/src/service_types/variable_attributes.rs
@@ -23,6 +23,11 @@ pub struct VariableAttributes {
     pub minimum_sampling_interval: f64,
     pub historizing: bool,
 }
+impl opcua::types::MessageInfo for VariableAttributes {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::VariableAttributes_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for VariableAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/variable_type_attributes.rs
+++ b/opcua-types/src/service_types/variable_type_attributes.rs
@@ -20,6 +20,11 @@ pub struct VariableTypeAttributes {
     pub array_dimensions: Option<Vec<u32>>,
     pub is_abstract: bool,
 }
+impl opcua::types::MessageInfo for VariableTypeAttributes {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::VariableTypeAttributes_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for VariableTypeAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/view_attributes.rs
+++ b/opcua-types/src/service_types/view_attributes.rs
@@ -17,6 +17,11 @@ pub struct ViewAttributes {
     pub contains_no_loops: bool,
     pub event_notifier: u8,
 }
+impl opcua::types::MessageInfo for ViewAttributes {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::ViewAttributes_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for ViewAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/writer_group_data_type.rs
+++ b/opcua-types/src/service_types/writer_group_data_type.rs
@@ -29,6 +29,11 @@ pub struct WriterGroupDataType {
         Vec<super::data_set_writer_data_type::DataSetWriterDataType>,
     >,
 }
+impl opcua::types::MessageInfo for WriterGroupDataType {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::WriterGroupDataType_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for WriterGroupDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;

--- a/opcua-types/src/service_types/x_509_identity_token.rs
+++ b/opcua-types/src/service_types/x_509_identity_token.rs
@@ -12,6 +12,11 @@ pub struct X509IdentityToken {
     pub policy_id: opcua::types::string::UAString,
     pub certificate_data: opcua::types::byte_string::ByteString,
 }
+impl opcua::types::MessageInfo for X509IdentityToken {
+    fn object_id(&self) -> opcua::types::ObjectId {
+        opcua::types::ObjectId::X509IdentityToken_Encoding_DefaultBinary
+    }
+}
 impl opcua::types::BinaryEncoder for X509IdentityToken {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;


### PR DESCRIPTION
 - Add From implementations for enums and bitfields.
 - Add implementations of a new trait AsVariantRef to basic types (not vectors, importantly)
 - Replace conversion from vectors to variant with blanket impls.
 - Effectively add EventField impls for enums