### PR TITLE
Low level client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,7 @@ dependencies = [
  "opcua-crypto",
  "opcua-types",
  "parking_lot",
+ "rsa",
  "serde",
  "tokio",
  "tokio-util",

--- a/opcua-client/Cargo.toml
+++ b/opcua-client/Cargo.toml
@@ -22,6 +22,7 @@ futures = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }
+rsa = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 serde = { workspace = true }

--- a/opcua-client/src/lib.rs
+++ b/opcua-client/src/lib.rs
@@ -124,9 +124,25 @@ pub use config::{ClientConfig, ClientEndpoint, ClientUserToken, ANONYMOUS_USER_T
 pub use session::{
     Client, DataChangeCallback, EventCallback, HistoryReadAction, HistoryUpdateAction,
     MonitoredItem, OnSubscriptionNotification, Session, SessionActivity, SessionConnectMode,
-    SessionEventLoop, SessionPollResult, Subscription, SubscriptionCallbacks,
+    SessionEventLoop, SessionPollResult, Subscription, SubscriptionCallbacks, UARequest,
 };
 pub use transport::AsyncSecureChannel;
+
+pub mod services {
+    //! This module contains request builders for most OPC-UA services.
+    //! Typically you can just use the methods on [`Session`], but if you need to specify
+    //! diagnostics, set a custom timeout, or do other header manipulation, you must use the
+    //! raw request builders.
+    //! Note that these let you pass a session manually, in this case you are responsible for
+    //! passing a valid session matching the secure channel.
+    pub use super::session::{
+        ActivateSession, AddNodes, AddReferences, Browse, BrowseNext, Call, Cancel, CloseSession,
+        CreateMonitoredItems, CreateSession, CreateSubscription, DeleteMonitoredItems, DeleteNodes,
+        DeleteReferences, DeleteSubscriptions, HistoryRead, HistoryUpdate, ModifyMonitoredItems,
+        ModifySubscription, Read, RegisterNodes, SetMonitoringMode, SetPublishingMode,
+        SetTriggering, TransferSubscriptions, TranslateBrowsePaths, UnregisterNodes, Write,
+    };
+}
 
 #[derive(Debug, Clone)]
 pub enum IdentityToken {

--- a/opcua-client/src/session/implementation.rs
+++ b/opcua-client/src/session/implementation.rs
@@ -177,7 +177,17 @@ impl Session {
 
     /// Disconnect from the server and wait until disconnected.
     pub async fn disconnect(&self) -> Result<(), StatusCode> {
-        self.close_session().await?;
+        self.close_session(true).await?;
+        self.channel.close_channel().await;
+
+        self.wait_for_state(false).await;
+
+        Ok(())
+    }
+
+    /// Disconnect the server without deleting subscriptions, then wait until disconnected.
+    pub async fn disconnect_without_delete_subscriptions(&self) -> Result<(), StatusCode> {
+        self.close_session(false).await?;
         self.channel.close_channel().await;
 
         self.wait_for_state(false).await;

--- a/opcua-client/src/session/implementation.rs
+++ b/opcua-client/src/session/implementation.rs
@@ -15,11 +15,10 @@ use crate::{
 use opcua_core::{
     handle::AtomicHandle,
     sync::{Mutex, RwLock},
-    RequestMessage, ResponseMessage,
 };
 use opcua_crypto::CertificateStore;
 use opcua_types::{
-    ApplicationDescription, DecodingOptions, NodeId, RequestHeader, StatusCode, UAString,
+    ApplicationDescription, DecodingOptions, IntegerId, NodeId, RequestHeader, StatusCode, UAString,
 };
 
 use super::{services::subscriptions::state::SubscriptionState, SessionEventLoop, SessionInfo};
@@ -126,16 +125,6 @@ impl Session {
         )
     }
 
-    /// Send a message and wait for response, using the default configured timeout.
-    ///
-    /// In order to set a different timeout, call `send` on the inner channel instead.
-    pub(super) async fn send(
-        &self,
-        request: impl Into<RequestMessage>,
-    ) -> Result<ResponseMessage, StatusCode> {
-        self.channel.send(request, self.request_timeout).await
-    }
-
     /// Create a request header with the default timeout.
     pub(super) fn make_request_header(&self) -> RequestHeader {
         self.channel.make_request_header(self.request_timeout)
@@ -198,5 +187,13 @@ impl Session {
 
     pub fn decoding_options(&self) -> &DecodingOptions {
         &self.decoding_options
+    }
+
+    pub fn channel(&self) -> &AsyncSecureChannel {
+        &self.channel
+    }
+
+    pub fn request_handle(&self) -> IntegerId {
+        self.channel.request_handle()
     }
 }

--- a/opcua-client/src/session/mod.rs
+++ b/opcua-client/src/session/mod.rs
@@ -2,6 +2,7 @@ mod client;
 mod connect;
 mod event_loop;
 mod implementation;
+mod request_builder;
 mod services;
 
 /// Information about the server endpoint, security policy, security mode and user identity that the session will
@@ -41,10 +42,21 @@ pub use connect::SessionConnectMode;
 pub use event_loop::{SessionActivity, SessionEventLoop, SessionPollResult};
 pub use implementation::Session;
 use log::{error, info};
-pub use services::attributes::{HistoryReadAction, HistoryUpdateAction};
+pub use request_builder::UARequest;
+pub use services::attributes::{
+    HistoryRead, HistoryReadAction, HistoryUpdate, HistoryUpdateAction, Read, Write,
+};
+pub use services::method::Call;
+pub use services::node_management::{AddNodes, AddReferences, DeleteNodes, DeleteReferences};
+pub use services::session::{ActivateSession, Cancel, CloseSession, CreateSession};
 pub use services::subscriptions::{
-    DataChangeCallback, EventCallback, MonitoredItem, OnSubscriptionNotification, Subscription,
-    SubscriptionCallbacks,
+    CreateMonitoredItems, CreateSubscription, DataChangeCallback, DeleteMonitoredItems,
+    DeleteSubscriptions, EventCallback, ModifyMonitoredItems, ModifySubscription, MonitoredItem,
+    OnSubscriptionNotification, SetMonitoringMode, SetPublishingMode, SetTriggering, Subscription,
+    SubscriptionCallbacks, TransferSubscriptions,
+};
+pub use services::view::{
+    Browse, BrowseNext, RegisterNodes, TranslateBrowsePaths, UnregisterNodes,
 };
 
 #[allow(unused)]

--- a/opcua-client/src/session/request_builder.rs
+++ b/opcua-client/src/session/request_builder.rs
@@ -55,19 +55,19 @@ impl RequestHeaderBuilder {
 }
 
 macro_rules! builder_base {
-    ($st:ty) => {
+    ($st:ident) => {
         impl $st {
-            builder_base!(_inner $st);
+            builder_base!(!_inner);
         }
     };
 
-    ($st:ty, $($gen:tt)*) => {
-        impl$($gen)* $st {
-            builder_base!(_inner $st);
+    ($st:ident$($gen:tt)*) => {
+        impl$($gen)* $st$($gen)* {
+            builder_base!(!_inner);
         }
     };
 
-    (_inner $st:ty) => {
+    (!_inner) => {
         /// Set requested diagnostic bits.
         pub fn diagnostics(mut self, bits: opcua_types::DiagnosticBits) -> Self {
             self.header.header.return_diagnostics = bits;

--- a/opcua-client/src/session/request_builder.rs
+++ b/opcua-client/src/session/request_builder.rs
@@ -1,0 +1,131 @@
+use std::{future::Future, time::Duration};
+
+use opcua_types::{DateTime, DiagnosticBits, IntegerId, NodeId, RequestHeader, StatusCode};
+
+use crate::AsyncSecureChannel;
+
+use super::Session;
+
+pub trait UARequest {
+    type Out;
+
+    fn send<'a>(
+        self,
+        channel: &'a AsyncSecureChannel,
+    ) -> impl Future<Output = Result<Self::Out, StatusCode>> + Send + Sync + 'a
+    where
+        Self: 'a;
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RequestHeaderBuilder {
+    pub(crate) header: RequestHeader,
+    pub(crate) timeout: Duration,
+    pub(crate) session_id: u32,
+}
+
+impl RequestHeaderBuilder {
+    pub fn new_from_session(session: &Session) -> Self {
+        Self {
+            header: session.make_request_header(),
+            timeout: session.request_timeout,
+            session_id: session.session_id(),
+        }
+    }
+
+    pub fn new(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            header: RequestHeader {
+                authentication_token: auth_token,
+                timestamp: DateTime::now(),
+                request_handle,
+                return_diagnostics: DiagnosticBits::empty(),
+                timeout_hint: timeout.as_millis().min(u32::MAX as u128) as u32,
+                ..Default::default()
+            },
+            timeout,
+            session_id,
+        }
+    }
+}
+
+macro_rules! builder_base {
+    ($st:ty) => {
+        impl $st {
+            builder_base!(_inner $st);
+        }
+    };
+
+    ($st:ty, $($gen:tt)*) => {
+        impl$($gen)* $st {
+            builder_base!(_inner $st);
+        }
+    };
+
+    (_inner $st:ty) => {
+        /// Set requested diagnostic bits.
+        pub fn diagnostics(mut self, bits: opcua_types::DiagnosticBits) -> Self {
+            self.header.header.return_diagnostics = bits;
+            self
+        }
+
+        /// Set the timeout for this request. Defaults to session timeout.
+        pub fn timeout(mut self, timeout: std::time::Duration) -> Self {
+            self.header.header.timeout_hint = timeout.as_millis().min(u32::MAX as u128) as u32;
+            self.header.timeout = timeout;
+            self
+        }
+
+        pub fn audit_entry_id(mut self, entry: impl Into<opcua_types::UAString>) -> Self {
+            self.header.header.audit_entry_id = entry.into();
+            self
+        }
+
+        pub fn header(&self) -> &opcua_types::RequestHeader {
+            &self.header.header
+        }
+    }
+}
+
+pub(crate) use builder_base;
+
+#[allow(unused)]
+macro_rules! builder_warn {
+    ($session: expr, $($arg:tt)*) =>  {
+        log::warn!("session:{} {}", $session.header.session_id, format!($($arg)*));
+    }
+}
+#[allow(unused)]
+pub(crate) use builder_warn;
+
+#[allow(unused)]
+macro_rules! builder_error {
+    ($session: expr, $($arg:tt)*) =>  {
+        log::error!("session:{} {}", $session.header.session_id, format!($($arg)*));
+    }
+}
+#[allow(unused)]
+pub(crate) use builder_error;
+
+#[allow(unused)]
+macro_rules! builder_debug {
+    ($session: expr, $($arg:tt)*) =>  {
+        log::debug!("session:{} {}", $session.header.session_id, format!($($arg)*));
+    }
+}
+#[allow(unused)]
+pub(crate) use builder_debug;
+
+#[allow(unused)]
+macro_rules! builder_trace {
+    ($session: expr, $($arg:tt)*) =>  {
+        log::trace!("session:{} {}", $session.header.session_id, format!($($arg)*));
+    }
+}
+#[allow(unused)]
+pub(crate) use builder_trace;

--- a/opcua-client/src/session/services/attributes.rs
+++ b/opcua-client/src/session/services/attributes.rs
@@ -218,7 +218,7 @@ pub struct HistoryRead<'a> {
     header: RequestHeaderBuilder,
 }
 
-builder_base!(HistoryRead<'a>, <'a>);
+builder_base!(HistoryRead<'a>);
 
 impl<'a> HistoryRead<'a> {
     pub fn new(details: &'a HistoryReadAction, session: &Session) -> Self {

--- a/opcua-client/src/session/services/attributes.rs
+++ b/opcua-client/src/session/services/attributes.rs
@@ -1,17 +1,25 @@
+use std::time::Duration;
+
 use crate::{
-    session::{process_service_result, process_unexpected_response, session_debug, session_error},
-    Session,
+    session::{
+        process_service_result, process_unexpected_response,
+        request_builder::{builder_base, builder_debug, builder_error, RequestHeaderBuilder},
+        UARequest,
+    },
+    AsyncSecureChannel, Session,
 };
 use opcua_core::ResponseMessage;
 use opcua_types::{
     DataValue, DeleteAtTimeDetails, DeleteEventDetails, DeleteRawModifiedDetails, ExtensionObject,
-    HistoryReadRequest, HistoryReadResult, HistoryReadValueId, HistoryUpdateRequest,
-    HistoryUpdateResult, ObjectId, ReadAtTimeDetails, ReadEventDetails, ReadProcessedDetails,
-    ReadRawModifiedDetails, ReadRequest, ReadValueId, StatusCode, TimestampsToReturn,
-    UpdateDataDetails, UpdateEventDetails, UpdateStructureDataDetails, WriteRequest, WriteValue,
+    HistoryReadRequest, HistoryReadResponse, HistoryReadResult, HistoryReadValueId,
+    HistoryUpdateRequest, HistoryUpdateResponse, HistoryUpdateResult, IntegerId, NodeId, ObjectId,
+    ReadAtTimeDetails, ReadEventDetails, ReadProcessedDetails, ReadRawModifiedDetails, ReadRequest,
+    ReadResponse, ReadValueId, StatusCode, TimestampsToReturn, UpdateDataDetails,
+    UpdateEventDetails, UpdateStructureDataDetails, WriteRequest, WriteResponse, WriteValue,
 };
 
 /// Enumeration used with Session::history_read()
+#[derive(Debug, Clone)]
 pub enum HistoryReadAction {
     ReadEventDetails(ReadEventDetails),
     ReadRawModifiedDetails(ReadRawModifiedDetails),
@@ -39,6 +47,7 @@ impl From<&HistoryReadAction> for ExtensionObject {
 }
 
 /// Enumeration used with Session::history_update()
+#[derive(Debug, Clone)]
 pub enum HistoryUpdateAction {
     UpdateDataDetails(UpdateDataDetails),
     UpdateStructureDataDetails(UpdateStructureDataDetails),
@@ -46,6 +55,37 @@ pub enum HistoryUpdateAction {
     DeleteRawModifiedDetails(DeleteRawModifiedDetails),
     DeleteAtTimeDetails(DeleteAtTimeDetails),
     DeleteEventDetails(DeleteEventDetails),
+}
+
+impl From<UpdateDataDetails> for HistoryUpdateAction {
+    fn from(value: UpdateDataDetails) -> Self {
+        Self::UpdateDataDetails(value)
+    }
+}
+impl From<UpdateStructureDataDetails> for HistoryUpdateAction {
+    fn from(value: UpdateStructureDataDetails) -> Self {
+        Self::UpdateStructureDataDetails(value)
+    }
+}
+impl From<UpdateEventDetails> for HistoryUpdateAction {
+    fn from(value: UpdateEventDetails) -> Self {
+        Self::UpdateEventDetails(value)
+    }
+}
+impl From<DeleteRawModifiedDetails> for HistoryUpdateAction {
+    fn from(value: DeleteRawModifiedDetails) -> Self {
+        Self::DeleteRawModifiedDetails(value)
+    }
+}
+impl From<DeleteAtTimeDetails> for HistoryUpdateAction {
+    fn from(value: DeleteAtTimeDetails) -> Self {
+        Self::DeleteAtTimeDetails(value)
+    }
+}
+impl From<DeleteEventDetails> for HistoryUpdateAction {
+    fn from(value: DeleteEventDetails) -> Self {
+        Self::DeleteEventDetails(value)
+    }
 }
 
 impl From<&HistoryUpdateAction> for ExtensionObject {
@@ -70,6 +110,368 @@ impl From<&HistoryUpdateAction> for ExtensionObject {
             HistoryUpdateAction::DeleteEventDetails(v) => {
                 Self::from_encodable(ObjectId::DeleteEventDetails_Encoding_DefaultBinary, v)
             }
+        }
+    }
+}
+
+/// Builder for a call to the `Read` service.
+///
+/// See OPC UA Part 4 - Services 5.10.2 for complete description of the service and error responses.
+#[derive(Debug, Clone)]
+pub struct Read {
+    nodes_to_read: Vec<ReadValueId>,
+    timestamps_to_return: TimestampsToReturn,
+    max_age: f64,
+
+    header: RequestHeaderBuilder,
+}
+
+impl Read {
+    /// Construct a new call to the `Read` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            nodes_to_read: Vec::new(),
+            timestamps_to_return: TimestampsToReturn::Neither,
+            max_age: 0.0,
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `Read` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            nodes_to_read: Vec::new(),
+            timestamps_to_return: TimestampsToReturn::Neither,
+            max_age: 0.0,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set timestamps to return.
+    pub fn timestamps_to_return(mut self, timestamps: TimestampsToReturn) -> Self {
+        self.timestamps_to_return = timestamps;
+        self
+    }
+
+    /// Set max age.
+    pub fn max_age(mut self, max_age: f64) -> Self {
+        self.max_age = max_age;
+        self
+    }
+
+    /// Set nodes to read, overwriting any that were set previously.
+    pub fn nodes_to_read(mut self, nodes_to_read: Vec<ReadValueId>) -> Self {
+        self.nodes_to_read = nodes_to_read;
+        self
+    }
+
+    /// Add a node to read.
+    pub fn node(mut self, node: ReadValueId) -> Self {
+        self.nodes_to_read.push(node);
+        self
+    }
+}
+
+builder_base!(Read);
+
+impl UARequest for Read {
+    type Out = ReadResponse;
+
+    async fn send<'b>(self, channel: &'b AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'b,
+    {
+        if self.nodes_to_read.is_empty() {
+            builder_error!(self, "read(), was not supplied with any nodes to read");
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = ReadRequest {
+            request_header: self.header.header,
+            max_age: self.max_age,
+            timestamps_to_return: self.timestamps_to_return,
+            nodes_to_read: Some(self.nodes_to_read),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::Read(response) = response {
+            builder_debug!(self, "read(), success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "read() value failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HistoryRead<'a> {
+    details: &'a HistoryReadAction,
+    timestamps_to_return: TimestampsToReturn,
+    release_continuation_points: bool,
+    nodes_to_read: Vec<HistoryReadValueId>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(HistoryRead<'a>, <'a>);
+
+impl<'a> HistoryRead<'a> {
+    pub fn new(details: &'a HistoryReadAction, session: &Session) -> Self {
+        Self {
+            details,
+            timestamps_to_return: TimestampsToReturn::Neither,
+            release_continuation_points: false,
+            nodes_to_read: Vec::new(),
+
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `HistoryRead` service, setting header parameters manually.
+    pub fn new_manual(
+        details: &'a HistoryReadAction,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            details,
+            timestamps_to_return: TimestampsToReturn::Neither,
+            release_continuation_points: false,
+            nodes_to_read: Vec::new(),
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set timestamps to return.
+    pub fn timestamps_to_return(mut self, timestamps: TimestampsToReturn) -> Self {
+        self.timestamps_to_return = timestamps;
+        self
+    }
+
+    /// Set release continuation points. Default is false, if this is true,
+    /// continuation points will be freed and the request will return without reading
+    /// any history.
+    pub fn release_continuation_points(mut self, release_continuation_points: bool) -> Self {
+        self.release_continuation_points = release_continuation_points;
+        self
+    }
+
+    /// Set nodes to read, overwriting any that were set previously.
+    pub fn nodes_to_read(mut self, nodes_to_read: Vec<HistoryReadValueId>) -> Self {
+        self.nodes_to_read = nodes_to_read;
+        self
+    }
+
+    /// Add a node to read.
+    pub fn node(mut self, node: HistoryReadValueId) -> Self {
+        self.nodes_to_read.push(node);
+        self
+    }
+}
+
+impl<'a> UARequest for HistoryRead<'a> {
+    type Out = HistoryReadResponse;
+
+    async fn send<'b>(self, channel: &'b AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'b,
+    {
+        let history_read_details = ExtensionObject::from(self.details);
+        builder_debug!(
+            self,
+            "history_read() requested to read nodes {:?}",
+            self.nodes_to_read
+        );
+        let request = HistoryReadRequest {
+            request_header: self.header.header,
+            history_read_details,
+            timestamps_to_return: self.timestamps_to_return,
+            release_continuation_points: self.release_continuation_points,
+            nodes_to_read: if self.nodes_to_read.is_empty() {
+                None
+            } else {
+                Some(self.nodes_to_read)
+            },
+        };
+
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::HistoryRead(response) = response {
+            builder_debug!(self, "history_read(), success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "history_read() value failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Writes values to nodes by sending a [`WriteRequest`] to the server. Note that some servers may reject DataValues
+/// containing source or server timestamps.
+///
+/// See OPC UA Part 4 - Services 5.10.4 for complete description of the service and error responses.
+pub struct Write {
+    nodes_to_write: Vec<WriteValue>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(Write);
+
+impl Write {
+    /// Construct a new call to the `Write` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            nodes_to_write: Vec::new(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `Write` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            nodes_to_write: Vec::new(),
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set nodes to write, overwriting any that were set previously.
+    pub fn nodes_to_write(mut self, nodes_to_write: Vec<WriteValue>) -> Self {
+        self.nodes_to_write = nodes_to_write;
+        self
+    }
+
+    /// Add a write value.
+    pub fn node(mut self, node: impl Into<WriteValue>) -> Self {
+        self.nodes_to_write.push(node.into());
+        self
+    }
+}
+
+impl UARequest for Write {
+    type Out = WriteResponse;
+
+    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.nodes_to_write.is_empty() {
+            builder_error!(self, "write() was not supplied with any nodes to write");
+            return Err(StatusCode::BadNothingToDo);
+        }
+
+        let request = WriteRequest {
+            request_header: self.header.header,
+            nodes_to_write: Some(self.nodes_to_write.to_vec()),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::Write(response) = response {
+            builder_debug!(self, "write(), success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "write() failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Updates historical values. The caller is expected to provide one or more history update operations
+/// in a slice of HistoryUpdateAction enums which are one of the following:
+///
+/// * [`UpdateDataDetails`]
+/// * [`UpdateStructureDataDetails`]
+/// * [`UpdateEventDetails`]
+/// * [`DeleteRawModifiedDetails`]
+/// * [`DeleteAtTimeDetails`]
+/// * [`DeleteEventDetails`]
+///
+/// See OPC UA Part 4 - Services 5.10.5 for complete description of the service and error responses.
+pub struct HistoryUpdate {
+    details: Vec<HistoryUpdateAction>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(HistoryUpdate);
+
+impl HistoryUpdate {
+    /// Construct a new call to the `HistoryUpdate` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            details: Vec::new(),
+
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `HistoryUpdate` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            details: Vec::new(),
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set the history update actions to perform.
+    pub fn details(mut self, details: Vec<HistoryUpdateAction>) -> Self {
+        self.details = details;
+        self
+    }
+
+    /// Add a history update action to the list.
+    pub fn action(mut self, action: impl Into<HistoryUpdateAction>) -> Self {
+        self.details.push(action.into());
+        self
+    }
+}
+
+impl UARequest for HistoryUpdate {
+    type Out = HistoryUpdateResponse;
+
+    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.details.is_empty() {
+            builder_error!(
+                self,
+                "history_update(), was not supplied with any detail to update"
+            );
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let details = self.details.iter().map(ExtensionObject::from).collect();
+        let request = HistoryUpdateRequest {
+            request_header: self.header.header,
+            history_update_details: Some(details),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::HistoryUpdate(response) = response {
+            builder_error!(self, "history_update(), success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "history_update() failed {:?}", response);
+            Err(process_unexpected_response(response))
         }
     }
 }
@@ -99,28 +501,14 @@ impl Session {
         timestamps_to_return: TimestampsToReturn,
         max_age: f64,
     ) -> Result<Vec<DataValue>, StatusCode> {
-        if nodes_to_read.is_empty() {
-            // No subscriptions
-            session_error!(self, "read(), was not supplied with any nodes to read");
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            session_debug!(self, "read() requested to read nodes {:?}", nodes_to_read);
-            let request = ReadRequest {
-                request_header: self.make_request_header(),
-                max_age,
-                timestamps_to_return,
-                nodes_to_read: Some(nodes_to_read.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::Read(response) = response {
-                session_debug!(self, "read(), success");
-                process_service_result(&response.response_header)?;
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "read() value failed");
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(Read::new(self)
+            .nodes_to_read(nodes_to_read.to_vec())
+            .timestamps_to_return(timestamps_to_return)
+            .max_age(max_age)
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Reads historical values or events of one or more nodes. The caller is expected to provide
@@ -152,33 +540,14 @@ impl Session {
         release_continuation_points: bool,
         nodes_to_read: &[HistoryReadValueId],
     ) -> Result<Vec<HistoryReadResult>, StatusCode> {
-        // Turn the enum into an extension object
-        let history_read_details = ExtensionObject::from(history_read_details);
-        let request = HistoryReadRequest {
-            request_header: self.make_request_header(),
-            history_read_details,
-            timestamps_to_return,
-            release_continuation_points,
-            nodes_to_read: if nodes_to_read.is_empty() {
-                None
-            } else {
-                Some(nodes_to_read.to_vec())
-            },
-        };
-        session_debug!(
-            self,
-            "history_read() requested to read nodes {:?}",
-            nodes_to_read
-        );
-        let response = self.send(request).await?;
-        if let ResponseMessage::HistoryRead(response) = response {
-            session_debug!(self, "history_read(), success");
-            process_service_result(&response.response_header)?;
-            Ok(response.results.unwrap_or_default())
-        } else {
-            session_error!(self, "history_read() value failed");
-            Err(process_unexpected_response(response))
-        }
+        Ok(HistoryRead::new(history_read_details, self)
+            .timestamps_to_return(timestamps_to_return)
+            .release_continuation_points(release_continuation_points)
+            .nodes_to_read(nodes_to_read.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Writes values to nodes by sending a [`WriteRequest`] to the server. Note that some servers may reject DataValues
@@ -199,25 +568,12 @@ impl Session {
         &self,
         nodes_to_write: &[WriteValue],
     ) -> Result<Vec<StatusCode>, StatusCode> {
-        if nodes_to_write.is_empty() {
-            // No subscriptions
-            session_error!(self, "write() was not supplied with any nodes to write");
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = WriteRequest {
-                request_header: self.make_request_header(),
-                nodes_to_write: Some(nodes_to_write.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::Write(response) = response {
-                session_debug!(self, "write(), success");
-                process_service_result(&response.response_header)?;
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "write() failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(Write::new(self)
+            .nodes_to_write(nodes_to_write.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Updates historical values. The caller is expected to provide one or more history update operations
@@ -245,33 +601,11 @@ impl Session {
         &self,
         history_update_details: &[HistoryUpdateAction],
     ) -> Result<Vec<HistoryUpdateResult>, StatusCode> {
-        if history_update_details.is_empty() {
-            // No subscriptions
-            session_error!(
-                self,
-                "history_update(), was not supplied with any detail to update"
-            );
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            // Turn the enums into ExtensionObjects
-            let history_update_details = history_update_details
-                .iter()
-                .map(ExtensionObject::from)
-                .collect::<Vec<ExtensionObject>>();
-
-            let request = HistoryUpdateRequest {
-                request_header: self.make_request_header(),
-                history_update_details: Some(history_update_details.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::HistoryUpdate(response) = response {
-                session_debug!(self, "history_update(), success");
-                process_service_result(&response.response_header)?;
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "history_update() failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(HistoryUpdate::new(self)
+            .details(history_update_details.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 }

--- a/opcua-client/src/session/services/node_management.rs
+++ b/opcua-client/src/session/services/node_management.rs
@@ -1,13 +1,319 @@
+use std::time::Duration;
+
 use crate::{
-    session::{process_service_result, process_unexpected_response, session_error},
-    Session,
+    session::{
+        process_service_result, process_unexpected_response,
+        request_builder::{builder_base, builder_debug, builder_error, RequestHeaderBuilder},
+    },
+    Session, UARequest,
 };
 
 use opcua_core::ResponseMessage;
 use opcua_types::{
-    AddNodesItem, AddNodesRequest, AddNodesResult, AddReferencesItem, AddReferencesRequest,
-    DeleteNodesItem, DeleteNodesRequest, DeleteReferencesItem, DeleteReferencesRequest, StatusCode,
+    AddNodesItem, AddNodesRequest, AddNodesResponse, AddNodesResult, AddReferencesItem,
+    AddReferencesRequest, AddReferencesResponse, DeleteNodesItem, DeleteNodesRequest,
+    DeleteNodesResponse, DeleteReferencesItem, DeleteReferencesRequest, DeleteReferencesResponse,
+    IntegerId, NodeId, StatusCode,
 };
+
+#[derive(Debug, Clone)]
+pub struct AddNodes {
+    nodes_to_add: Vec<AddNodesItem>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(AddNodes);
+
+/// Add nodes by sending a [`AddNodesRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.7.2 for complete description of the service and error responses.
+impl AddNodes {
+    /// Construct a new call to the `AddNodes` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            nodes_to_add: Vec::new(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `AddNodes` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            nodes_to_add: Vec::new(),
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set nodes to add, overwriting any that were set previously.
+    pub fn nodes_to_add(mut self, nodes_to_add: Vec<AddNodesItem>) -> Self {
+        self.nodes_to_add = nodes_to_add;
+        self
+    }
+
+    /// Add a node to create.
+    pub fn node(mut self, node: impl Into<AddNodesItem>) -> Self {
+        self.nodes_to_add.push(node.into());
+        self
+    }
+}
+
+impl UARequest for AddNodes {
+    type Out = AddNodesResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.nodes_to_add.is_empty() {
+            builder_error!(self, "add_nodes, called with no nodes to add");
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = AddNodesRequest {
+            request_header: self.header.header,
+            nodes_to_add: Some(self.nodes_to_add),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::AddNodes(response) = response {
+            builder_debug!(self, "add_nodes, success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "add_nodes failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Add references by sending a [`AddReferencesRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.7.3 for complete description of the service and error responses.
+pub struct AddReferences {
+    references_to_add: Vec<AddReferencesItem>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(AddReferences);
+
+impl AddReferences {
+    /// Construct a new call to the `AddReferences` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            references_to_add: Vec::new(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `AddReferences` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            references_to_add: Vec::new(),
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set references to add, overwriting any that were set previously.
+    pub fn references_to_add(mut self, references_to_add: Vec<AddReferencesItem>) -> Self {
+        self.references_to_add = references_to_add;
+        self
+    }
+
+    /// Add a reference to create.
+    pub fn reference(mut self, reference: impl Into<AddReferencesItem>) -> Self {
+        self.references_to_add.push(reference.into());
+        self
+    }
+}
+
+impl UARequest for AddReferences {
+    type Out = AddReferencesResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.references_to_add.is_empty() {
+            builder_error!(self, "add_references, called with no references to add");
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = AddReferencesRequest {
+            request_header: self.header.header,
+            references_to_add: Some(self.references_to_add),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::AddReferences(response) = response {
+            builder_debug!(self, "add_references, success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "add_references failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Delete nodes by sending a [`DeleteNodesRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.7.4 for complete description of the service and error responses.
+pub struct DeleteNodes {
+    nodes_to_delete: Vec<DeleteNodesItem>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(DeleteNodes);
+
+impl DeleteNodes {
+    /// Construct a new call to the `DeleteNodes` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            nodes_to_delete: Vec::new(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `DeleteNodes` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            nodes_to_delete: Vec::new(),
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set nodes to delete, overwriting any that were set previously.
+    pub fn nodes_to_delete(mut self, nodes_to_delete: Vec<DeleteNodesItem>) -> Self {
+        self.nodes_to_delete = nodes_to_delete;
+        self
+    }
+
+    /// Add a node to delete.
+    pub fn node(mut self, reference: impl Into<DeleteNodesItem>) -> Self {
+        self.nodes_to_delete.push(reference.into());
+        self
+    }
+}
+
+impl UARequest for DeleteNodes {
+    type Out = DeleteNodesResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.nodes_to_delete.is_empty() {
+            builder_error!(self, "delete_nodes, called with no nodes to delete");
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = DeleteNodesRequest {
+            request_header: self.header.header,
+            nodes_to_delete: Some(self.nodes_to_delete),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::DeleteNodes(response) = response {
+            builder_debug!(self, "delete_nodes, success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "delete_nodes failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Delete references by sending a [`DeleteReferencesRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.7.5 for complete description of the service and error responses.
+pub struct DeleteReferences {
+    references_to_delete: Vec<DeleteReferencesItem>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(DeleteReferences);
+
+impl DeleteReferences {
+    /// Construct a new call to the `DeleteReferences` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            references_to_delete: Vec::new(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `DeleteReferences` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            references_to_delete: Vec::new(),
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set nodes to delete, overwriting any that were set previously.
+    pub fn references_to_delete(mut self, references_to_delete: Vec<DeleteReferencesItem>) -> Self {
+        self.references_to_delete = references_to_delete;
+        self
+    }
+
+    /// Add a reference to delete.
+    pub fn reference(mut self, reference: impl Into<DeleteReferencesItem>) -> Self {
+        self.references_to_delete.push(reference.into());
+        self
+    }
+}
+
+impl UARequest for DeleteReferences {
+    type Out = DeleteReferencesResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.references_to_delete.is_empty() {
+            builder_error!(
+                self,
+                "delete_references, called with no references to delete"
+            );
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = DeleteReferencesRequest {
+            request_header: self.header.header,
+            references_to_delete: Some(self.references_to_delete),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::DeleteReferences(response) = response {
+            builder_debug!(self, "delete_references, success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "delete_references failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
 
 impl Session {
     /// Add nodes by sending a [`AddNodesRequest`] to the server.
@@ -27,21 +333,12 @@ impl Session {
         &self,
         nodes_to_add: &[AddNodesItem],
     ) -> Result<Vec<AddNodesResult>, StatusCode> {
-        if nodes_to_add.is_empty() {
-            session_error!(self, "add_nodes, called with no nodes to add");
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = AddNodesRequest {
-                request_header: self.make_request_header(),
-                nodes_to_add: Some(nodes_to_add.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::AddNodes(response) = response {
-                Ok(response.results.unwrap())
-            } else {
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(AddNodes::new(self)
+            .nodes_to_add(nodes_to_add.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Add references by sending a [`AddReferencesRequest`] to the server.
@@ -61,22 +358,12 @@ impl Session {
         &self,
         references_to_add: &[AddReferencesItem],
     ) -> Result<Vec<StatusCode>, StatusCode> {
-        if references_to_add.is_empty() {
-            session_error!(self, "add_references, called with no references to add");
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = AddReferencesRequest {
-                request_header: self.make_request_header(),
-                references_to_add: Some(references_to_add.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::AddReferences(response) = response {
-                process_service_result(&response.response_header)?;
-                Ok(response.results.unwrap())
-            } else {
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(AddReferences::new(self)
+            .references_to_add(references_to_add.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Delete nodes by sending a [`DeleteNodesRequest`] to the server.
@@ -96,21 +383,12 @@ impl Session {
         &self,
         nodes_to_delete: &[DeleteNodesItem],
     ) -> Result<Vec<StatusCode>, StatusCode> {
-        if nodes_to_delete.is_empty() {
-            session_error!(self, "delete_nodes, called with no nodes to delete");
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = DeleteNodesRequest {
-                request_header: self.make_request_header(),
-                nodes_to_delete: Some(nodes_to_delete.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::DeleteNodes(response) = response {
-                Ok(response.results.unwrap())
-            } else {
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(DeleteNodes::new(self)
+            .nodes_to_delete(nodes_to_delete.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Delete references by sending a [`DeleteReferencesRequest`] to the server.
@@ -130,23 +408,11 @@ impl Session {
         &self,
         references_to_delete: &[DeleteReferencesItem],
     ) -> Result<Vec<StatusCode>, StatusCode> {
-        if references_to_delete.is_empty() {
-            session_error!(
-                self,
-                "delete_references, called with no references to delete"
-            );
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = DeleteReferencesRequest {
-                request_header: self.make_request_header(),
-                references_to_delete: Some(references_to_delete.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::DeleteReferences(response) = response {
-                Ok(response.results.unwrap())
-            } else {
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(DeleteReferences::new(self)
+            .references_to_delete(references_to_delete.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 }

--- a/opcua-client/src/session/services/session.rs
+++ b/opcua-client/src/session/services/session.rs
@@ -627,8 +627,11 @@ impl Session {
     /// Close the session by sending a [`CloseSessionRequest`] to the server.
     ///
     /// This is not accessible by users, they must instead call `disconnect` to properly close the session.
-    pub(crate) async fn close_session(&self) -> Result<(), StatusCode> {
-        CloseSession::new(self).send(&self.channel).await?;
+    pub(crate) async fn close_session(&self, delete_subscriptions: bool) -> Result<(), StatusCode> {
+        CloseSession::new(self)
+            .delete_subscriptions(delete_subscriptions)
+            .send(&self.channel)
+            .await?;
         Ok(())
     }
 

--- a/opcua-client/src/session/services/session.rs
+++ b/opcua-client/src/session/services/session.rs
@@ -1,24 +1,527 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use log::error;
 use opcua_core::{
     comms::{secure_channel::SecureChannel, url::hostname_from_url},
+    sync::RwLock,
     trace_read_lock, trace_write_lock, ResponseMessage,
 };
 use opcua_crypto::{
-    self, certificate_store::CertificateStore, user_identity::make_user_name_identity_token,
+    self, certificate_store::CertificateStore, user_identity::make_user_name_identity_token, PKey,
     SecurityPolicy,
 };
 use opcua_types::{
-    ActivateSessionRequest, AnonymousIdentityToken, ByteString, CancelRequest, CloseSessionRequest,
-    CreateSessionRequest, ExtensionObject, IntegerId, NodeId, ObjectId, SignatureData, StatusCode,
-    UAString, UserNameIdentityToken, UserTokenPolicy, UserTokenType, X509IdentityToken,
+    ActivateSessionRequest, ActivateSessionResponse, AnonymousIdentityToken,
+    ApplicationDescription, ByteString, CancelRequest, CancelResponse, CloseSessionRequest,
+    CloseSessionResponse, CreateSessionRequest, CreateSessionResponse, EndpointDescription,
+    ExtensionObject, IntegerId, NodeId, SignatureData, SignedSoftwareCertificate, StatusCode,
+    UAString, UserTokenType, X509IdentityToken,
 };
+use rsa::RsaPrivateKey;
 
 use crate::{
-    session::{process_service_result, process_unexpected_response},
-    IdentityToken, Session,
+    session::{
+        process_service_result, process_unexpected_response,
+        request_builder::{builder_base, builder_error, RequestHeaderBuilder},
+    },
+    AsyncSecureChannel, IdentityToken, Session, UARequest,
 };
+
+#[derive(Debug, Clone)]
+pub struct CreateSession {
+    client_description: ApplicationDescription,
+    server_uri: UAString,
+    endpoint_url: UAString,
+    session_name: UAString,
+    client_certificate: ByteString,
+    session_timeout: f64,
+    max_response_message_size: u32,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(CreateSession);
+
+impl CreateSession {
+    pub fn new(session: &Session) -> Self {
+        Self {
+            endpoint_url: session.session_info.endpoint.endpoint_url.clone(),
+            server_uri: UAString::null(),
+            client_description: session.application_description.clone(),
+            session_name: session.session_name.clone(),
+            client_certificate: {
+                let cert_store = trace_read_lock!(session.certificate_store);
+                cert_store
+                    .read_own_cert()
+                    .ok()
+                    .map(|m| m.as_byte_string())
+                    .unwrap_or_default()
+            },
+            session_timeout: session.session_timeout,
+            max_response_message_size: 0,
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            endpoint_url: UAString::null(),
+            server_uri: UAString::null(),
+            client_description: ApplicationDescription::default(),
+            session_name: UAString::null(),
+            client_certificate: ByteString::null(),
+            session_timeout: 0.0,
+            max_response_message_size: 0,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    pub fn client_description(mut self, desc: impl Into<ApplicationDescription>) -> Self {
+        self.client_description = desc.into();
+        self
+    }
+
+    pub fn server_uri(mut self, server_uri: impl Into<UAString>) -> Self {
+        self.server_uri = server_uri.into();
+        self
+    }
+
+    pub fn endpoint_url(mut self, endpoint_url: impl Into<UAString>) -> Self {
+        self.endpoint_url = endpoint_url.into();
+        self
+    }
+
+    pub fn session_name(mut self, session_name: impl Into<UAString>) -> Self {
+        self.session_name = session_name.into();
+        self
+    }
+
+    pub fn client_certificate(mut self, client_certificate: ByteString) -> Self {
+        self.client_certificate = client_certificate;
+        self
+    }
+
+    pub fn client_cert_from_store(mut self, certificate_store: &RwLock<CertificateStore>) -> Self {
+        let cert_store = trace_read_lock!(certificate_store);
+        self.client_certificate = cert_store
+            .read_own_cert()
+            .ok()
+            .map(|m| m.as_byte_string())
+            .unwrap_or_default();
+        self
+    }
+
+    pub fn session_timeout(mut self, session_timeout: f64) -> Self {
+        self.session_timeout = session_timeout;
+        self
+    }
+
+    pub fn max_response_message_size(mut self, max_response_message_size: u32) -> Self {
+        self.max_response_message_size = max_response_message_size;
+        self
+    }
+}
+
+impl UARequest for CreateSession {
+    type Out = CreateSessionResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        let request = CreateSessionRequest {
+            request_header: self.header.header,
+            client_description: self.client_description,
+            server_uri: self.server_uri,
+            endpoint_url: self.endpoint_url,
+            session_name: self.session_name,
+            client_nonce: channel.client_nonce(),
+            client_certificate: self.client_certificate,
+            requested_session_timeout: self.session_timeout,
+            max_response_message_size: self.max_response_message_size,
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+
+        if let ResponseMessage::CreateSession(response) = response {
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ActivateSession {
+    identity_token: IdentityToken,
+    private_key: Option<PKey<RsaPrivateKey>>,
+    locale_ids: Vec<UAString>,
+    client_software_certificates: Vec<SignedSoftwareCertificate>,
+    endpoint: EndpointDescription,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(ActivateSession);
+
+impl ActivateSession {
+    pub fn new(session: &Session) -> Self {
+        Self {
+            identity_token: session.session_info.user_identity_token.clone(),
+            private_key: {
+                let cert_store = trace_read_lock!(session.certificate_store);
+                cert_store.read_own_pkey().ok()
+            },
+            locale_ids: session
+                .session_info
+                .preferred_locales
+                .iter()
+                .map(UAString::from)
+                .collect(),
+            client_software_certificates: Vec::new(),
+            endpoint: session.session_info.endpoint.clone(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    pub fn new_manual(
+        endpoint: EndpointDescription,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            identity_token: IdentityToken::Anonymous,
+            private_key: None,
+            locale_ids: Vec::new(),
+            client_software_certificates: Vec::new(),
+            endpoint,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    pub fn identity_token(mut self, identity_token: IdentityToken) -> Self {
+        self.identity_token = identity_token;
+        self
+    }
+
+    pub fn private_key(mut self, private_key: PKey<RsaPrivateKey>) -> Self {
+        self.private_key = Some(private_key);
+        self
+    }
+
+    pub fn locale_ids(mut self, locale_ids: Vec<UAString>) -> Self {
+        self.locale_ids = locale_ids;
+        self
+    }
+
+    pub fn locale_id(mut self, locale_id: impl Into<UAString>) -> Self {
+        self.locale_ids.push(locale_id.into());
+        self
+    }
+
+    pub fn client_software_certificates(
+        mut self,
+        certificates: Vec<SignedSoftwareCertificate>,
+    ) -> Self {
+        self.client_software_certificates = certificates;
+        self
+    }
+
+    pub fn client_software_certificate(mut self, certificate: SignedSoftwareCertificate) -> Self {
+        self.client_software_certificates.push(certificate);
+        self
+    }
+
+    fn user_identity_token(
+        &self,
+        secure_channel: &SecureChannel,
+    ) -> Result<(ExtensionObject, SignatureData), StatusCode> {
+        let user_token_type = match &self.identity_token {
+            IdentityToken::Anonymous => UserTokenType::Anonymous,
+            IdentityToken::UserName(_, _) => UserTokenType::UserName,
+            IdentityToken::X509(_, _) => UserTokenType::Certificate,
+        };
+        let Some(policy) = self.endpoint.find_policy(user_token_type) else {
+            builder_error!(
+                self,
+                "Cannot find user token type {:?} for this endpoint, cannot connect",
+                user_token_type
+            );
+            return Err(StatusCode::BadSecurityPolicyRejected);
+        };
+        let security_policy = if policy.security_policy_uri.is_null() {
+            // Assume None
+            SecurityPolicy::None
+        } else {
+            SecurityPolicy::from_uri(policy.security_policy_uri.as_ref())
+        };
+
+        if security_policy == SecurityPolicy::Unknown {
+            error!("Unknown security policy {}", policy.security_policy_uri);
+            return Err(StatusCode::BadSecurityPolicyRejected);
+        }
+
+        match &self.identity_token {
+            IdentityToken::Anonymous => {
+                let identity_token = AnonymousIdentityToken {
+                    policy_id: policy.policy_id.clone(),
+                };
+                let identity_token = ExtensionObject::from_message(&identity_token);
+                Ok((identity_token, SignatureData::null()))
+            }
+            IdentityToken::UserName(user, pass) => {
+                let channel_sec_policy = secure_channel.security_policy();
+                let nonce = secure_channel.remote_nonce();
+                let cert = secure_channel.remote_cert();
+                let identity_token = make_user_name_identity_token(
+                    channel_sec_policy,
+                    policy,
+                    nonce,
+                    &cert,
+                    user,
+                    pass,
+                )?;
+                Ok((
+                    ExtensionObject::from_message(&identity_token),
+                    SignatureData::null(),
+                ))
+            }
+            IdentityToken::X509(cert_path, private_key_path) => {
+                let nonce = secure_channel.remote_nonce();
+                let cert = secure_channel.remote_cert();
+                let Some(server_cert) = &cert else {
+                    error!("Cannot create an X509IdentityToken because the remote server has no cert with which to create a signature");
+                    return Err(StatusCode::BadCertificateInvalid);
+                };
+                let certificate_data = CertificateStore::read_cert(cert_path).map_err(|e| {
+                    error!(
+                        "Certificate cannot be loaded from path {}, error = {}",
+                        cert_path.to_str().unwrap(),
+                        e
+                    );
+                    StatusCode::BadSecurityPolicyRejected
+                })?;
+                let private_key = CertificateStore::read_pkey(private_key_path).map_err(|e| {
+                    error!(
+                        "Private key cannot be loaded from path {}, error = {}",
+                        private_key_path.to_str().unwrap(),
+                        e
+                    );
+                    StatusCode::BadSecurityPolicyRejected
+                })?;
+                let user_token_signature = opcua_crypto::create_signature_data(
+                    &private_key,
+                    security_policy,
+                    &server_cert.as_byte_string(),
+                    &ByteString::from(&nonce),
+                )?;
+
+                // Create identity token
+                let identity_token = X509IdentityToken {
+                    policy_id: policy.policy_id.clone(),
+                    certificate_data: certificate_data.as_byte_string(),
+                };
+
+                Ok((
+                    ExtensionObject::from_message(&identity_token),
+                    user_token_signature,
+                ))
+            }
+        }
+    }
+
+    fn build_request(
+        self,
+        channel: &AsyncSecureChannel,
+    ) -> Result<ActivateSessionRequest, StatusCode> {
+        let secure_channel = trace_read_lock!(channel.secure_channel);
+        let (user_identity_token, user_token_signature) =
+            self.user_identity_token(&secure_channel)?;
+        let security_policy = secure_channel.security_policy();
+        let client_signature = match security_policy {
+            SecurityPolicy::None => SignatureData::null(),
+            _ => {
+                let Some(client_pkey) = self.private_key else {
+                    error!("Cannot create client signature - no pkey!");
+                    return Err(StatusCode::BadUnexpectedError);
+                };
+
+                let Some(server_cert) = secure_channel.remote_cert() else {
+                    error!("Cannot sign server certificate because server cert is null");
+                    return Err(StatusCode::BadUnexpectedError);
+                };
+
+                let server_nonce = secure_channel.remote_nonce_as_byte_string();
+                if server_nonce.is_empty() {
+                    error!("Cannot sign server certificate because server nonce is empty");
+                    return Err(StatusCode::BadUnexpectedError);
+                }
+
+                let server_cert = server_cert.as_byte_string();
+                opcua_crypto::create_signature_data(
+                    &client_pkey,
+                    security_policy,
+                    &server_cert,
+                    &server_nonce,
+                )?
+            }
+        };
+
+        Ok(ActivateSessionRequest {
+            request_header: self.header.header,
+            client_signature,
+            client_software_certificates: if self.client_software_certificates.is_empty() {
+                None
+            } else {
+                Some(self.client_software_certificates)
+            },
+            locale_ids: if self.locale_ids.is_empty() {
+                None
+            } else {
+                Some(self.locale_ids)
+            },
+            user_identity_token,
+            user_token_signature,
+        })
+    }
+}
+
+impl UARequest for ActivateSession {
+    type Out = ActivateSessionResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        let timeout = self.header.timeout;
+        let request = self.build_request(channel)?;
+
+        let response = channel.send(request, timeout).await?;
+
+        if let ResponseMessage::ActivateSession(response) = response {
+            // trace!("ActivateSessionResponse = {:#?}", response);
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CloseSession {
+    delete_subscriptions: bool,
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(CloseSession);
+
+impl CloseSession {
+    pub fn new(session: &Session) -> Self {
+        Self {
+            delete_subscriptions: true,
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            delete_subscriptions: true,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    pub fn delete_subscriptions(mut self, delete_subscriptions: bool) -> Self {
+        self.delete_subscriptions = delete_subscriptions;
+        self
+    }
+}
+
+impl UARequest for CloseSession {
+    type Out = CloseSessionResponse;
+
+    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        let request = CloseSessionRequest {
+            delete_subscriptions: self.delete_subscriptions,
+            request_header: self.header.header,
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::CloseSession(response) = response {
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            error!("close_session failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Cancel {
+    request_handle: IntegerId,
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(Cancel);
+
+impl Cancel {
+    pub fn new(request_to_cancel: IntegerId, session: &Session) -> Self {
+        Self {
+            request_handle: request_to_cancel,
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    pub fn new_manual(
+        request_to_cancel: IntegerId,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            request_handle: request_to_cancel,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+}
+
+impl UARequest for Cancel {
+    type Out = CancelResponse;
+
+    async fn send<'a>(self, channel: &'a AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        let request = CancelRequest {
+            request_header: self.header.header,
+            request_handle: self.request_handle,
+        };
+
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::Cancel(response) = response {
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            Err(process_unexpected_response(response))
+        }
+    }
+}
 
 impl Session {
     /// Sends a [`CreateSessionRequest`] to the server, returning the session id of the created
@@ -33,81 +536,42 @@ impl Session {
     /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub(crate) async fn create_session(&self) -> Result<NodeId, StatusCode> {
-        let endpoint_url = self.session_info.endpoint.endpoint_url.clone();
+        let response = CreateSession::new(self).send(&self.channel).await?;
 
-        let client_nonce = self.channel.client_nonce();
-        let server_uri = UAString::null();
-        let session_name = self.session_name.clone();
+        let security_policy = self.channel.security_policy();
 
-        let (client_certificate, _) = {
-            let certificate_store = trace_write_lock!(self.certificate_store);
-            certificate_store.read_own_cert_and_pkey_optional()
-        };
+        if security_policy != SecurityPolicy::None {
+            if let Ok(server_certificate) =
+                opcua_crypto::X509::from_byte_string(&response.server_certificate)
+            {
+                // Validate server certificate against hostname and application_uri
+                let hostname = hostname_from_url(self.session_info.endpoint.endpoint_url.as_ref())
+                    .map_err(|_| StatusCode::BadUnexpectedError)?;
+                let application_uri = self.session_info.endpoint.server.application_uri.as_ref();
 
-        let client_certificate = if let Some(ref client_certificate) = client_certificate {
-            client_certificate.as_byte_string()
-        } else {
-            ByteString::null()
-        };
-
-        let request = CreateSessionRequest {
-            request_header: self.make_request_header(),
-            client_description: self.application_description.clone(),
-            server_uri,
-            endpoint_url,
-            session_name,
-            client_nonce,
-            client_certificate,
-            requested_session_timeout: self.session_timeout,
-            max_response_message_size: 0,
-        };
-
-        let response = self.send(request).await?;
-
-        if let ResponseMessage::CreateSession(response) = response {
-            process_service_result(&response.response_header)?;
-
-            let security_policy = self.channel.security_policy();
-
-            if security_policy != SecurityPolicy::None {
-                if let Ok(server_certificate) =
-                    opcua_crypto::X509::from_byte_string(&response.server_certificate)
-                {
-                    // Validate server certificate against hostname and application_uri
-                    let hostname =
-                        hostname_from_url(self.session_info.endpoint.endpoint_url.as_ref())
-                            .map_err(|_| StatusCode::BadUnexpectedError)?;
-                    let application_uri =
-                        self.session_info.endpoint.server.application_uri.as_ref();
-
-                    let certificate_store = trace_write_lock!(self.certificate_store);
-                    certificate_store.validate_or_reject_application_instance_cert(
-                        &server_certificate,
-                        security_policy,
-                        Some(&hostname),
-                        Some(application_uri),
-                    )?;
-                } else {
-                    return Err(StatusCode::BadCertificateInvalid);
-                }
+                let certificate_store = trace_write_lock!(self.certificate_store);
+                certificate_store.validate_or_reject_application_instance_cert(
+                    &server_certificate,
+                    security_policy,
+                    Some(&hostname),
+                    Some(application_uri),
+                )?;
+            } else {
+                return Err(StatusCode::BadCertificateInvalid);
             }
-
-            let session_id = {
-                self.session_id.store(Arc::new(response.session_id.clone()));
-                response.session_id.clone()
-            };
-            self.auth_token
-                .store(Arc::new(response.authentication_token));
-
-            self.channel.update_from_created_session(
-                &response.server_nonce,
-                &response.server_certificate,
-            )?;
-
-            Ok(session_id)
-        } else {
-            Err(process_unexpected_response(response))
         }
+
+        let session_id = {
+            self.session_id.store(Arc::new(response.session_id.clone()));
+            response.session_id.clone()
+        };
+        self.auth_token
+            .store(Arc::new(response.authentication_token));
+
+        self.channel
+            .update_from_created_session(&response.server_nonce, &response.server_certificate)?;
+
+        Ok(session_id)
     }
 
     /// Sends an [`ActivateSessionRequest`] to the server to activate this session
@@ -120,226 +584,16 @@ impl Session {
     /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub(crate) async fn activate_session(&self) -> Result<(), StatusCode> {
-        let (server_cert, server_nonce, user_identity_token, user_token_signature) = {
-            let secure_channel = trace_read_lock!(self.channel.secure_channel);
-
-            let (user_identity_token, user_token_signature) =
-                self.user_identity_token(&secure_channel)?;
-
-            (
-                secure_channel.remote_cert(),
-                secure_channel.remote_nonce_as_byte_string(),
-                user_identity_token,
-                user_token_signature,
-            )
-        };
-
-        let locale_ids = if self.session_info.preferred_locales.is_empty() {
-            None
-        } else {
-            let locale_ids = self
-                .session_info
-                .preferred_locales
-                .iter()
-                .map(UAString::from)
-                .collect();
-            Some(locale_ids)
-        };
-
-        let security_policy = self.channel.security_policy();
-        let client_signature = match security_policy {
-            SecurityPolicy::None => SignatureData::null(),
-            _ => {
-                let (_, client_pkey) = {
-                    let certificate_store = trace_write_lock!(self.certificate_store);
-                    certificate_store.read_own_cert_and_pkey_optional()
-                };
-
-                // Create a signature data
-                if client_pkey.is_none() {
-                    error!("Cannot create client signature - no pkey!");
-                    return Err(StatusCode::BadUnexpectedError);
-                } else if server_cert.is_none() {
-                    error!("Cannot sign server certificate because server cert is null");
-                    return Err(StatusCode::BadUnexpectedError);
-                } else if server_nonce.is_empty() {
-                    error!("Cannot sign server certificate because server nonce is empty");
-                    return Err(StatusCode::BadUnexpectedError);
-                }
-
-                let server_cert = server_cert.unwrap().as_byte_string();
-                let signing_key = client_pkey.as_ref().unwrap();
-                opcua_crypto::create_signature_data(
-                    signing_key,
-                    security_policy,
-                    &server_cert,
-                    &server_nonce,
-                )?
-            }
-        };
-
-        let request = ActivateSessionRequest {
-            request_header: self.make_request_header(),
-            client_signature,
-            client_software_certificates: None,
-            locale_ids,
-            user_identity_token,
-            user_token_signature,
-        };
-
-        let response = self.send(request).await?;
-
-        if let ResponseMessage::ActivateSession(response) = response {
-            // trace!("ActivateSessionResponse = {:#?}", response);
-            process_service_result(&response.response_header)?;
-            Ok(())
-        } else {
-            Err(process_unexpected_response(response))
-        }
-    }
-
-    /// Create a user identity token from config and the secure channel.
-    fn user_identity_token(
-        &self,
-        channel: &SecureChannel,
-    ) -> Result<(ExtensionObject, SignatureData), StatusCode> {
-        let server_cert = &channel.remote_cert();
-        let server_nonce = &channel.remote_nonce();
-
-        let user_identity_token = &self.session_info.user_identity_token;
-        let user_token_type = match user_identity_token {
-            IdentityToken::Anonymous => UserTokenType::Anonymous,
-            IdentityToken::UserName(_, _) => UserTokenType::UserName,
-            IdentityToken::X509(_, _) => UserTokenType::Certificate,
-        };
-
-        let endpoint = &self.session_info.endpoint;
-        let policy = endpoint.find_policy(user_token_type);
-
-        match policy {
-            None => {
-                error!(
-                    "Cannot find user token type {:?} for this endpoint, cannot connect",
-                    user_token_type
-                );
-                Err(StatusCode::BadSecurityPolicyRejected)
-            }
-            Some(policy) => {
-                let security_policy = if policy.security_policy_uri.is_null() {
-                    // Assume None
-                    SecurityPolicy::None
-                } else {
-                    SecurityPolicy::from_uri(policy.security_policy_uri.as_ref())
-                };
-
-                if security_policy == SecurityPolicy::Unknown {
-                    error!("Unknown security policy {}", policy.security_policy_uri);
-                    return Err(StatusCode::BadSecurityPolicyRejected);
-                }
-
-                match &user_identity_token {
-                    IdentityToken::Anonymous => {
-                        let identity_token = AnonymousIdentityToken {
-                            policy_id: policy.policy_id.clone(),
-                        };
-                        let identity_token = ExtensionObject::from_encodable(
-                            ObjectId::AnonymousIdentityToken_Encoding_DefaultBinary,
-                            &identity_token,
-                        );
-                        Ok((identity_token, SignatureData::null()))
-                    }
-                    IdentityToken::UserName(user, pass) => {
-                        let identity_token =
-                            self.make_user_name_identity_token(channel, policy, user, pass)?;
-                        let identity_token = ExtensionObject::from_encodable(
-                            ObjectId::UserNameIdentityToken_Encoding_DefaultBinary,
-                            &identity_token,
-                        );
-                        Ok((identity_token, SignatureData::null()))
-                    }
-                    IdentityToken::X509(cert_path, private_key_path) => {
-                        let Some(server_cert) = &server_cert else {
-                            error!("Cannot create an X509IdentityToken because the remote server has no cert with which to create a signature");
-                            return Err(StatusCode::BadCertificateInvalid);
-                        };
-                        let certificate_data =
-                            CertificateStore::read_cert(cert_path).map_err(|e| {
-                                error!(
-                                    "Certificate cannot be loaded from path {}, error = {}",
-                                    cert_path.to_str().unwrap(),
-                                    e
-                                );
-                                StatusCode::BadSecurityPolicyRejected
-                            })?;
-                        let private_key =
-                            CertificateStore::read_pkey(private_key_path).map_err(|e| {
-                                error!(
-                                    "Private key cannot be loaded from path {}, error = {}",
-                                    private_key_path.to_str().unwrap(),
-                                    e
-                                );
-                                StatusCode::BadSecurityPolicyRejected
-                            })?;
-                        let user_token_signature = opcua_crypto::create_signature_data(
-                            &private_key,
-                            security_policy,
-                            &server_cert.as_byte_string(),
-                            &ByteString::from(server_nonce),
-                        )?;
-
-                        // Create identity token
-                        let identity_token = X509IdentityToken {
-                            policy_id: policy.policy_id.clone(),
-                            certificate_data: certificate_data.as_byte_string(),
-                        };
-                        let identity_token = ExtensionObject::from_encodable(
-                            ObjectId::X509IdentityToken_Encoding_DefaultBinary,
-                            &identity_token,
-                        );
-
-                        Ok((identity_token, user_token_signature))
-                    }
-                }
-            }
-        }
-    }
-
-    /// Create a user name identity token.
-    fn make_user_name_identity_token(
-        &self,
-        secure_channel: &SecureChannel,
-        user_token_policy: &UserTokenPolicy,
-        user: &str,
-        pass: &str,
-    ) -> Result<UserNameIdentityToken, StatusCode> {
-        let channel_security_policy = secure_channel.security_policy();
-        let nonce = secure_channel.remote_nonce();
-        let cert = secure_channel.remote_cert();
-        make_user_name_identity_token(
-            channel_security_policy,
-            user_token_policy,
-            nonce,
-            &cert,
-            user,
-            pass,
-        )
+        ActivateSession::new(self).send(&self.channel).await?;
+        Ok(())
     }
 
     /// Close the session by sending a [`CloseSessionRequest`] to the server.
     ///
     /// This is not accessible by users, they must instead call `disconnect` to properly close the session.
     pub(crate) async fn close_session(&self) -> Result<(), StatusCode> {
-        let request = CloseSessionRequest {
-            delete_subscriptions: true,
-            request_header: self.make_request_header(),
-        };
-        let response = self.send(request).await?;
-        if let ResponseMessage::CloseSession(_) = response {
-            Ok(())
-        } else {
-            error!("close_session failed {:?}", response);
-            Err(process_unexpected_response(response))
-        }
+        CloseSession::new(self).send(&self.channel).await?;
+        Ok(())
     }
 
     /// Cancels an outstanding service request by sending a [`CancelRequest`] to the server.
@@ -356,16 +610,9 @@ impl Session {
     /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn cancel(&self, request_handle: IntegerId) -> Result<u32, StatusCode> {
-        let request = CancelRequest {
-            request_header: self.make_request_header(),
-            request_handle,
-        };
-        let response = self.send(request).await?;
-        if let ResponseMessage::Cancel(response) = response {
-            process_service_result(&response.response_header)?;
-            Ok(response.cancel_count)
-        } else {
-            Err(process_unexpected_response(response))
-        }
+        Ok(Cancel::new(request_handle, self)
+            .send(&self.channel)
+            .await?
+            .cancel_count)
     }
 }

--- a/opcua-client/src/session/services/subscriptions/mod.rs
+++ b/opcua-client/src/session/services/subscriptions/mod.rs
@@ -152,6 +152,8 @@ impl OnSubscriptionNotification for EventCallback {
     }
 }
 
+#[derive(Debug, Clone)]
+/// Client-side representation of a monitored item.
 pub struct MonitoredItem {
     /// This is the monitored item's id within the subscription
     id: u32,
@@ -244,6 +246,7 @@ impl MonitoredItem {
     }
 }
 
+/// Client-side representation of a subscription.
 pub struct Subscription {
     /// Subscription id, supplied by server
     subscription_id: u32,
@@ -327,6 +330,13 @@ impl Subscription {
         self.publishing_enabled
     }
 
+    pub fn insert_existing_monitored_item(&mut self, item: MonitoredItem) {
+        let client_handle = item.client_handle();
+        let monitored_item_id = item.id();
+        self.monitored_items.insert(monitored_item_id, item);
+        self.client_handles.insert(client_handle, monitored_item_id);
+    }
+
     pub(crate) fn set_publishing_interval(&mut self, publishing_interval: Duration) {
         self.publishing_interval = publishing_interval;
     }
@@ -365,11 +375,7 @@ impl Subscription {
                 filter: i.filter,
             };
 
-            let client_handle = monitored_item.client_handle();
-            let monitored_item_id = monitored_item.id();
-            self.monitored_items
-                .insert(monitored_item_id, monitored_item);
-            self.client_handles.insert(client_handle, monitored_item_id);
+            self.insert_existing_monitored_item(monitored_item);
         });
     }
 

--- a/opcua-client/src/session/services/subscriptions/mod.rs
+++ b/opcua-client/src/session/services/subscriptions/mod.rs
@@ -14,6 +14,12 @@ use opcua_types::{
     StatusChangeNotification, Variant,
 };
 
+pub use service::{
+    CreateMonitoredItems, CreateSubscription, DeleteMonitoredItems, DeleteSubscriptions,
+    ModifyMonitoredItems, ModifySubscription, SetMonitoringMode, SetPublishingMode, SetTriggering,
+    TransferSubscriptions,
+};
+
 pub(crate) struct CreateMonitoredItem {
     pub id: u32,
     pub client_handle: u32,

--- a/opcua-client/src/session/services/subscriptions/service.rs
+++ b/opcua-client/src/session/services/subscriptions/service.rs
@@ -6,26 +6,1411 @@ use std::{
 use crate::{
     session::{
         process_service_result, process_unexpected_response,
+        request_builder::{builder_base, builder_debug, builder_error, RequestHeaderBuilder},
         services::subscriptions::{CreateMonitoredItem, ModifyMonitoredItem, Subscription},
-        session_debug, session_error, session_trace, session_warn,
+        session_debug, session_error, session_warn,
     },
-    Session,
+    Session, UARequest,
 };
 use log::{debug, log_enabled};
-use opcua_core::{trace_lock, trace_read_lock, ResponseMessage};
+use opcua_core::{handle::AtomicHandle, sync::Mutex, trace_lock, trace_read_lock, ResponseMessage};
 use opcua_types::{
-    CreateMonitoredItemsRequest, CreateSubscriptionRequest, DeleteMonitoredItemsRequest,
-    DeleteSubscriptionsRequest, ModifyMonitoredItemsRequest, ModifySubscriptionRequest,
-    MonitoredItemCreateRequest, MonitoredItemCreateResult, MonitoredItemModifyRequest,
-    MonitoredItemModifyResult, MonitoringMode, MonitoringParameters, NotificationMessage,
-    PublishRequest, RepublishRequest, SetMonitoringModeRequest, SetPublishingModeRequest,
-    SetTriggeringRequest, StatusCode, TimestampsToReturn, TransferResult,
-    TransferSubscriptionsRequest,
+    AttributeId, CreateMonitoredItemsRequest, CreateMonitoredItemsResponse,
+    CreateSubscriptionRequest, CreateSubscriptionResponse, DeleteMonitoredItemsRequest,
+    DeleteMonitoredItemsResponse, DeleteSubscriptionsRequest, DeleteSubscriptionsResponse,
+    IntegerId, ModifyMonitoredItemsRequest, ModifyMonitoredItemsResponse,
+    ModifySubscriptionRequest, ModifySubscriptionResponse, MonitoredItemCreateRequest,
+    MonitoredItemCreateResult, MonitoredItemModifyRequest, MonitoredItemModifyResult,
+    MonitoringMode, MonitoringParameters, NodeId, NotificationMessage, PublishRequest, ReadValueId,
+    RepublishRequest, SetMonitoringModeRequest, SetMonitoringModeResponse,
+    SetPublishingModeRequest, SetPublishingModeResponse, SetTriggeringRequest,
+    SetTriggeringResponse, StatusCode, TimestampsToReturn, TransferResult,
+    TransferSubscriptionsRequest, TransferSubscriptionsResponse,
 };
 
-use super::OnSubscriptionNotification;
+use super::{state::SubscriptionState, OnSubscriptionNotification};
+
+/// Create a subscription by sending a [`CreateSubscriptionRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.13.2 for complete description of the service and error responses.
+pub struct CreateSubscription<'a> {
+    subscriptions: &'a Mutex<SubscriptionState>,
+    callback: Box<dyn OnSubscriptionNotification>,
+
+    publishing_interval: Duration,
+    lifetime_count: u32,
+    keep_alive_count: u32,
+    max_notifications_per_publish: u32,
+    publishing_enabled: bool,
+    priority: u8,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(CreateSubscription<'a>, <'a>);
+
+impl<'a> CreateSubscription<'a> {
+    /// Construct a new call to the `CreateSubscription` service.
+    pub fn new(session: &'a Session, callback: Box<dyn OnSubscriptionNotification>) -> Self {
+        Self {
+            publishing_interval: Duration::from_millis(500),
+            lifetime_count: 60,
+            keep_alive_count: 20,
+            max_notifications_per_publish: 0,
+            publishing_enabled: true,
+            priority: 0,
+            subscriptions: session.subscription_state(),
+            header: RequestHeaderBuilder::new_from_session(session),
+            callback,
+        }
+    }
+
+    /// Construct a new call to the `CreateSubscription` service, setting header parameters manually.
+    pub fn new_manual(
+        subscriptions: &'a Mutex<SubscriptionState>,
+        callback: Box<dyn OnSubscriptionNotification>,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            subscriptions,
+            callback,
+            publishing_interval: Duration::from_millis(500),
+            lifetime_count: 60,
+            keep_alive_count: 20,
+            max_notifications_per_publish: 0,
+            publishing_enabled: true,
+            priority: 0,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// The requested publishing interval defines the cyclic rate that
+    /// the Subscription is being requested to return Notifications to the Client. This interval
+    /// is expressed in milliseconds. This interval is represented by the publishing timer in the
+    /// Subscription state table. The negotiated value for this parameter returned in the
+    /// response is used as the default sampling interval for MonitoredItems assigned to this
+    /// Subscription. If the requested value is 0 or negative, the server shall revise with the
+    /// fastest supported publishing interval in milliseconds.
+    pub fn publishing_interval(mut self, interval: Duration) -> Self {
+        self.publishing_interval = interval;
+        self
+    }
+
+    /// Requested lifetime count. The lifetime count shall be a minimum of
+    /// three times the keep keep-alive count. When the publishing timer has expired this
+    /// number of times without a Publish request being available to send a NotificationMessage,
+    /// then the Subscription shall be deleted by the Server.
+    pub fn max_lifetime_count(mut self, lifetime_count: u32) -> Self {
+        self.lifetime_count = lifetime_count;
+        self
+    }
+
+    /// Requested maximum keep-alive count. When the publishing timer has
+    /// expired this number of times without requiring any NotificationMessage to be sent, the
+    /// Subscription sends a keep-alive Message to the Client. The negotiated value for this
+    /// parameter is returned in the response. If the requested value is 0, the server shall
+    /// revise with the smallest supported keep-alive count.
+    pub fn max_keep_alive_count(mut self, keep_alive_count: u32) -> Self {
+        self.keep_alive_count = keep_alive_count;
+        self
+    }
+
+    /// The maximum number of notifications that the Client
+    /// wishes to receive in a single Publish response. A value of zero indicates that there is
+    /// no limit. The number of notifications per Publish is the sum of monitoredItems in
+    /// the DataChangeNotification and events in the EventNotificationList.
+    pub fn max_notifications_per_publish(mut self, max_notifications_per_publish: u32) -> Self {
+        self.max_notifications_per_publish = max_notifications_per_publish;
+        self
+    }
+
+    /// Indicates the relative priority of the Subscription. When more than one
+    /// Subscription needs to send Notifications, the Server should de-queue a Publish request
+    /// to the Subscription with the highest priority number. For Subscriptions with equal
+    /// priority the Server should de-queue Publish requests in a round-robin fashion.
+    pub fn priority(mut self, priority: u8) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// A boolean parameter with the following values - `true` publishing
+    /// is enabled for the Subscription, `false`, publishing is disabled for the Subscription.
+    /// The value of this parameter does not affect the value of the monitoring mode Attribute of
+    /// MonitoredItems.
+    pub fn publishing_enabled(mut self, publishing_enabled: bool) -> Self {
+        self.publishing_enabled = publishing_enabled;
+        self
+    }
+}
+
+impl<'b> UARequest for CreateSubscription<'b> {
+    type Out = CreateSubscriptionResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        let request = CreateSubscriptionRequest {
+            request_header: self.header.header,
+            requested_publishing_interval: self.publishing_interval.as_millis() as f64,
+            requested_lifetime_count: self.lifetime_count,
+            requested_max_keep_alive_count: self.keep_alive_count,
+            max_notifications_per_publish: self.max_notifications_per_publish,
+            publishing_enabled: self.publishing_enabled,
+            priority: self.priority,
+        };
+
+        let response = channel.send(request, self.header.timeout).await?;
+
+        if let ResponseMessage::CreateSubscription(response) = response {
+            process_service_result(&response.response_header)?;
+            let subscription = Subscription::new(
+                response.subscription_id,
+                Duration::from_millis(response.revised_publishing_interval.max(0.0).floor() as u64),
+                response.revised_lifetime_count,
+                response.revised_max_keep_alive_count,
+                self.max_notifications_per_publish,
+                self.priority,
+                self.publishing_enabled,
+                self.callback,
+            );
+            {
+                let mut subscription_state = trace_lock!(self.subscriptions);
+                subscription_state.add_subscription(subscription);
+            }
+            builder_debug!(
+                self,
+                "create_subscription, created a subscription with id {}",
+                response.subscription_id
+            );
+            Ok(*response)
+        } else {
+            builder_error!(self, "create_subscription failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+/// Modifies a subscription by sending a [`ModifySubscriptionRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.13.3 for complete description of the service and error responses.
+#[derive(Clone)]
+pub struct ModifySubscription<'a> {
+    subscriptions: &'a Mutex<SubscriptionState>,
+    subscription_id: u32,
+    publishing_interval: Duration,
+    lifetime_count: u32,
+    keep_alive_count: u32,
+    max_notifications_per_publish: u32,
+    priority: u8,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(ModifySubscription<'a>, <'a>);
+
+impl<'a> ModifySubscription<'a> {
+    /// Construct a new call to the `ModifySubscription` service.
+    pub fn new(subscription_id: u32, session: &'a Session) -> Self {
+        Self {
+            subscription_id,
+            publishing_interval: Duration::from_millis(500),
+            lifetime_count: 60,
+            keep_alive_count: 20,
+            max_notifications_per_publish: 0,
+            priority: 0,
+            subscriptions: session.subscription_state(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `ModifySubscription` service, setting header parameters manually.
+    pub fn new_manual(
+        subscription_id: u32,
+        subscriptions: &'a Mutex<SubscriptionState>,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            subscription_id,
+            subscriptions,
+            publishing_interval: Duration::from_millis(500),
+            lifetime_count: 60,
+            keep_alive_count: 20,
+            max_notifications_per_publish: 0,
+            priority: 0,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// The requested publishing interval defines the cyclic rate that
+    /// the Subscription is being requested to return Notifications to the Client. This interval
+    /// is expressed in milliseconds. This interval is represented by the publishing timer in the
+    /// Subscription state table. The negotiated value for this parameter returned in the
+    /// response is used as the default sampling interval for MonitoredItems assigned to this
+    /// Subscription. If the requested value is 0 or negative, the server shall revise with the
+    /// fastest supported publishing interval in milliseconds.
+    pub fn publishing_interval(mut self, interval: Duration) -> Self {
+        self.publishing_interval = interval;
+        self
+    }
+
+    /// Requested lifetime count. The lifetime count shall be a minimum of
+    /// three times the keep keep-alive count. When the publishing timer has expired this
+    /// number of times without a Publish request being available to send a NotificationMessage,
+    /// then the Subscription shall be deleted by the Server.
+    pub fn max_lifetime_count(mut self, lifetime_count: u32) -> Self {
+        self.lifetime_count = lifetime_count;
+        self
+    }
+
+    /// Requested maximum keep-alive count. When the publishing timer has
+    /// expired this number of times without requiring any NotificationMessage to be sent, the
+    /// Subscription sends a keep-alive Message to the Client. The negotiated value for this
+    /// parameter is returned in the response. If the requested value is 0, the server shall
+    /// revise with the smallest supported keep-alive count.
+    pub fn max_keep_alive_count(mut self, keep_alive_count: u32) -> Self {
+        self.keep_alive_count = keep_alive_count;
+        self
+    }
+
+    /// The maximum number of notifications that the Client
+    /// wishes to receive in a single Publish response. A value of zero indicates that there is
+    /// no limit. The number of notifications per Publish is the sum of monitoredItems in
+    /// the DataChangeNotification and events in the EventNotificationList.
+    pub fn max_notifications_per_publish(mut self, max_notifications_per_publish: u32) -> Self {
+        self.max_notifications_per_publish = max_notifications_per_publish;
+        self
+    }
+
+    /// Indicates the relative priority of the Subscription. When more than one
+    /// Subscription needs to send Notifications, the Server should de-queue a Publish request
+    /// to the Subscription with the highest priority number. For Subscriptions with equal
+    /// priority the Server should de-queue Publish requests in a round-robin fashion.
+    pub fn priority(mut self, priority: u8) -> Self {
+        self.priority = priority;
+        self
+    }
+}
+
+impl<'b> UARequest for ModifySubscription<'b> {
+    type Out = ModifySubscriptionResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.subscription_id == 0 {
+            builder_error!(
+                self,
+                "modify_subscription, subscription id must be non-zero"
+            );
+            return Err(StatusCode::BadInvalidArgument);
+        }
+
+        let request = ModifySubscriptionRequest {
+            request_header: self.header.header,
+            subscription_id: self.subscription_id,
+            requested_publishing_interval: self.publishing_interval.as_millis() as f64,
+            requested_lifetime_count: self.lifetime_count,
+            requested_max_keep_alive_count: self.keep_alive_count,
+            max_notifications_per_publish: self.max_notifications_per_publish,
+            priority: self.priority,
+        };
+
+        let response = channel.send(request, self.header.timeout).await?;
+
+        if let ResponseMessage::ModifySubscription(response) = response {
+            process_service_result(&response.response_header)?;
+            let mut subscription_state = trace_lock!(self.subscriptions);
+            subscription_state.modify_subscription(
+                self.subscription_id,
+                Duration::from_millis(response.revised_publishing_interval.max(0.0).floor() as u64),
+                response.revised_lifetime_count,
+                response.revised_max_keep_alive_count,
+                self.max_notifications_per_publish,
+                self.priority,
+            );
+            builder_debug!(
+                self,
+                "modify_subscription success for {}",
+                self.subscription_id
+            );
+            Ok(*response)
+        } else {
+            builder_debug!(self, "modify_subscription failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+/// Changes the publishing mode of subscriptions by sending a [`SetPublishingModeRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.13.4 for complete description of the service and error responses.
+#[derive(Clone)]
+pub struct SetPublishingMode<'a> {
+    subscriptions: &'a Mutex<SubscriptionState>,
+    subscription_ids: Vec<u32>,
+    publishing_enabled: bool,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(SetPublishingMode<'a>, <'a>);
+
+impl<'a> SetPublishingMode<'a> {
+    /// Construct a new call to the `SetPublishingMode` service.
+    pub fn new(publishing_enabled: bool, session: &'a Session) -> Self {
+        Self {
+            subscription_ids: Vec::new(),
+            publishing_enabled,
+            subscriptions: session.subscription_state(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `SetPublishingMode` service, setting header parameters manually.
+    pub fn new_manual(
+        publishing_enabled: bool,
+        subscriptions: &'a Mutex<SubscriptionState>,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            subscription_ids: Vec::new(),
+            publishing_enabled,
+            subscriptions,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set the subscription IDs to update, overwriting any that were added previously.
+    pub fn subscription_ids(mut self, subscription_ids: Vec<u32>) -> Self {
+        self.subscription_ids = subscription_ids;
+        self
+    }
+
+    /// Add a subscription ID to update.
+    pub fn subscription(mut self, subscription_id: u32) -> Self {
+        self.subscription_ids.push(subscription_id);
+        self
+    }
+}
+
+impl<'b> UARequest for SetPublishingMode<'b> {
+    type Out = SetPublishingModeResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        builder_debug!(
+            self,
+            "set_publishing_mode, for subscriptions {:?}, publishing enabled {}",
+            self.subscription_ids,
+            self.publishing_enabled
+        );
+        if self.subscription_ids.is_empty() {
+            builder_error!(
+                self,
+                "set_publishing_mode, no subscription ids were provided"
+            );
+            return Err(StatusCode::BadNothingToDo);
+        }
+
+        let request = SetPublishingModeRequest {
+            request_header: self.header.header,
+            publishing_enabled: self.publishing_enabled,
+            subscription_ids: Some(self.subscription_ids.clone()),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::SetPublishingMode(response) = response {
+            process_service_result(&response.response_header)?;
+            let num_results = response
+                .results
+                .as_ref()
+                .map(|l| l.len())
+                .unwrap_or_default();
+
+            if num_results != self.subscription_ids.len() {
+                builder_error!(
+                    self,
+                    "set_publishing_mode returned an incorrect number of results. Expected {}, got {}",
+                    self.subscription_ids.len(),
+                    num_results
+                );
+                return Err(StatusCode::BadUnexpectedError);
+            }
+
+            {
+                // Update all subscriptions where the returned status is good.
+                let mut subscription_state = trace_lock!(self.subscriptions);
+                let ids = self
+                    .subscription_ids
+                    .iter()
+                    .zip(response.results.iter().flat_map(|f| f.iter()))
+                    .filter(|(_, s)| s.is_good())
+                    .map(|(v, _)| *v)
+                    .collect::<Vec<_>>();
+                subscription_state.set_publishing_mode(&ids, self.publishing_enabled);
+            }
+            builder_debug!(self, "set_publishing_mode success");
+            Ok(*response)
+        } else {
+            builder_error!(self, "set_publishing_mode failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Clone)]
+/// Transfers Subscriptions and their MonitoredItems from one Session to another. For example,
+/// a Client may need to reopen a Session and then transfer its Subscriptions to that Session.
+/// It may also be used by one Client to take over a Subscription from another Client by
+/// transferring the Subscription to its Session.
+///
+/// Note that if you call this manually, you will need to register the
+/// subscriptions in the subscription state ([`Session::subscription_state`]) in order to
+/// receive notifications.
+///
+/// See OPC UA Part 4 - Services 5.13.7 for complete description of the service and error responses.
+///
+pub struct TransferSubscriptions {
+    subscription_ids: Vec<u32>,
+    send_initial_values: bool,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(TransferSubscriptions);
+
+impl TransferSubscriptions {
+    /// Construct a new call to the `TransferSubscriptions` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            subscription_ids: Vec::new(),
+            send_initial_values: false,
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `TransferSubscriptions` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            subscription_ids: Vec::new(),
+            send_initial_values: false,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+    /// A boolean parameter with the following values - `true` the first
+    /// publish response shall contain the current values of all monitored items in the subscription,
+    /// `false`, the first publish response shall contain only the value changes since the last
+    /// publish response was sent.
+    pub fn send_initial_values(mut self, send_initial_values: bool) -> Self {
+        self.send_initial_values = send_initial_values;
+        self
+    }
+
+    /// Set the subscription IDs to transfer, overwriting any that were added previously.
+    pub fn subscription_ids(mut self, subscription_ids: Vec<u32>) -> Self {
+        self.subscription_ids = subscription_ids;
+        self
+    }
+
+    /// Add a subscription ID to transfer.
+    pub fn subscription(mut self, subscription_id: u32) -> Self {
+        self.subscription_ids.push(subscription_id);
+        self
+    }
+}
+
+impl UARequest for TransferSubscriptions {
+    type Out = TransferSubscriptionsResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.subscription_ids.is_empty() {
+            builder_error!(
+                self,
+                "transfer_subscriptions, no subscription ids were provided"
+            );
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = TransferSubscriptionsRequest {
+            request_header: self.header.header,
+            subscription_ids: Some(self.subscription_ids),
+            send_initial_values: self.send_initial_values,
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::TransferSubscriptions(response) = response {
+            process_service_result(&response.response_header)?;
+            builder_debug!(self, "transfer_subscriptions success");
+            Ok(*response)
+        } else {
+            builder_error!(self, "transfer_subscriptions failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Clone)]
+/// Deletes subscriptions by sending a [`DeleteSubscriptionsRequest`] to the server with the list
+/// of subscriptions to delete.
+///
+/// See OPC UA Part 4 - Services 5.13.8 for complete description of the service and error responses.
+pub struct DeleteSubscriptions<'a> {
+    subscription_ids: Vec<u32>,
+    subscriptions: &'a Mutex<SubscriptionState>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(DeleteSubscriptions<'a>, <'a>);
+
+impl<'a> DeleteSubscriptions<'a> {
+    /// Construct a new call to the `DeleteSubscriptions` service.
+    pub fn new(session: &'a Session) -> Self {
+        Self {
+            subscription_ids: Vec::new(),
+            subscriptions: session.subscription_state(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `DeleteSubscriptions` service, setting header parameters manually.
+    pub fn new_manual(
+        subscriptions: &'a Mutex<SubscriptionState>,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            subscription_ids: Vec::new(),
+            subscriptions,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set the subscription IDs to delete, overwriting any that were added previously.
+    pub fn subscription_ids(mut self, subscription_ids: Vec<u32>) -> Self {
+        self.subscription_ids = subscription_ids;
+        self
+    }
+
+    /// Add a subscription ID to delete.
+    pub fn subscription(mut self, subscription_id: u32) -> Self {
+        self.subscription_ids.push(subscription_id);
+        self
+    }
+}
+
+impl<'b> UARequest for DeleteSubscriptions<'b> {
+    type Out = DeleteSubscriptionsResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.subscription_ids.is_empty() {
+            builder_error!(self, "delete_subscriptions called with no subscription IDs");
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = DeleteSubscriptionsRequest {
+            request_header: self.header.header,
+            subscription_ids: Some(self.subscription_ids.clone()),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::DeleteSubscriptions(response) = response {
+            process_service_result(&response.response_header)?;
+            {
+                // Clear out deleted subscriptions, assuming the delete worked
+                let mut subscription_state = trace_lock!(self.subscriptions);
+                for id in self.subscription_ids {
+                    subscription_state.delete_subscription(id);
+                }
+            }
+            builder_debug!(self, "delete_subscriptions success");
+            Ok(*response)
+        } else {
+            builder_error!(self, "delete_subscriptions failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CreateMonitoredItems<'a> {
+    subscription_id: u32,
+    timestamps_to_return: TimestampsToReturn,
+    items_to_create: Vec<MonitoredItemCreateRequest>,
+    subscriptions: &'a Mutex<SubscriptionState>,
+    handle: &'a AtomicHandle,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(CreateMonitoredItems<'a>, <'a>);
+
+impl<'a> CreateMonitoredItems<'a> {
+    /// Construct a new call to the `CreateMonitoredItems` service.
+    pub fn new(subscription_id: u32, session: &'a Session) -> Self {
+        Self {
+            subscription_id,
+            timestamps_to_return: TimestampsToReturn::Neither,
+            items_to_create: Vec::new(),
+            subscriptions: session.subscription_state(),
+            handle: &session.monitored_item_handle,
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `CreateMonitoredItems` service, setting header parameters manually.
+    pub fn new_manual(
+        subscription_id: u32,
+        subscriptions: &'a Mutex<SubscriptionState>,
+        monitored_item_handle: &'a AtomicHandle,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            subscription_id,
+            timestamps_to_return: TimestampsToReturn::Neither,
+            items_to_create: Vec::new(),
+            subscriptions,
+            handle: monitored_item_handle,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// An enumeration that specifies the timestamp Attributes to be transmitted for each MonitoredItem.
+    pub fn timestamps_to_return(mut self, timestamps_to_return: TimestampsToReturn) -> Self {
+        self.timestamps_to_return = timestamps_to_return;
+        self
+    }
+
+    /// Set the monitored items to create, overwriting any that were added previously.
+    pub fn items_to_create(mut self, items_to_create: Vec<MonitoredItemCreateRequest>) -> Self {
+        self.items_to_create = items_to_create;
+        self
+    }
+
+    /// Add a monitored item to create.
+    pub fn item(mut self, item: MonitoredItemCreateRequest) -> Self {
+        self.items_to_create.push(item);
+        self
+    }
+
+    /// Add a monitored item to create, subscribing to values on `node_id` with the
+    /// given `sampling_interval` and `queue_size`.
+    pub fn value(mut self, node_id: NodeId, sampling_interval: f64, queue_size: u32) -> Self {
+        self.items_to_create.push(MonitoredItemCreateRequest {
+            item_to_monitor: ReadValueId {
+                node_id,
+                attribute_id: AttributeId::Value as u32,
+                ..Default::default()
+            },
+            monitoring_mode: MonitoringMode::Reporting,
+            requested_parameters: MonitoringParameters {
+                client_handle: self.handle.next(),
+                sampling_interval,
+                queue_size,
+                discard_oldest: true,
+                ..Default::default()
+            },
+        });
+        self
+    }
+}
+
+impl<'b> UARequest for CreateMonitoredItems<'b> {
+    type Out = CreateMonitoredItemsResponse;
+
+    async fn send<'a>(
+        mut self,
+        channel: &'a crate::AsyncSecureChannel,
+    ) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        builder_debug!(
+            self,
+            "create_monitored_items, for subscription {}, {} items",
+            self.subscription_id,
+            self.items_to_create.len()
+        );
+        if self.subscription_id == 0 {
+            builder_error!(self, "create_monitored_items, subscription id 0 is invalid");
+            return Err(StatusCode::BadSubscriptionIdInvalid);
+        }
+        {
+            let state = trace_lock!(self.subscriptions);
+            if !state.subscription_exists(self.subscription_id) {
+                builder_error!(
+                    self,
+                    "create_monitored_items, subscription id {} does not exist",
+                    self.subscription_id
+                );
+                return Err(StatusCode::BadSubscriptionIdInvalid);
+            }
+        }
+        if self.items_to_create.is_empty() {
+            builder_error!(
+                self,
+                "create_monitored_items, called with no items to create"
+            );
+            return Err(StatusCode::BadNothingToDo);
+        }
+        for item in &mut self.items_to_create {
+            if item.requested_parameters.client_handle == 0 {
+                item.requested_parameters.client_handle = self.handle.next();
+            }
+        }
+
+        let request = CreateMonitoredItemsRequest {
+            request_header: self.header.header,
+            subscription_id: self.subscription_id,
+            timestamps_to_return: self.timestamps_to_return,
+            items_to_create: Some(self.items_to_create.clone()),
+        };
+
+        let response = channel.send(request, self.header.timeout).await?;
+
+        if let ResponseMessage::CreateMonitoredItems(response) = response {
+            process_service_result(&response.response_header)?;
+            if let Some(ref results) = response.results {
+                if results.len() != self.items_to_create.len() {
+                    builder_error!(
+                        self,
+                        "create_monitored_items, unexpected number of results. Got {}, expected {}",
+                        results.len(),
+                        self.items_to_create.len()
+                    );
+                    return Err(StatusCode::BadUnexpectedError);
+                }
+                builder_debug!(
+                    self,
+                    "create_monitored_items, {} items created",
+                    self.items_to_create.len()
+                );
+                // Set the items in our internal state
+                let items_to_create = self
+                    .items_to_create
+                    .into_iter()
+                    .zip(results)
+                    .map(|(i, r)| CreateMonitoredItem {
+                        id: r.monitored_item_id,
+                        client_handle: i.requested_parameters.client_handle,
+                        discard_oldest: i.requested_parameters.discard_oldest,
+                        item_to_monitor: i.item_to_monitor.clone(),
+                        monitoring_mode: i.monitoring_mode,
+                        queue_size: r.revised_queue_size,
+                        sampling_interval: r.revised_sampling_interval,
+                        filter: i.requested_parameters.filter,
+                    })
+                    .collect::<Vec<CreateMonitoredItem>>();
+                {
+                    let mut subscription_state = trace_lock!(self.subscriptions);
+                    subscription_state
+                        .insert_monitored_items(self.subscription_id, items_to_create);
+                }
+            } else {
+                builder_error!(
+                    self,
+                    "create_monitored_items, success but no monitored items were created"
+                );
+                return Err(StatusCode::BadUnexpectedError);
+            }
+            Ok(*response)
+        } else {
+            builder_error!(self, "create_monitored_items failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+pub struct ModifyMonitoredItems<'a> {
+    subscription_id: u32,
+    timestamps_to_return: TimestampsToReturn,
+    items_to_modify: Vec<MonitoredItemModifyRequest>,
+    subscriptions: &'a Mutex<SubscriptionState>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(ModifyMonitoredItems<'a>, <'a>);
+
+impl<'a> ModifyMonitoredItems<'a> {
+    /// Construct a new call to the `ModifyMonitoredItems` service.
+    pub fn new(subscription_id: u32, session: &'a Session) -> Self {
+        Self {
+            subscription_id,
+            timestamps_to_return: TimestampsToReturn::Neither,
+            items_to_modify: Vec::new(),
+            subscriptions: session.subscription_state(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `ModifyMonitoredItems` service, setting header parameters manually.
+    pub fn new_manual(
+        subscription_id: u32,
+        subscriptions: &'a Mutex<SubscriptionState>,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            subscription_id,
+            timestamps_to_return: TimestampsToReturn::Neither,
+            items_to_modify: Vec::new(),
+            subscriptions,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// An enumeration that specifies the timestamp Attributes to be transmitted for each MonitoredItem.
+    pub fn timestamps_to_return(mut self, timestamps_to_return: TimestampsToReturn) -> Self {
+        self.timestamps_to_return = timestamps_to_return;
+        self
+    }
+
+    /// Set the monitored items to modify, overwriting any that were added previously.
+    pub fn items_to_modify(mut self, items_to_modify: Vec<MonitoredItemModifyRequest>) -> Self {
+        self.items_to_modify = items_to_modify;
+        self
+    }
+
+    /// Add a monitored item to modify.
+    pub fn item(mut self, item: MonitoredItemModifyRequest) -> Self {
+        self.items_to_modify.push(item);
+        self
+    }
+}
+
+impl<'b> UARequest for ModifyMonitoredItems<'b> {
+    type Out = ModifyMonitoredItemsResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        builder_debug!(
+            self,
+            "modify_monitored_items, for subscription {}, {} items",
+            self.subscription_id,
+            self.items_to_modify.len()
+        );
+        if self.subscription_id == 0 {
+            builder_error!(self, "modify_monitored_items, subscription id 0 is invalid");
+            return Err(StatusCode::BadInvalidArgument);
+        }
+        {
+            let state = trace_lock!(self.subscriptions);
+            if !state.subscription_exists(self.subscription_id) {
+                builder_error!(
+                    self,
+                    "modify_monitored_items, subscription id {} does not exist",
+                    self.subscription_id
+                );
+                return Err(StatusCode::BadSubscriptionIdInvalid);
+            }
+        }
+        if self.items_to_modify.is_empty() {
+            builder_error!(
+                self,
+                "modify_monitored_items, called with no items to modify"
+            );
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let ids = self
+            .items_to_modify
+            .iter()
+            .map(|i| i.monitored_item_id)
+            .collect::<Vec<_>>();
+        let request = ModifyMonitoredItemsRequest {
+            request_header: self.header.header,
+            subscription_id: self.subscription_id,
+            timestamps_to_return: self.timestamps_to_return,
+            items_to_modify: Some(self.items_to_modify),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::ModifyMonitoredItems(response) = response {
+            process_service_result(&response.response_header)?;
+            let Some(results) = &response.results else {
+                builder_error!(self, "modify_monitored_items, got empty response");
+                return Err(StatusCode::BadUnexpectedError);
+            };
+            if results.len() != ids.len() {
+                builder_error!(
+                    self,
+                    "modify_monitored_items, unexpected number of results. Expected {}, got {}",
+                    ids.len(),
+                    results.len()
+                );
+                return Err(StatusCode::BadUnexpectedError);
+            }
+            let items_to_modify = ids
+                .iter()
+                .zip(results.iter())
+                .map(|(id, r)| ModifyMonitoredItem {
+                    id: *id,
+                    queue_size: r.revised_queue_size,
+                    sampling_interval: r.revised_sampling_interval,
+                })
+                .collect::<Vec<ModifyMonitoredItem>>();
+            {
+                let mut subscription_state = trace_lock!(self.subscriptions);
+                subscription_state.modify_monitored_items(self.subscription_id, &items_to_modify);
+            }
+            builder_debug!(self, "modify_monitored_items, success");
+            Ok(*response)
+        } else {
+            builder_error!(self, "modify_monitored_items failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+pub struct SetMonitoringMode<'a> {
+    subscription_id: u32,
+    monitoring_mode: MonitoringMode,
+    monitored_item_ids: Vec<u32>,
+    subscriptions: &'a Mutex<SubscriptionState>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(SetMonitoringMode<'a>, <'a>);
+
+impl<'a> SetMonitoringMode<'a> {
+    /// Construct a new call to the `SetMonitoringMode` service.
+    pub fn new(
+        subscription_id: u32,
+        monitoring_mode: MonitoringMode,
+        session: &'a Session,
+    ) -> Self {
+        Self {
+            subscription_id,
+            monitored_item_ids: Vec::new(),
+            monitoring_mode,
+            subscriptions: session.subscription_state(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `SetMonitoringMode` service, setting header parameters manually.
+    pub fn new_manual(
+        subscription_id: u32,
+        monitoring_mode: MonitoringMode,
+        subscriptions: &'a Mutex<SubscriptionState>,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            subscription_id,
+            monitored_item_ids: Vec::new(),
+            monitoring_mode,
+            subscriptions,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set the monitored items to modify, overwriting any that were added previously.
+    pub fn monitored_item_ids(mut self, monitored_item_ids: Vec<u32>) -> Self {
+        self.monitored_item_ids = monitored_item_ids;
+        self
+    }
+
+    /// Add a monitored item to modify.
+    pub fn item(mut self, item: u32) -> Self {
+        self.monitored_item_ids.push(item);
+        self
+    }
+}
+
+impl<'b> UARequest for SetMonitoringMode<'b> {
+    type Out = SetMonitoringModeResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        builder_debug!(
+            self,
+            "set_monitoring_mode, for subscription {}, {} items",
+            self.subscription_id,
+            self.monitored_item_ids.len()
+        );
+        if self.subscription_id == 0 {
+            builder_error!(self, "set_monitoring_mode, subscription id 0 is invalid");
+            return Err(StatusCode::BadInvalidArgument);
+        }
+        {
+            let state = trace_lock!(self.subscriptions);
+            if !state.subscription_exists(self.subscription_id) {
+                builder_error!(
+                    self,
+                    "set_monitoring_mode, subscription id {} does not exist",
+                    self.subscription_id
+                );
+                return Err(StatusCode::BadSubscriptionIdInvalid);
+            }
+        }
+        if self.monitored_item_ids.is_empty() {
+            builder_error!(self, "set_monitoring_mode, called with no items to modify");
+            return Err(StatusCode::BadNothingToDo);
+        }
+
+        let request = SetMonitoringModeRequest {
+            request_header: self.header.header,
+            subscription_id: self.subscription_id,
+            monitoring_mode: self.monitoring_mode,
+            monitored_item_ids: Some(self.monitored_item_ids.clone()),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::SetMonitoringMode(response) = response {
+            let Some(results) = &response.results else {
+                builder_error!(self, "set_monitoring_mode, got empty response");
+                return Err(StatusCode::BadUnexpectedError);
+            };
+            if results.len() != self.monitored_item_ids.len() {
+                builder_error!(
+                    self,
+                    "set_monitoring_mode, unexpected number of results. Expected {}, got {}",
+                    self.monitored_item_ids.len(),
+                    results.len()
+                );
+                return Err(StatusCode::BadUnexpectedError);
+            }
+            let ok_ids: Vec<_> = self
+                .monitored_item_ids
+                .iter()
+                .zip(results.iter())
+                .filter(|(_, s)| s.is_good())
+                .map(|(v, _)| *v)
+                .collect();
+            {
+                let mut subscription_state = trace_lock!(self.subscriptions);
+                subscription_state.set_monitoring_mode(
+                    self.subscription_id,
+                    &ok_ids,
+                    self.monitoring_mode,
+                );
+            }
+
+            Ok(*response)
+        } else {
+            builder_error!(self, "set_monitoring_mode failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+pub struct SetTriggering<'a> {
+    subscription_id: u32,
+    triggering_item_id: u32,
+    links_to_add: Vec<u32>,
+    links_to_remove: Vec<u32>,
+    subscriptions: &'a Mutex<SubscriptionState>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(SetTriggering<'a>, <'a>);
+
+impl<'a> SetTriggering<'a> {
+    /// Construct a new call to the `SetTriggering` service.
+    pub fn new(subscription_id: u32, triggering_item_id: u32, session: &'a Session) -> Self {
+        Self {
+            subscription_id,
+            triggering_item_id,
+            links_to_add: Vec::new(),
+            links_to_remove: Vec::new(),
+            subscriptions: session.subscription_state(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `SetTriggering` service, setting header parameters manually.
+    pub fn new_manual(
+        subscription_id: u32,
+        triggering_item_id: u32,
+        subscriptions: &'a Mutex<SubscriptionState>,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            subscription_id,
+            triggering_item_id,
+            links_to_add: Vec::new(),
+            links_to_remove: Vec::new(),
+            subscriptions,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set the links to add, overwriting any that were added previously.
+    pub fn links_to_add(mut self, links_to_add: Vec<u32>) -> Self {
+        self.links_to_add = links_to_add;
+        self
+    }
+
+    /// Add a new trigger target.
+    pub fn add_link(mut self, item: u32) -> Self {
+        self.links_to_add.push(item);
+        self
+    }
+
+    /// Set the links to add, overwriting any that were added previously.
+    pub fn links_to_remove(mut self, links_to_remove: Vec<u32>) -> Self {
+        self.links_to_remove = links_to_remove;
+        self
+    }
+
+    /// Add a new trigger to remove.
+    pub fn remove_link(mut self, item: u32) -> Self {
+        self.links_to_remove.push(item);
+        self
+    }
+}
+
+impl<'b> UARequest for SetTriggering<'b> {
+    type Out = SetTriggeringResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        builder_debug!(
+            self,
+            "set_triggering, for subscription {}, {} links to add, {} links to remove",
+            self.subscription_id,
+            self.links_to_add.len(),
+            self.links_to_remove.len()
+        );
+        if self.subscription_id == 0 {
+            builder_error!(self, "set_triggering, subscription id 0 is invalid");
+            return Err(StatusCode::BadInvalidArgument);
+        }
+        {
+            let state = trace_lock!(self.subscriptions);
+            if !state.subscription_exists(self.subscription_id) {
+                builder_error!(
+                    self,
+                    "set_triggering, subscription id {} does not exist",
+                    self.subscription_id
+                );
+                return Err(StatusCode::BadSubscriptionIdInvalid);
+            }
+        }
+        if self.links_to_add.is_empty() && self.links_to_remove.is_empty() {
+            builder_error!(self, "set_triggering, called with nothing to add or remove");
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = SetTriggeringRequest {
+            request_header: self.header.header,
+            subscription_id: self.subscription_id,
+            triggering_item_id: self.triggering_item_id,
+            links_to_add: if self.links_to_add.is_empty() {
+                None
+            } else {
+                Some(self.links_to_add.clone())
+            },
+            links_to_remove: if self.links_to_remove.is_empty() {
+                None
+            } else {
+                Some(self.links_to_remove.clone())
+            },
+        };
+
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::SetTriggering(response) = response {
+            let to_add_res = response.add_results.as_deref().unwrap_or(&[]);
+            let to_remove_res = response.remove_results.as_deref().unwrap_or(&[]);
+            if to_add_res.len() != self.links_to_add.len() {
+                builder_error!(
+                    self,
+                    "set_triggering, got unexpected number of add results: {}, expected {}",
+                    to_add_res.len(),
+                    self.links_to_add.len()
+                );
+                return Err(StatusCode::BadUnexpectedError);
+            }
+            if to_remove_res.len() != self.links_to_remove.len() {
+                builder_error!(
+                    self,
+                    "set_triggering, got unexpected number of remove results: {}, expected {}",
+                    to_remove_res.len(),
+                    self.links_to_add.len()
+                );
+                return Err(StatusCode::BadUnexpectedError);
+            }
+            let ok_adds = to_add_res
+                .iter()
+                .zip(self.links_to_add)
+                .filter(|(s, _)| s.is_good())
+                .map(|(_, v)| v)
+                .collect::<Vec<_>>();
+            let ok_removes = to_remove_res
+                .iter()
+                .zip(self.links_to_remove)
+                .filter(|(s, _)| s.is_good())
+                .map(|(_, v)| v)
+                .collect::<Vec<_>>();
+
+            // Update client side state
+            let mut subscription_state = trace_lock!(self.subscriptions);
+            subscription_state.set_triggering(
+                self.subscription_id,
+                self.triggering_item_id,
+                &ok_adds,
+                &ok_removes,
+            );
+            Ok(*response)
+        } else {
+            builder_error!(self, "set_triggering failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+pub struct DeleteMonitoredItems<'a> {
+    subscription_id: u32,
+    items_to_delete: Vec<u32>,
+    subscriptions: &'a Mutex<SubscriptionState>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(DeleteMonitoredItems<'a>, <'a>);
+
+impl<'a> DeleteMonitoredItems<'a> {
+    /// Construct a new call to the `DeleteMonitoredItems` service.
+    pub fn new(subscription_id: u32, session: &'a Session) -> Self {
+        Self {
+            subscription_id,
+            items_to_delete: Vec::new(),
+            subscriptions: session.subscription_state(),
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `DeleteMonitoredItems` service, setting header parameters manually.
+    pub fn new_manual(
+        subscription_id: u32,
+        subscriptions: &'a Mutex<SubscriptionState>,
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            subscription_id,
+            items_to_delete: Vec::new(),
+            subscriptions,
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set the items to delete, overwriting any that were added previously.
+    pub fn items_to_delete(mut self, items_to_delete: Vec<u32>) -> Self {
+        self.items_to_delete = items_to_delete;
+        self
+    }
+
+    /// Add a new item to delete.
+    pub fn item(mut self, item: u32) -> Self {
+        self.items_to_delete.push(item);
+        self
+    }
+}
+
+impl<'b> UARequest for DeleteMonitoredItems<'b> {
+    type Out = DeleteMonitoredItemsResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        builder_debug!(
+            self,
+            "delete_monitored_items, subscription {} for {} items",
+            self.subscription_id,
+            self.items_to_delete.len(),
+        );
+        if self.subscription_id == 0 {
+            builder_error!(self, "delete_monitored_items, subscription id 0 is invalid");
+            return Err(StatusCode::BadInvalidArgument);
+        }
+        {
+            let state = trace_lock!(self.subscriptions);
+            if !state.subscription_exists(self.subscription_id) {
+                builder_error!(
+                    self,
+                    "delete_monitored_items, subscription id {} does not exist",
+                    self.subscription_id
+                );
+                return Err(StatusCode::BadSubscriptionIdInvalid);
+            }
+        }
+        if self.items_to_delete.is_empty() {
+            builder_error!(
+                self,
+                "delete_monitored_items, called with no items to delete"
+            );
+            return Err(StatusCode::BadNothingToDo);
+        }
+
+        let request = DeleteMonitoredItemsRequest {
+            request_header: self.header.header,
+            subscription_id: self.subscription_id,
+            monitored_item_ids: Some(self.items_to_delete.clone()),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::DeleteMonitoredItems(response) = response {
+            process_service_result(&response.response_header)?;
+            if response.results.is_some() {
+                let mut subscription_state = trace_lock!(self.subscriptions);
+                subscription_state
+                    .delete_monitored_items(self.subscription_id, &self.items_to_delete);
+            }
+            builder_debug!(self, "delete_monitored_items, success");
+            Ok(*response)
+        } else {
+            builder_error!(self, "delete_monitored_items failed {:?}", response);
+            Err(process_unexpected_response(response))
+        }
+    }
+}
 
 impl Session {
+    /// Get the internal state of subscriptions registered on the session.
+    pub fn subscription_state(&self) -> &Mutex<SubscriptionState> {
+        &self.subscription_state
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn create_subscription_inner(
         &self,
@@ -37,48 +1422,19 @@ impl Session {
         priority: u8,
         callback: Box<dyn OnSubscriptionNotification>,
     ) -> Result<u32, StatusCode> {
-        let request = CreateSubscriptionRequest {
-            request_header: self.make_request_header(),
-            requested_publishing_interval: publishing_interval.as_millis() as f64,
-            requested_lifetime_count: lifetime_count,
-            requested_max_keep_alive_count: max_keep_alive_count,
-            max_notifications_per_publish,
-            publishing_enabled,
-            priority,
-        };
-        let response = self.send(request).await?;
-        if let ResponseMessage::CreateSubscription(response) = response {
-            process_service_result(&response.response_header)?;
-            let subscription = Subscription::new(
-                response.subscription_id,
-                Duration::from_millis(response.revised_publishing_interval.max(0.0).floor() as u64),
-                response.revised_lifetime_count,
-                response.revised_max_keep_alive_count,
-                max_notifications_per_publish,
-                priority,
-                publishing_enabled,
-                callback,
-            );
+        let response = CreateSubscription::new(self, callback)
+            .publishing_interval(publishing_interval)
+            .max_lifetime_count(lifetime_count)
+            .max_keep_alive_count(max_keep_alive_count)
+            .max_notifications_per_publish(max_notifications_per_publish)
+            .publishing_enabled(publishing_enabled)
+            .priority(priority)
+            .send(&self.channel)
+            .await?;
 
-            // Add the new subscription to the subscription state
-            {
-                let mut subscription_state = trace_lock!(self.subscription_state);
-                subscription_state.add_subscription(subscription);
-            }
+        let _ = self.trigger_publish_tx.send(Instant::now());
 
-            // Send an async publish request for this new subscription
-            let _ = self.trigger_publish_tx.send(Instant::now());
-
-            session_debug!(
-                self,
-                "create_subscription, created a subscription with id {}",
-                response.subscription_id
-            );
-            Ok(response.subscription_id)
-        } else {
-            session_error!(self, "create_subscription failed {:?}", response);
-            Err(process_unexpected_response(response))
-        }
+        Ok(response.subscription_id)
     }
 
     /// Create a subscription by sending a [`CreateSubscriptionRequest`] to the server.
@@ -197,43 +1553,21 @@ impl Session {
         max_notifications_per_publish: u32,
         priority: u8,
     ) -> Result<(), StatusCode> {
-        if subscription_id == 0 {
-            session_error!(self, "modify_subscription, subscription id must be non-zero, or the subscription is considered invalid");
-            Err(StatusCode::BadInvalidArgument)
-        } else if !self.subscription_exists(subscription_id) {
+        if !self.subscription_exists(subscription_id) {
             session_error!(self, "modify_subscription, subscription id does not exist");
-            Err(StatusCode::BadInvalidArgument)
-        } else {
-            let request = ModifySubscriptionRequest {
-                request_header: self.make_request_header(),
-                subscription_id,
-                requested_publishing_interval: publishing_interval.as_millis() as f64,
-                requested_lifetime_count: lifetime_count,
-                requested_max_keep_alive_count: max_keep_alive_count,
-                max_notifications_per_publish,
-                priority,
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::ModifySubscription(response) = response {
-                process_service_result(&response.response_header)?;
-                let mut subscription_state = trace_lock!(self.subscription_state);
-                subscription_state.modify_subscription(
-                    subscription_id,
-                    Duration::from_millis(
-                        response.revised_publishing_interval.max(0.0).floor() as u64
-                    ),
-                    response.revised_lifetime_count,
-                    response.revised_max_keep_alive_count,
-                    max_notifications_per_publish,
-                    priority,
-                );
-                session_debug!(self, "modify_subscription success for {}", subscription_id);
-                Ok(())
-            } else {
-                session_error!(self, "modify_subscription failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
+            return Err(StatusCode::BadInvalidArgument);
         }
+
+        ModifySubscription::new(subscription_id, self)
+            .publishing_interval(publishing_interval)
+            .max_lifetime_count(lifetime_count)
+            .max_keep_alive_count(max_keep_alive_count)
+            .max_notifications_per_publish(max_notifications_per_publish)
+            .priority(priority)
+            .send(&self.channel)
+            .await?;
+
+        Ok(())
     }
 
     /// Changes the publishing mode of subscriptions by sending a [`SetPublishingModeRequest`] to the server.
@@ -256,40 +1590,12 @@ impl Session {
         subscription_ids: &[u32],
         publishing_enabled: bool,
     ) -> Result<Vec<StatusCode>, StatusCode> {
-        session_debug!(
-            self,
-            "set_publishing_mode, for subscriptions {:?}, publishing enabled {}",
-            subscription_ids,
-            publishing_enabled
-        );
-        if subscription_ids.is_empty() {
-            // No subscriptions
-            session_error!(
-                self,
-                "set_publishing_mode, no subscription ids were provided"
-            );
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = SetPublishingModeRequest {
-                request_header: self.make_request_header(),
-                publishing_enabled,
-                subscription_ids: Some(subscription_ids.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::SetPublishingMode(response) = response {
-                process_service_result(&response.response_header)?;
-                {
-                    // Clear out all subscriptions, assuming the delete worked
-                    let mut subscription_state = trace_lock!(self.subscription_state);
-                    subscription_state.set_publishing_mode(subscription_ids, publishing_enabled);
-                }
-                session_debug!(self, "set_publishing_mode success");
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "set_publishing_mode failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(SetPublishingMode::new(publishing_enabled, self)
+            .subscription_ids(subscription_ids.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Transfers Subscriptions and their MonitoredItems from one Session to another. For example,
@@ -297,8 +1603,9 @@ impl Session {
     /// It may also be used by one Client to take over a Subscription from another Client by
     /// transferring the Subscription to its Session.
     ///
-    /// NOTE: This method is incomplete, currently if you call this manually there is no way
-    /// to register a listener for the new subscription.
+    /// Note that if you call this manually, you will need to register the
+    /// subscriptions in the subscription state ([`Session::subscription_state`]) in order to
+    /// receive notifications.
     ///
     /// See OPC UA Part 4 - Services 5.13.7 for complete description of the service and error responses.
     ///
@@ -318,31 +1625,13 @@ impl Session {
         subscription_ids: &[u32],
         send_initial_values: bool,
     ) -> Result<Vec<TransferResult>, StatusCode> {
-        if subscription_ids.is_empty() {
-            // No subscriptions
-            session_error!(
-                self,
-                "transfer_subscriptions, no subscription ids were provided"
-            );
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = TransferSubscriptionsRequest {
-                request_header: self.make_request_header(),
-                subscription_ids: Some(subscription_ids.to_vec()),
-                send_initial_values,
-            };
-            let response = self.send(request).await?;
-            // TODO: Create a method where a user can register a subscription without creating it on the server
-            // somehow. That's necessary if this method is going to be useable manually.
-            if let ResponseMessage::TransferSubscriptions(response) = response {
-                process_service_result(&response.response_header)?;
-                session_debug!(self, "transfer_subscriptions success");
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "transfer_subscriptions failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(TransferSubscriptions::new(self)
+            .send_initial_values(send_initial_values)
+            .subscription_ids(subscription_ids.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Deletes a subscription by sending a [`DeleteSubscriptionsRequest`] to the server.
@@ -397,33 +1686,12 @@ impl Session {
         &self,
         subscription_ids: &[u32],
     ) -> Result<Vec<StatusCode>, StatusCode> {
-        if subscription_ids.is_empty() {
-            // No subscriptions
-            session_trace!(self, "delete_subscriptions with no subscriptions");
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            // Send a delete request holding all the subscription ides that we wish to delete
-            let request = DeleteSubscriptionsRequest {
-                request_header: self.make_request_header(),
-                subscription_ids: Some(subscription_ids.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::DeleteSubscriptions(response) = response {
-                process_service_result(&response.response_header)?;
-                {
-                    // Clear out deleted subscriptions, assuming the delete worked
-                    let mut subscription_state = trace_lock!(self.subscription_state);
-                    subscription_ids.iter().for_each(|id| {
-                        let _ = subscription_state.delete_subscription(*id);
-                    });
-                }
-                session_debug!(self, "delete_subscriptions success");
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "delete_subscriptions failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(DeleteSubscriptions::new(self)
+            .subscription_ids(subscription_ids.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Creates monitored items on a subscription by sending a [`CreateMonitoredItemsRequest`] to the server.
@@ -448,88 +1716,13 @@ impl Session {
         timestamps_to_return: TimestampsToReturn,
         items_to_create: Vec<MonitoredItemCreateRequest>,
     ) -> Result<Vec<MonitoredItemCreateResult>, StatusCode> {
-        session_debug!(
-            self,
-            "create_monitored_items, for subscription {}, {} items",
-            subscription_id,
-            items_to_create.len()
-        );
-        if subscription_id == 0 {
-            session_error!(self, "create_monitored_items, subscription id 0 is invalid");
-            Err(StatusCode::BadInvalidArgument)
-        } else if !self.subscription_exists(subscription_id) {
-            session_error!(
-                self,
-                "create_monitored_items, subscription id {} does not exist",
-                subscription_id
-            );
-            Err(StatusCode::BadInvalidArgument)
-        } else if items_to_create.is_empty() {
-            session_error!(
-                self,
-                "create_monitored_items, called with no items to create"
-            );
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let mut final_items_to_create = Vec::new();
-            let mut created_items = Vec::new();
-
-            for mut req in items_to_create {
-                if req.requested_parameters.client_handle == 0 {
-                    req.requested_parameters.client_handle = self.monitored_item_handle.next();
-                }
-
-                final_items_to_create.push(req.clone());
-                created_items.push(req);
-            }
-
-            let request = CreateMonitoredItemsRequest {
-                request_header: self.make_request_header(),
-                subscription_id,
-                timestamps_to_return,
-                items_to_create: Some(final_items_to_create.clone()),
-            };
-            let response = self.send(request).await?;
-
-            if let ResponseMessage::CreateMonitoredItems(response) = response {
-                process_service_result(&response.response_header)?;
-                if let Some(ref results) = response.results {
-                    session_debug!(
-                        self,
-                        "create_monitored_items, {} items created",
-                        created_items.len()
-                    );
-                    // Set the items in our internal state
-                    let items_to_create = created_items
-                        .into_iter()
-                        .zip(results)
-                        .map(|(i, r)| CreateMonitoredItem {
-                            id: r.monitored_item_id,
-                            client_handle: i.requested_parameters.client_handle,
-                            discard_oldest: i.requested_parameters.discard_oldest,
-                            item_to_monitor: i.item_to_monitor.clone(),
-                            monitoring_mode: i.monitoring_mode,
-                            queue_size: r.revised_queue_size,
-                            sampling_interval: r.revised_sampling_interval,
-                            filter: i.requested_parameters.filter,
-                        })
-                        .collect::<Vec<CreateMonitoredItem>>();
-                    {
-                        let mut subscription_state = trace_lock!(self.subscription_state);
-                        subscription_state.insert_monitored_items(subscription_id, items_to_create);
-                    }
-                } else {
-                    session_debug!(
-                        self,
-                        "create_monitored_items, success but no monitored items were created"
-                    );
-                }
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "create_monitored_items failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(CreateMonitoredItems::new(subscription_id, self)
+            .items_to_create(items_to_create)
+            .timestamps_to_return(timestamps_to_return)
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Modifies monitored items on a subscription by sending a [`ModifyMonitoredItemsRequest`] to the server.
@@ -554,66 +1747,13 @@ impl Session {
         timestamps_to_return: TimestampsToReturn,
         items_to_modify: &[MonitoredItemModifyRequest],
     ) -> Result<Vec<MonitoredItemModifyResult>, StatusCode> {
-        session_debug!(
-            self,
-            "modify_monitored_items, for subscription {}, {} items",
-            subscription_id,
-            items_to_modify.len()
-        );
-        if subscription_id == 0 {
-            session_error!(self, "modify_monitored_items, subscription id 0 is invalid");
-            Err(StatusCode::BadInvalidArgument)
-        } else if !self.subscription_exists(subscription_id) {
-            session_error!(
-                self,
-                "modify_monitored_items, subscription id {} does not exist",
-                subscription_id
-            );
-            Err(StatusCode::BadInvalidArgument)
-        } else if items_to_modify.is_empty() {
-            session_error!(
-                self,
-                "modify_monitored_items, called with no items to modify"
-            );
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let monitored_item_ids = items_to_modify
-                .iter()
-                .map(|i| i.monitored_item_id)
-                .collect::<Vec<u32>>();
-            let request = ModifyMonitoredItemsRequest {
-                request_header: self.make_request_header(),
-                subscription_id,
-                timestamps_to_return,
-                items_to_modify: Some(items_to_modify.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::ModifyMonitoredItems(response) = response {
-                process_service_result(&response.response_header)?;
-                if let Some(ref results) = response.results {
-                    // Set the items in our internal state
-                    let items_to_modify = monitored_item_ids
-                        .iter()
-                        .zip(results.iter())
-                        .map(|(id, r)| ModifyMonitoredItem {
-                            id: *id,
-                            queue_size: r.revised_queue_size,
-                            sampling_interval: r.revised_sampling_interval,
-                        })
-                        .collect::<Vec<ModifyMonitoredItem>>();
-                    {
-                        let mut subscription_state = trace_lock!(self.subscription_state);
-                        subscription_state
-                            .modify_monitored_items(subscription_id, &items_to_modify);
-                    }
-                }
-                session_debug!(self, "modify_monitored_items, success");
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "modify_monitored_items failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(ModifyMonitoredItems::new(subscription_id, self)
+            .timestamps_to_return(timestamps_to_return)
+            .items_to_modify(items_to_modify.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Sets the monitoring mode on one or more monitored items by sending a [`SetMonitoringModeRequest`]
@@ -638,36 +1778,14 @@ impl Session {
         monitoring_mode: MonitoringMode,
         monitored_item_ids: &[u32],
     ) -> Result<Vec<StatusCode>, StatusCode> {
-        if monitored_item_ids.is_empty() {
-            session_error!(self, "set_monitoring_mode, called with nothing to do");
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = {
-                let monitored_item_ids = Some(monitored_item_ids.to_vec());
-                SetMonitoringModeRequest {
-                    request_header: self.make_request_header(),
-                    subscription_id,
-                    monitoring_mode,
-                    monitored_item_ids,
-                }
-            };
-            let response = self.send(request).await?;
-
-            {
-                let mut subscription_state = trace_lock!(self.subscription_state);
-                subscription_state.set_monitoring_mode(
-                    subscription_id,
-                    monitored_item_ids,
-                    monitoring_mode,
-                );
-            }
-            if let ResponseMessage::SetMonitoringMode(response) = response {
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "set_monitoring_mode failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(
+            SetMonitoringMode::new(subscription_id, monitoring_mode, self)
+                .monitored_item_ids(monitored_item_ids.to_vec())
+                .send(&self.channel)
+                .await?
+                .results
+                .unwrap_or_default(),
+        )
     }
 
     /// Sets a monitored item so it becomes the trigger that causes other monitored items to send
@@ -695,45 +1813,12 @@ impl Session {
         links_to_add: &[u32],
         links_to_remove: &[u32],
     ) -> Result<(Option<Vec<StatusCode>>, Option<Vec<StatusCode>>), StatusCode> {
-        if links_to_add.is_empty() && links_to_remove.is_empty() {
-            session_error!(self, "set_triggering, called with nothing to add or remove");
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = {
-                let links_to_add = if links_to_add.is_empty() {
-                    None
-                } else {
-                    Some(links_to_add.to_vec())
-                };
-                let links_to_remove = if links_to_remove.is_empty() {
-                    None
-                } else {
-                    Some(links_to_remove.to_vec())
-                };
-                SetTriggeringRequest {
-                    request_header: self.make_request_header(),
-                    subscription_id,
-                    triggering_item_id,
-                    links_to_add,
-                    links_to_remove,
-                }
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::SetTriggering(response) = response {
-                // Update client side state
-                let mut subscription_state = trace_lock!(self.subscription_state);
-                subscription_state.set_triggering(
-                    subscription_id,
-                    triggering_item_id,
-                    links_to_add,
-                    links_to_remove,
-                );
-                Ok((response.add_results, response.remove_results))
-            } else {
-                session_error!(self, "set_triggering failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        let response = SetTriggering::new(subscription_id, triggering_item_id, self)
+            .links_to_add(links_to_add.to_vec())
+            .links_to_remove(links_to_remove.to_vec())
+            .send(&self.channel)
+            .await?;
+        Ok((response.add_results, response.remove_results))
     }
 
     /// Deletes monitored items from a subscription by sending a [`DeleteMonitoredItemsRequest`] to the server.
@@ -756,48 +1841,12 @@ impl Session {
         subscription_id: u32,
         items_to_delete: &[u32],
     ) -> Result<Vec<StatusCode>, StatusCode> {
-        session_debug!(
-            self,
-            "delete_monitored_items, subscription {} for {} items",
-            subscription_id,
-            items_to_delete.len()
-        );
-        if subscription_id == 0 {
-            session_error!(self, "delete_monitored_items, subscription id 0 is invalid");
-            Err(StatusCode::BadInvalidArgument)
-        } else if !self.subscription_exists(subscription_id) {
-            session_error!(
-                self,
-                "delete_monitored_items, subscription id {} does not exist",
-                subscription_id
-            );
-            Err(StatusCode::BadInvalidArgument)
-        } else if items_to_delete.is_empty() {
-            session_error!(
-                self,
-                "delete_monitored_items, called with no items to delete"
-            );
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = DeleteMonitoredItemsRequest {
-                request_header: self.make_request_header(),
-                subscription_id,
-                monitored_item_ids: Some(items_to_delete.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::DeleteMonitoredItems(response) = response {
-                process_service_result(&response.response_header)?;
-                if response.results.is_some() {
-                    let mut subscription_state = trace_lock!(self.subscription_state);
-                    subscription_state.delete_monitored_items(subscription_id, items_to_delete);
-                }
-                session_debug!(self, "delete_monitored_items, success");
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "delete_monitored_items failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(DeleteMonitoredItems::new(subscription_id, self)
+            .items_to_delete(items_to_delete.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     pub(crate) fn next_publish_time(&self, set_last_publish: bool) -> Option<Instant> {

--- a/opcua-client/src/session/services/subscriptions/service.rs
+++ b/opcua-client/src/session/services/subscriptions/service.rs
@@ -1433,6 +1433,11 @@ impl Session {
         &self.subscription_state
     }
 
+    /// Trigger a publish to fire immediately.
+    pub fn trigger_publish_now(&self) {
+        let _ = self.trigger_publish_tx.send(Instant::now());
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn create_subscription_inner(
         &self,

--- a/opcua-client/src/session/services/subscriptions/service.rs
+++ b/opcua-client/src/session/services/subscriptions/service.rs
@@ -47,7 +47,7 @@ pub struct CreateSubscription<'a> {
     header: RequestHeaderBuilder,
 }
 
-builder_base!(CreateSubscription<'a>, <'a>);
+builder_base!(CreateSubscription<'a>);
 
 impl<'a> CreateSubscription<'a> {
     /// Construct a new call to the `CreateSubscription` service.
@@ -210,7 +210,7 @@ pub struct ModifySubscription<'a> {
     header: RequestHeaderBuilder,
 }
 
-builder_base!(ModifySubscription<'a>, <'a>);
+builder_base!(ModifySubscription<'a>);
 
 impl<'a> ModifySubscription<'a> {
     /// Construct a new call to the `ModifySubscription` service.
@@ -361,7 +361,7 @@ pub struct SetPublishingMode<'a> {
     header: RequestHeaderBuilder,
 }
 
-builder_base!(SetPublishingMode<'a>, <'a>);
+builder_base!(SetPublishingMode<'a>);
 
 impl<'a> SetPublishingMode<'a> {
     /// Construct a new call to the `SetPublishingMode` service.
@@ -579,7 +579,7 @@ pub struct DeleteSubscriptions<'a> {
     header: RequestHeaderBuilder,
 }
 
-builder_base!(DeleteSubscriptions<'a>, <'a>);
+builder_base!(DeleteSubscriptions<'a>);
 
 impl<'a> DeleteSubscriptions<'a> {
     /// Construct a new call to the `DeleteSubscriptions` service.
@@ -654,6 +654,9 @@ impl<'b> UARequest for DeleteSubscriptions<'b> {
 }
 
 #[derive(Clone)]
+/// Creates monitored items on a subscription by sending a [`CreateMonitoredItemsRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.12.2 for complete description of the service and error responses.
 pub struct CreateMonitoredItems<'a> {
     subscription_id: u32,
     timestamps_to_return: TimestampsToReturn,
@@ -664,7 +667,7 @@ pub struct CreateMonitoredItems<'a> {
     header: RequestHeaderBuilder,
 }
 
-builder_base!(CreateMonitoredItems<'a>, <'a>);
+builder_base!(CreateMonitoredItems<'a>);
 
 impl<'a> CreateMonitoredItems<'a> {
     /// Construct a new call to the `CreateMonitoredItems` service.
@@ -845,6 +848,10 @@ impl<'b> UARequest for CreateMonitoredItems<'b> {
     }
 }
 
+#[derive(Clone)]
+/// Modifies monitored items on a subscription by sending a [`ModifyMonitoredItemsRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.12.3 for complete description of the service and error responses.
 pub struct ModifyMonitoredItems<'a> {
     subscription_id: u32,
     timestamps_to_return: TimestampsToReturn,
@@ -854,7 +861,7 @@ pub struct ModifyMonitoredItems<'a> {
     header: RequestHeaderBuilder,
 }
 
-builder_base!(ModifyMonitoredItems<'a>, <'a>);
+builder_base!(ModifyMonitoredItems<'a>);
 
 impl<'a> ModifyMonitoredItems<'a> {
     /// Construct a new call to the `ModifyMonitoredItems` service.
@@ -989,6 +996,11 @@ impl<'b> UARequest for ModifyMonitoredItems<'b> {
     }
 }
 
+#[derive(Clone)]
+/// Sets the monitoring mode on one or more monitored items by sending a [`SetMonitoringModeRequest`]
+/// to the server.
+///
+/// See OPC UA Part 4 - Services 5.12.4 for complete description of the service and error responses.
 pub struct SetMonitoringMode<'a> {
     subscription_id: u32,
     monitoring_mode: MonitoringMode,
@@ -998,7 +1010,7 @@ pub struct SetMonitoringMode<'a> {
     header: RequestHeaderBuilder,
 }
 
-builder_base!(SetMonitoringMode<'a>, <'a>);
+builder_base!(SetMonitoringMode<'a>);
 
 impl<'a> SetMonitoringMode<'a> {
     /// Construct a new call to the `SetMonitoringMode` service.
@@ -1126,6 +1138,12 @@ impl<'b> UARequest for SetMonitoringMode<'b> {
     }
 }
 
+#[derive(Clone)]
+/// Sets a monitored item so it becomes the trigger that causes other monitored items to send
+/// change events in the same update. Sends a [`SetTriggeringRequest`] to the server.
+/// Note that `items_to_remove` is applied before `items_to_add`.
+///
+/// See OPC UA Part 4 - Services 5.12.5 for complete description of the service and error responses.
 pub struct SetTriggering<'a> {
     subscription_id: u32,
     triggering_item_id: u32,
@@ -1136,7 +1154,7 @@ pub struct SetTriggering<'a> {
     header: RequestHeaderBuilder,
 }
 
-builder_base!(SetTriggering<'a>, <'a>);
+builder_base!(SetTriggering<'a>);
 
 impl<'a> SetTriggering<'a> {
     /// Construct a new call to the `SetTriggering` service.
@@ -1296,6 +1314,10 @@ impl<'b> UARequest for SetTriggering<'b> {
     }
 }
 
+#[derive(Clone)]
+/// Deletes monitored items from a subscription by sending a [`DeleteMonitoredItemsRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.12.6 for complete description of the service and error responses.
 pub struct DeleteMonitoredItems<'a> {
     subscription_id: u32,
     items_to_delete: Vec<u32>,
@@ -1304,7 +1326,7 @@ pub struct DeleteMonitoredItems<'a> {
     header: RequestHeaderBuilder,
 }
 
-builder_base!(DeleteMonitoredItems<'a>, <'a>);
+builder_base!(DeleteMonitoredItems<'a>);
 
 impl<'a> DeleteMonitoredItems<'a> {
     /// Construct a new call to the `DeleteMonitoredItems` service.

--- a/opcua-client/src/session/services/subscriptions/state.rs
+++ b/opcua-client/src/session/services/subscriptions/state.rs
@@ -103,7 +103,11 @@ impl SubscriptionState {
             .count()
     }
 
-    pub(crate) fn add_subscription(&mut self, subscription: Subscription) {
+    /// Add a subscription to the state. Note that this
+    /// does not create the subscription, you need to do that yourself.
+    ///
+    /// Most users should simply call [`crate::Session::create_subscription`]
+    pub fn add_subscription(&mut self, subscription: Subscription) {
         self.subscriptions
             .insert(subscription.subscription_id(), subscription);
         self.set_keep_alive_timeout();

--- a/opcua-client/src/session/services/view.rs
+++ b/opcua-client/src/session/services/view.rs
@@ -1,13 +1,445 @@
+use std::time::Duration;
+
 use crate::{
-    session::{process_service_result, process_unexpected_response, session_debug, session_error},
-    Session,
+    session::{
+        process_service_result, process_unexpected_response,
+        request_builder::{builder_base, builder_debug, builder_error, RequestHeaderBuilder},
+    },
+    Session, UARequest,
 };
 use opcua_core::ResponseMessage;
 use opcua_types::{
-    BrowseDescription, BrowseNextRequest, BrowsePath, BrowsePathResult, BrowseRequest,
-    BrowseResult, ByteString, DateTime, NodeId, RegisterNodesRequest, StatusCode,
-    TranslateBrowsePathsToNodeIdsRequest, UnregisterNodesRequest, ViewDescription,
+    BrowseDescription, BrowseNextRequest, BrowseNextResponse, BrowsePath, BrowsePathResult,
+    BrowseRequest, BrowseResponse, BrowseResult, ByteString, IntegerId, NodeId,
+    RegisterNodesRequest, RegisterNodesResponse, StatusCode, TranslateBrowsePathsToNodeIdsRequest,
+    TranslateBrowsePathsToNodeIdsResponse, UnregisterNodesRequest, UnregisterNodesResponse,
+    ViewDescription,
 };
+
+#[derive(Debug, Clone)]
+/// Discover the references to the specified nodes by sending a [`BrowseRequest`] to the server.
+///
+/// See OPC UA Part 4 - Services 5.8.2 for complete description of the service and error responses.
+pub struct Browse {
+    nodes_to_browse: Vec<BrowseDescription>,
+    view: ViewDescription,
+    max_references_per_node: u32,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(Browse);
+
+impl Browse {
+    /// Construct a new call to the `Browse` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            nodes_to_browse: Vec::new(),
+            view: ViewDescription::default(),
+            max_references_per_node: 0,
+
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `Browse` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            nodes_to_browse: Vec::new(),
+            view: ViewDescription::default(),
+            max_references_per_node: 0,
+
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set the view to browse.
+    pub fn view(mut self, view: ViewDescription) -> Self {
+        self.view = view;
+        self
+    }
+
+    /// Set max references per node. The default is zero, meaning server-defined.
+    pub fn max_references_per_node(mut self, max_references_per_node: u32) -> Self {
+        self.max_references_per_node = max_references_per_node;
+        self
+    }
+
+    /// Set nodes to browse, overwriting any that were set previously.
+    pub fn nodes_to_browse(mut self, nodes_to_browse: Vec<BrowseDescription>) -> Self {
+        self.nodes_to_browse = nodes_to_browse;
+        self
+    }
+
+    /// Add a node to browse.
+    pub fn browse_node(mut self, node_to_browse: impl Into<BrowseDescription>) -> Self {
+        self.nodes_to_browse.push(node_to_browse.into());
+        self
+    }
+}
+
+impl UARequest for Browse {
+    type Out = BrowseResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.nodes_to_browse.is_empty() {
+            builder_error!(self, "browse was not supplied with any nodes to browse");
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = BrowseRequest {
+            request_header: self.header.header,
+            view: self.view,
+            requested_max_references_per_node: self.max_references_per_node,
+            nodes_to_browse: Some(self.nodes_to_browse),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::Browse(response) = response {
+            builder_debug!(self, "browse, success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "browse failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Continue to discover references to nodes by sending continuation points in a [`BrowseNextRequest`]
+/// to the server. This function may have to be called repeatedly to process the initial query.
+///
+/// See OPC UA Part 4 - Services 5.8.3 for complete description of the service and error responses.
+pub struct BrowseNext {
+    continuation_points: Vec<ByteString>,
+    release_continuation_points: bool,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(BrowseNext);
+
+impl BrowseNext {
+    /// Construct a new call to the `BrowseNext` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            continuation_points: Vec::new(),
+            release_continuation_points: false,
+
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `BrowseNext` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            continuation_points: Vec::new(),
+            release_continuation_points: false,
+
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set release continuation points. Default is false, if this is true,
+    /// continuation points will be released and no results will be returned.
+    pub fn release_continuation_points(mut self, release_continuation_points: bool) -> Self {
+        self.release_continuation_points = release_continuation_points;
+        self
+    }
+
+    /// Set continuation points, overwriting any that were set previously.
+    pub fn continuation_points(mut self, continuation_points: Vec<ByteString>) -> Self {
+        self.continuation_points = continuation_points;
+        self
+    }
+
+    /// Add a continuation point to the request.
+    pub fn continuation_point(mut self, continuation_point: ByteString) -> Self {
+        self.continuation_points.push(continuation_point);
+        self
+    }
+}
+
+impl UARequest for BrowseNext {
+    type Out = BrowseNextResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.continuation_points.is_empty() {
+            builder_error!(
+                self,
+                "browse_next was not supplied with any continuation points"
+            );
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = BrowseNextRequest {
+            request_header: self.header.header,
+            continuation_points: Some(self.continuation_points),
+            release_continuation_points: self.release_continuation_points,
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::BrowseNext(response) = response {
+            builder_debug!(self, "browse_next, success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "browse_next failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Translate browse paths to NodeIds by sending a [`TranslateBrowsePathsToNodeIdsRequest`] request to the Server
+/// Each [`BrowsePath`] is constructed of a starting node and a `RelativePath`. The specified starting node
+/// identifies the node from which the RelativePath is based. The RelativePath contains a sequence of
+/// ReferenceTypes and BrowseNames.
+///
+/// See OPC UA Part 4 - Services 5.8.4 for complete description of the service and error responses.
+pub struct TranslateBrowsePaths {
+    browse_paths: Vec<BrowsePath>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(TranslateBrowsePaths);
+
+impl TranslateBrowsePaths {
+    /// Construct a new call to the `TranslateBrowsePaths` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            browse_paths: Vec::new(),
+
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `TranslateBrowsePaths` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            browse_paths: Vec::new(),
+
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set browse paths, overwriting any that were set previously.
+    pub fn browse_paths(mut self, browse_paths: Vec<BrowsePath>) -> Self {
+        self.browse_paths = browse_paths;
+        self
+    }
+
+    /// Add a browse path to the request.
+    pub fn browse_path(mut self, browse_path: BrowsePath) -> Self {
+        self.browse_paths.push(browse_path);
+        self
+    }
+}
+
+impl UARequest for TranslateBrowsePaths {
+    type Out = TranslateBrowsePathsToNodeIdsResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.browse_paths.is_empty() {
+            builder_error!(
+                self,
+                "translate_browse_paths_to_node_ids was not supplied with any browse paths"
+            );
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = TranslateBrowsePathsToNodeIdsRequest {
+            request_header: self.header.header,
+            browse_paths: Some(self.browse_paths),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::TranslateBrowsePathsToNodeIds(response) = response {
+            builder_debug!(self, "translate_browse_paths_to_node_ids, success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "translate_browse_paths_to_node_ids failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Register nodes on the server by sending a [`RegisterNodesRequest`]. The purpose of this
+/// call is server-dependent but allows a client to ask a server to create nodes which are
+/// otherwise expensive to set up or maintain, e.g. nodes attached to hardware.
+///
+/// See OPC UA Part 4 - Services 5.8.5 for complete description of the service and error responses.
+pub struct RegisterNodes {
+    nodes_to_register: Vec<NodeId>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(RegisterNodes);
+
+impl RegisterNodes {
+    /// Construct a new call to the `RegisterNodes` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            nodes_to_register: Vec::new(),
+
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `RegisterNodes` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            nodes_to_register: Vec::new(),
+
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set nodes to register, overwriting any that were set previously.
+    pub fn nodes_to_register(mut self, nodes_to_register: Vec<NodeId>) -> Self {
+        self.nodes_to_register = nodes_to_register;
+        self
+    }
+
+    /// Add a node to the request.
+    pub fn node_to_register(mut self, node_to_register: impl Into<NodeId>) -> Self {
+        self.nodes_to_register.push(node_to_register.into());
+        self
+    }
+}
+
+impl UARequest for RegisterNodes {
+    type Out = RegisterNodesResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.nodes_to_register.is_empty() {
+            builder_error!(self, "register_nodes was not supplied with any node IDs");
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = RegisterNodesRequest {
+            request_header: self.header.header,
+            nodes_to_register: Some(self.nodes_to_register),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::RegisterNodes(response) = response {
+            builder_debug!(self, "register_nodes, success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "register_nodes failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Unregister nodes on the server by sending a [`UnregisterNodesRequest`]. This indicates to
+/// the server that the client relinquishes any need for these nodes. The server will ignore
+/// unregistered nodes.
+///
+/// See OPC UA Part 4 - Services 5.8.5 for complete description of the service and error responses.
+pub struct UnregisterNodes {
+    nodes_to_unregister: Vec<NodeId>,
+
+    header: RequestHeaderBuilder,
+}
+
+builder_base!(UnregisterNodes);
+
+impl UnregisterNodes {
+    /// Construct a new call to the `UnregisterNodes` service.
+    pub fn new(session: &Session) -> Self {
+        Self {
+            nodes_to_unregister: Vec::new(),
+
+            header: RequestHeaderBuilder::new_from_session(session),
+        }
+    }
+
+    /// Construct a new call to the `UnregisterNodes` service, setting header parameters manually.
+    pub fn new_manual(
+        session_id: u32,
+        timeout: Duration,
+        auth_token: NodeId,
+        request_handle: IntegerId,
+    ) -> Self {
+        Self {
+            nodes_to_unregister: Vec::new(),
+
+            header: RequestHeaderBuilder::new(session_id, timeout, auth_token, request_handle),
+        }
+    }
+
+    /// Set nodes to register, overwriting any that were set previously.
+    pub fn nodes_to_unregister(mut self, nodes_to_unregister: Vec<NodeId>) -> Self {
+        self.nodes_to_unregister = nodes_to_unregister;
+        self
+    }
+
+    /// Add a continuation point to the request.
+    pub fn node_to_unregister(mut self, node_to_unregister: impl Into<NodeId>) -> Self {
+        self.nodes_to_unregister.push(node_to_unregister.into());
+        self
+    }
+}
+
+impl UARequest for UnregisterNodes {
+    type Out = UnregisterNodesResponse;
+
+    async fn send<'a>(self, channel: &'a crate::AsyncSecureChannel) -> Result<Self::Out, StatusCode>
+    where
+        Self: 'a,
+    {
+        if self.nodes_to_unregister.is_empty() {
+            builder_error!(self, "unregister_nodes was not supplied with any node IDs");
+            return Err(StatusCode::BadNothingToDo);
+        }
+        let request = UnregisterNodesRequest {
+            request_header: self.header.header,
+            nodes_to_unregister: Some(self.nodes_to_unregister),
+        };
+        let response = channel.send(request, self.header.timeout).await?;
+        if let ResponseMessage::UnregisterNodes(response) = response {
+            builder_debug!(self, "unregister_nodes, success");
+            process_service_result(&response.response_header)?;
+            Ok(*response)
+        } else {
+            builder_error!(self, "unregister_nodes failed");
+            Err(process_unexpected_response(response))
+        }
+    }
+}
 
 impl Session {
     /// Discover the references to the specified nodes by sending a [`BrowseRequest`] to the server.
@@ -30,30 +462,14 @@ impl Session {
         max_references_per_node: u32,
         view: Option<ViewDescription>,
     ) -> Result<Vec<BrowseResult>, StatusCode> {
-        if nodes_to_browse.is_empty() {
-            session_error!(self, "browse, was not supplied with any nodes to browse");
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = BrowseRequest {
-                request_header: self.make_request_header(),
-                view: view.unwrap_or_else(|| ViewDescription {
-                    view_id: NodeId::null(),
-                    timestamp: DateTime::null(),
-                    view_version: 0,
-                }),
-                requested_max_references_per_node: max_references_per_node,
-                nodes_to_browse: Some(nodes_to_browse.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::Browse(response) = response {
-                session_debug!(self, "browse, success");
-                process_service_result(&response.response_header)?;
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "browse failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(Browse::new(self)
+            .nodes_to_browse(nodes_to_browse.to_vec())
+            .view(view.unwrap_or_default())
+            .max_references_per_node(max_references_per_node)
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Continue to discover references to nodes by sending continuation points in a [`BrowseNextRequest`]
@@ -77,24 +493,13 @@ impl Session {
         release_continuation_points: bool,
         continuation_points: &[ByteString],
     ) -> Result<Vec<BrowseResult>, StatusCode> {
-        if continuation_points.is_empty() {
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = BrowseNextRequest {
-                request_header: self.make_request_header(),
-                continuation_points: Some(continuation_points.to_vec()),
-                release_continuation_points,
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::BrowseNext(response) = response {
-                session_debug!(self, "browse_next, success");
-                process_service_result(&response.response_header)?;
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(self, "browse_next failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(BrowseNext::new(self)
+            .continuation_points(continuation_points.to_vec())
+            .release_continuation_points(release_continuation_points)
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Translate browse paths to NodeIds by sending a [`TranslateBrowsePathsToNodeIdsRequest`] request to the Server
@@ -119,31 +524,12 @@ impl Session {
         &self,
         browse_paths: &[BrowsePath],
     ) -> Result<Vec<BrowsePathResult>, StatusCode> {
-        if browse_paths.is_empty() {
-            session_error!(
-                self,
-                "translate_browse_paths_to_node_ids, was not supplied with any browse paths"
-            );
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = TranslateBrowsePathsToNodeIdsRequest {
-                request_header: self.make_request_header(),
-                browse_paths: Some(browse_paths.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::TranslateBrowsePathsToNodeIds(response) = response {
-                session_debug!(self, "translate_browse_paths_to_node_ids, success");
-                process_service_result(&response.response_header)?;
-                Ok(response.results.unwrap_or_default())
-            } else {
-                session_error!(
-                    self,
-                    "translate_browse_paths_to_node_ids failed {:?}",
-                    response
-                );
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(TranslateBrowsePaths::new(self)
+            .browse_paths(browse_paths.to_vec())
+            .send(&self.channel)
+            .await?
+            .results
+            .unwrap_or_default())
     }
 
     /// Register nodes on the server by sending a [`RegisterNodesRequest`]. The purpose of this
@@ -166,27 +552,12 @@ impl Session {
         &self,
         nodes_to_register: &[NodeId],
     ) -> Result<Vec<NodeId>, StatusCode> {
-        if nodes_to_register.is_empty() {
-            session_error!(
-                self,
-                "register_nodes, was not supplied with any nodes to register"
-            );
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = RegisterNodesRequest {
-                request_header: self.make_request_header(),
-                nodes_to_register: Some(nodes_to_register.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::RegisterNodes(response) = response {
-                session_debug!(self, "register_nodes, success");
-                process_service_result(&response.response_header)?;
-                Ok(response.registered_node_ids.unwrap())
-            } else {
-                session_error!(self, "register_nodes failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        Ok(RegisterNodes::new(self)
+            .nodes_to_register(nodes_to_register.to_vec())
+            .send(&self.channel)
+            .await?
+            .registered_node_ids
+            .unwrap_or_default())
     }
 
     /// Unregister nodes on the server by sending a [`UnregisterNodesRequest`]. This indicates to
@@ -205,26 +576,10 @@ impl Session {
     /// * `Err(StatusCode)` - Request failed, [Status code](StatusCode) is the reason for failure.
     ///
     pub async fn unregister_nodes(&self, nodes_to_unregister: &[NodeId]) -> Result<(), StatusCode> {
-        if nodes_to_unregister.is_empty() {
-            session_error!(
-                self,
-                "unregister_nodes, was not supplied with any nodes to unregister"
-            );
-            Err(StatusCode::BadNothingToDo)
-        } else {
-            let request = UnregisterNodesRequest {
-                request_header: self.make_request_header(),
-                nodes_to_unregister: Some(nodes_to_unregister.to_vec()),
-            };
-            let response = self.send(request).await?;
-            if let ResponseMessage::UnregisterNodes(response) = response {
-                session_debug!(self, "unregister_nodes, success");
-                process_service_result(&response.response_header)?;
-                Ok(())
-            } else {
-                session_error!(self, "unregister_nodes failed {:?}", response);
-                Err(process_unexpected_response(response))
-            }
-        }
+        UnregisterNodes::new(self)
+            .nodes_to_unregister(nodes_to_unregister.to_vec())
+            .send(&self.channel)
+            .await?;
+        Ok(())
     }
 }

--- a/opcua-client/src/transport/state.rs
+++ b/opcua-client/src/transport/state.rs
@@ -14,8 +14,8 @@ use opcua_core::{
 };
 use opcua_crypto::SecurityPolicy;
 use opcua_types::{
-    DateTime, DiagnosticBits, MessageSecurityMode, NodeId, OpenSecureChannelRequest, RequestHeader,
-    SecurityTokenRequestType, StatusCode,
+    DateTime, DiagnosticBits, IntegerId, MessageSecurityMode, NodeId, OpenSecureChannelRequest,
+    RequestHeader, SecurityTokenRequestType, StatusCode,
 };
 
 pub(crate) type RequestSend = tokio::sync::mpsc::Sender<OutgoingMessage>;
@@ -205,5 +205,9 @@ impl SecureChannelState {
             timeout_hint: timeout.as_millis().min(u32::MAX as u128) as u32,
             ..Default::default()
         }
+    }
+
+    pub fn request_handle(&self) -> IntegerId {
+        self.request_handle.next()
     }
 }

--- a/opcua-client/src/transport/state.rs
+++ b/opcua-client/src/transport/state.rs
@@ -83,7 +83,7 @@ impl Request {
 
         match cb_recv.await {
             Ok(r) => r,
-            // Should not really happen, would mean something paniced.
+            // Should not really happen, would mean something panicked.
             Err(_) => Err(StatusCode::BadConnectionClosed),
         }
     }

--- a/opcua-core/src/comms/secure_channel.rs
+++ b/opcua-core/src/comms/secure_channel.rs
@@ -100,12 +100,21 @@ impl SecureChannel {
     ) -> SecureChannel {
         let (cert, private_key) = {
             let certificate_store = certificate_store.read();
-            if let Ok((cert, pkey)) = certificate_store.read_own_cert_and_pkey() {
-                (Some(cert), Some(pkey))
-            } else {
-                error!("Cannot read our own certificate and private key. Check paths. Crypto won't work");
-                (None, None)
-            }
+            let cert = match certificate_store.read_own_cert() {
+                Err(e) => {
+                    error!("Failed to read own certificate: {e}. Check paths, crypto won't work");
+                    None
+                }
+                Ok(r) => Some(r),
+            };
+            let pkey = match certificate_store.read_own_pkey() {
+                Err(e) => {
+                    error!("Failed to read own private key: {e}. Check paths, crypto won't work");
+                    None
+                }
+                Ok(r) => Some(r),
+            };
+            (cert, pkey)
         };
         SecureChannel {
             role,

--- a/opcua-crypto/src/pkey.rs
+++ b/opcua-crypto/src/pkey.rs
@@ -62,6 +62,7 @@ impl From<rsa::Error> for PKeyError {
 
 /// This is a wrapper around an asymmetric key pair. Since the PKey is either
 /// a public or private key so we have to differentiate that as well.
+#[derive(Clone)]
 pub struct PKey<T> {
     pub(crate) value: T,
 }

--- a/opcua-nodes/src/type_tree.rs
+++ b/opcua-nodes/src/type_tree.rs
@@ -75,6 +75,8 @@ pub trait TypeTree {
         type_id: &NodeId,
         path: &[QualifiedName],
     ) -> Option<&TypeProperty>;
+
+    fn get_supertype<'a>(&'a self, node: &NodeId) -> Option<&'a NodeId>;
 }
 
 impl TypeTree for DefaultTypeTree {
@@ -131,6 +133,10 @@ impl TypeTree for DefaultTypeTree {
         path: &[QualifiedName],
     ) -> Option<&TypeProperty> {
         self.type_properties.get(type_id).and_then(|p| p.get(path))
+    }
+
+    fn get_supertype<'a>(&'a self, node: &NodeId) -> Option<&'a NodeId> {
+        self.subtypes_by_target.get(node)
     }
 }
 

--- a/opcua-types/src/service_types/close_session_request.rs
+++ b/opcua-types/src/service_types/close_session_request.rs
@@ -6,7 +6,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
-mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
+mod opcua {
+    pub use crate as types;
+}
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "json", serde_with::skip_serializing_none)]
 #[cfg_attr(feature = "json", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "json", serde(rename_all = "PascalCase"))]
@@ -28,10 +31,7 @@ impl opcua::types::BinaryEncoder for CloseSessionRequest {
         size
     }
     #[allow(unused_variables)]
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         let mut size = 0usize;
         size += self.request_header.encode(stream)?;
         size += self.delete_subscriptions.encode(stream)?;
@@ -42,16 +42,15 @@ impl opcua::types::BinaryEncoder for CloseSessionRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
-            stream,
-            decoding_options,
-        )?;
-        let __request_handle = request_header.request_handle;
-        let delete_subscriptions = <bool as opcua::types::BinaryEncoder>::decode(
+        let request_header =
+            <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
                 stream,
                 decoding_options,
-            )
-            .map_err(|e| e.with_request_handle(__request_handle))?;
+            )?;
+        let __request_handle = request_header.request_handle;
+        let delete_subscriptions =
+            <bool as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+                .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,
             delete_subscriptions,


### PR DESCRIPTION
Refactors the client to use a request-builder approach, making it possible to customize requests more, and also to do stuff like we now do in a test, transfer subscriptions without being in the same session.