### PR TITLE
Improve certificate generation

### DIFF
--- a/opcua-client/src/session/services/session.rs
+++ b/opcua-client/src/session/services/session.rs
@@ -82,15 +82,12 @@ impl Session {
                         self.session_info.endpoint.server.application_uri.as_ref();
 
                     let certificate_store = trace_write_lock!(self.certificate_store);
-                    let result = certificate_store.validate_or_reject_application_instance_cert(
+                    certificate_store.validate_or_reject_application_instance_cert(
                         &server_certificate,
                         security_policy,
                         Some(&hostname),
                         Some(application_uri),
-                    );
-                    if result.is_bad() {
-                        return Err(result);
-                    }
+                    )?;
                 } else {
                     return Err(StatusCode::BadCertificateInvalid);
                 }

--- a/opcua-crypto/src/tests/crypto.rs
+++ b/opcua-crypto/src/tests/crypto.rs
@@ -132,7 +132,7 @@ fn test_and_reject_application_instance_cert() {
         None,
         None,
     );
-    assert!(result.is_bad());
+    assert!(result.is_err());
 
     drop(tmp_dir);
 }
@@ -161,7 +161,7 @@ fn test_and_trust_application_instance_cert() {
         None,
         None,
     );
-    assert!(result.is_good());
+    assert!(result.is_ok());
 
     drop(tmp_dir);
 }
@@ -191,7 +191,7 @@ fn test_and_reject_thumbprint_mismatch() {
         None,
         None,
     );
-    assert!(result.is_bad());
+    assert!(result.is_err());
 
     drop(tmp_dir);
 }
@@ -566,18 +566,17 @@ fn certificate_with_hostname_mismatch() {
 
     // Create a certificate and ensure that when the hostname does not match, the verification fails
     // with the correct error
-    let result = cert.is_hostname_valid(&wrong_host_name);
+    let result = cert.is_hostname_valid(&wrong_host_name).unwrap_err();
     assert_eq!(result, StatusCode::BadCertificateHostNameInvalid);
 
     // Create a certificate and ensure that when the hostname does  match, the verification succeeds
-    let result = cert.is_hostname_valid(APPLICATION_HOSTNAME);
-    assert_eq!(result, StatusCode::Good);
+    cert.is_hostname_valid(APPLICATION_HOSTNAME).unwrap();
 
     // Try a few times with different case
-    let result = cert.is_hostname_valid(&APPLICATION_HOSTNAME.to_string().to_uppercase());
-    assert_eq!(result, StatusCode::Good);
-    let result = cert.is_hostname_valid(&APPLICATION_HOSTNAME.to_string().to_lowercase());
-    assert_eq!(result, StatusCode::Good);
+    cert.is_hostname_valid(&APPLICATION_HOSTNAME.to_string().to_uppercase())
+        .unwrap();
+    cert.is_hostname_valid(&APPLICATION_HOSTNAME.to_string().to_lowercase())
+        .unwrap();
 }
 
 #[test]
@@ -585,12 +584,11 @@ fn certificate_with_application_uri_mismatch() {
     let (cert, _) = make_test_cert_2048();
 
     // Compare the certificate to the wrong application uri in the description, expect error
-    let result = cert.is_application_uri_valid("urn:WrongURI");
+    let result = cert.is_application_uri_valid("urn:WrongURI").unwrap_err();
     assert_eq!(result, StatusCode::BadCertificateUriInvalid);
 
     // Compare the certificate to the correct application uri in the description, expect success
-    let result = cert.is_application_uri_valid(APPLICATION_URI);
-    assert_eq!(result, StatusCode::Good);
+    cert.is_application_uri_valid(APPLICATION_URI).unwrap();
 }
 
 #[test]

--- a/opcua-server/src/info.rs
+++ b/opcua-server/src/info.rs
@@ -459,7 +459,11 @@ impl ServerInfo {
         token: &AnonymousIdentityToken,
     ) -> Result<UserToken, StatusCode> {
         if token.policy_id.as_ref() != POLICY_ID_ANONYMOUS {
-            error!("Token doesn't possess the correct policy id");
+            error!(
+                "Token doesn't possess the correct policy id. Got {}, expected {}",
+                token.policy_id.as_ref(),
+                POLICY_ID_ANONYMOUS
+            );
             return Err(StatusCode::BadIdentityTokenInvalid);
         }
         self.authenticator

--- a/samples/server.conf
+++ b/samples/server.conf
@@ -11,7 +11,7 @@ pki_dir: ./pki
 # discovery_server_url: opc.tcp://localhost:4840/UADiscovery
 tcp_config:
   hello_timeout: 5
-  host: 127.0.0.1
+  host: localhost
   port: 4855
 limits:
   clients_can_modify_address_space: false


### PR DESCRIPTION
We weren't generating valid OPC-UA RSA certificates. This fixes that by adding SKI, AKI, and CA:FALSE extensions, as well as properly setting the application URI as an URI, so it is recognized and can be compared to the application URI by clients/servers.

Also rewrites some of the certificate validation methods to return return a result instead of just a status code. If we had FromResidual we could do it differently, but this is more ergonomic since we don't.

Finally, the server would log an error every time you connected to an anonymous endpoint without a certificate, which was unnecessary.

UAExpert now makes a nice green checkmark when you connect to the sample server.