### PR TITLE
Make server use a generic connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
 name = "opcua-simple-client"
 version = "0.13.0"
 dependencies = [
+ "log",
  "opcua",
  "pico-args",
  "tokio",

--- a/opcua-client/src/transport/core.rs
+++ b/opcua-client/src/transport/core.rs
@@ -125,7 +125,14 @@ impl TransportState {
                 StatusCode::BadUnexpectedError
             }
             Message::Chunk(chunk) => self.process_chunk(chunk).err().unwrap_or(StatusCode::Good),
-            Message::Error(error) => StatusCode::from(error.error),
+            Message::Error(error) => {
+                let status = StatusCode::from(error.error);
+                error!(
+                    "Received error {} from server. Reason: {}",
+                    status, error.reason
+                );
+                status
+            }
             m => {
                 error!("Expected a recognized message, got {:?}", m);
                 StatusCode::BadUnexpectedError

--- a/opcua-server/src/server.rs
+++ b/opcua-server/src/server.rs
@@ -25,7 +25,7 @@ use opcua_crypto::CertificateStore;
 
 use crate::{
     node_manager::{DefaultTypeTreeGetter, ServerContext},
-    session::controller::SessionStarter,
+    session::controller::{ControllerCommand, SessionStarter},
     transport::tcp::{TcpConnector, TransportConfig},
     ServerStatusWrapper,
 };
@@ -39,7 +39,7 @@ use super::{
     info::ServerInfo,
     node_manager::{NodeManagers, NodeManagersRef},
     server_handle::ServerHandle,
-    session::{controller::ControllerCommand, manager::SessionManager},
+    session::manager::SessionManager,
     subscriptions::SubscriptionCache,
     ServerCapabilities,
 };

--- a/opcua-server/src/server.rs
+++ b/opcua-server/src/server.rs
@@ -25,7 +25,8 @@ use opcua_crypto::CertificateStore;
 
 use crate::{
     node_manager::{DefaultTypeTreeGetter, ServerContext},
-    session::controller::SessionController,
+    session::controller::SessionStarter,
+    transport::tcp::{TcpConnector, TransportConfig},
     ServerStatusWrapper,
 };
 use opcua_types::{DateTime, LocalizedText, ServerState, UAString};
@@ -327,14 +328,21 @@ impl Server {
                     match rs {
                         Ok((socket, addr)) => {
                             info!("Accept new connection from {addr} ({connection_counter})");
-                            let conn = SessionController::new(
-                                socket,
+                            let conn = SessionStarter::new(
+                                TcpConnector::new(socket, TransportConfig {
+                                    send_buffer_size: self.info.config.limits.send_buffer_size,
+                                    max_message_size: self.info.config.limits.max_message_size,
+                                    max_chunk_count: self.info.config.limits.max_chunk_count,
+                                    receive_buffer_size: self.info.config.limits.receive_buffer_size,
+                                    hello_timeout: Duration::from_secs(self.info.config.tcp_config.hello_timeout as u64),
+                                }, self.info.decoding_options()),
+                                self.info.clone(),
                                 self.session_manager.clone(),
                                 self.certificate_store.clone(),
-                                self.info.clone(),
                                 self.node_managers.clone(),
                                 self.subscriptions.clone()
                             );
+
                             let (send, recv) = tokio::sync::mpsc::channel(5);
                             let handle = tokio::spawn(conn.run(recv).map(move |_| connection_counter));
                             self.connections.push(handle);

--- a/opcua-server/src/session/controller.rs
+++ b/opcua-server/src/session/controller.rs
@@ -7,7 +7,6 @@ use std::{
 use futures::{future::Either, stream::FuturesUnordered, Future, StreamExt};
 use log::{debug, error, trace, warn};
 use opcua_core::{trace_read_lock, trace_write_lock, Message, RequestMessage, ResponseMessage};
-use tokio::net::TcpStream;
 
 use opcua_core::{
     comms::{
@@ -29,7 +28,8 @@ use crate::{
     info::ServerInfo,
     node_manager::NodeManagers,
     subscriptions::SubscriptionCache,
-    transport::tcp::{Request, TcpTransport, TransportConfig, TransportPollResult},
+    transport::tcp::{Request, TcpTransport, TransportPollResult},
+    transport::Connector,
 };
 
 use super::{
@@ -86,9 +86,69 @@ enum RequestProcessResult {
     Close,
 }
 
+pub struct SessionStarter<T> {
+    connector: T,
+    info: Arc<ServerInfo>,
+    session_manager: Arc<RwLock<SessionManager>>,
+    certificate_store: Arc<RwLock<CertificateStore>>,
+    node_managers: NodeManagers,
+    subscriptions: Arc<SubscriptionCache>,
+}
+
+impl<T: Connector> SessionStarter<T> {
+    pub fn new(
+        connector: T,
+        info: Arc<ServerInfo>,
+        session_manager: Arc<RwLock<SessionManager>>,
+        certificate_store: Arc<RwLock<CertificateStore>>,
+        node_managers: NodeManagers,
+        subscriptions: Arc<SubscriptionCache>,
+    ) -> Self {
+        Self {
+            connector,
+            info,
+            session_manager,
+            certificate_store,
+            node_managers,
+            subscriptions,
+        }
+    }
+
+    pub async fn run(self, mut command: tokio::sync::mpsc::Receiver<ControllerCommand>) {
+        let transport = tokio::select! {
+            cmd = command.recv() => {
+                match cmd {
+                    Some(ControllerCommand::Close) | None => {
+                        return;
+                    }
+                }
+            }
+            r = self.connector.connect(self.info.clone()) => {
+                match r {
+                    Ok(t) => t,
+                    Err(e) => {
+                        log::error!("Connection failed while waiting for channel to be established: {e}");
+                        return;
+                    }
+                }
+            }
+        };
+
+        let controller = SessionController::new(
+            transport,
+            self.session_manager,
+            self.certificate_store,
+            self.info,
+            self.node_managers,
+            self.subscriptions,
+        );
+        controller.run(command).await
+    }
+}
+
 impl SessionController {
     pub fn new(
-        socket: TcpStream,
+        transport: TcpTransport,
         session_manager: Arc<RwLock<SessionManager>>,
         certificate_store: Arc<RwLock<CertificateStore>>,
         info: Arc<ServerInfo>,
@@ -99,18 +159,6 @@ impl SessionController {
             certificate_store.clone(),
             opcua_core::comms::secure_channel::Role::Server,
             info.decoding_options(),
-        );
-        let transport = TcpTransport::new(
-            socket,
-            TransportConfig {
-                send_buffer_size: info.config.limits.send_buffer_size,
-                max_message_size: info.config.limits.max_message_size,
-                max_chunk_count: info.config.limits.max_chunk_count,
-                receive_buffer_size: info.config.limits.receive_buffer_size,
-                hello_timeout: Duration::from_secs(info.config.tcp_config.hello_timeout as u64),
-            },
-            info.decoding_options(),
-            info.clone(),
         );
 
         Self {

--- a/opcua-server/src/session/manager.rs
+++ b/opcua-server/src/session/manager.rs
@@ -149,6 +149,7 @@ impl SessionManager {
             request.client_description.clone(),
             channel.security_mode(),
         );
+        info!("Created new session with ID {}", session.session_id());
 
         let session_id = session.session_id().clone();
         self.sessions
@@ -232,7 +233,7 @@ impl SessionManager {
 }
 
 // This is a non-self method to avoid holding the manager
-// across an away point.
+// across an await point.
 pub(crate) async fn close_session(
     mgr_lck: &RwLock<SessionManager>,
     channel: &mut SecureChannel,
@@ -258,6 +259,7 @@ pub(crate) async fn close_session(
             (id, token, session_id)
         };
 
+        info!("Closed session with ID {}", session_id);
         let session = mgr.sessions.remove(&session_id).unwrap();
         {
             let mut session_lck = trace_write_lock!(session);

--- a/opcua-server/src/transport/connect.rs
+++ b/opcua-server/src/transport/connect.rs
@@ -1,0 +1,14 @@
+use std::{future::Future, sync::Arc};
+
+use opcua_types::StatusCode;
+
+use crate::info::ServerInfo;
+
+use super::tcp::TcpTransport;
+
+pub trait Connector {
+    fn connect(
+        self,
+        info: Arc<ServerInfo>,
+    ) -> impl Future<Output = Result<TcpTransport, StatusCode>> + Send + Sync;
+}

--- a/opcua-server/src/transport/connect.rs
+++ b/opcua-server/src/transport/connect.rs
@@ -1,6 +1,7 @@
 use std::{future::Future, sync::Arc};
 
 use opcua_types::StatusCode;
+use tokio_util::sync::CancellationToken;
 
 use crate::info::ServerInfo;
 
@@ -10,5 +11,6 @@ pub trait Connector {
     fn connect(
         self,
         info: Arc<ServerInfo>,
+        token: CancellationToken,
     ) -> impl Future<Output = Result<TcpTransport, StatusCode>> + Send + Sync;
 }

--- a/opcua-server/src/transport/mod.rs
+++ b/opcua-server/src/transport/mod.rs
@@ -1,1 +1,3 @@
+mod connect;
 pub mod tcp;
+pub use connect::Connector;

--- a/opcua-server/src/transport/tcp.rs
+++ b/opcua-server/src/transport/tcp.rs
@@ -12,20 +12,24 @@ use opcua_core::{
         message_chunk_info::ChunkInfo,
         secure_channel::SecureChannel,
         tcp_codec::{Message, TcpCodec},
-        tcp_types::{AcknowledgeMessage, ErrorMessage, HelloMessage},
+        tcp_types::{AcknowledgeMessage, ErrorMessage},
     },
     RequestMessage, ResponseMessage,
 };
 
 use crate::info::ServerInfo;
-use opcua_types::{DecodingOptions, EncodingError, ResponseHeader, ServiceFault, StatusCode};
+use opcua_types::{
+    BinaryEncoder, DecodingOptions, EncodingError, ResponseHeader, ServiceFault, StatusCode,
+};
 
 use futures::StreamExt;
 use tokio::{
-    io::{ReadHalf, WriteHalf},
+    io::{AsyncWriteExt, ReadHalf, WriteHalf},
     net::TcpStream,
 };
 use tokio_util::codec::FramedRead;
+
+use super::connect::Connector;
 
 /// Transport implementation for opc.tcp.
 pub(crate) struct TcpTransport {
@@ -38,12 +42,9 @@ pub(crate) struct TcpTransport {
     pub(crate) client_protocol_version: u32,
     /// Last decoded sequence number
     last_received_sequence_number: u32,
-    info: Arc<ServerInfo>,
-    receive_buffer_size: usize,
 }
 
 enum TransportState {
-    WaitingForHello(Instant),
     Running,
     Closing,
 }
@@ -70,7 +71,6 @@ pub(crate) enum TransportPollResult {
     OutgoingMessageSent,
     IncomingChunk,
     IncomingMessage(Request),
-    IncomingHello,
     Error(StatusCode),
     RecoverableError(StatusCode, u32, u32),
     Closed,
@@ -86,30 +86,158 @@ fn min_zero_infinite(server: u32, client: u32) -> u32 {
     }
 }
 
-impl TcpTransport {
+pub struct TcpConnector {
+    read: FramedRead<ReadHalf<TcpStream>, TcpCodec>,
+    write: WriteHalf<TcpStream>,
+    deadline: Instant,
+    config: TransportConfig,
+    decoding_options: DecodingOptions,
+}
+
+impl TcpConnector {
     pub fn new(
         stream: TcpStream,
         config: TransportConfig,
         decoding_options: DecodingOptions,
-        info: Arc<ServerInfo>,
     ) -> Self {
         let (read, write) = tokio::io::split(stream);
-        let read = FramedRead::new(read, TcpCodec::new(decoding_options));
+        let read = FramedRead::new(read, TcpCodec::new(decoding_options.clone()));
+        TcpConnector {
+            read,
+            write,
+            deadline: Instant::now() + config.hello_timeout,
+            config,
+            decoding_options,
+        }
+    }
 
+    async fn connect_inner(&mut self, info: Arc<ServerInfo>) -> Result<SendBuffer, ErrorMessage> {
+        let hello = match self.read.next().await {
+            Some(Ok(Message::Hello(hello))) => Ok(hello),
+            Some(Ok(bad_msg)) => Err(ErrorMessage::new(
+                StatusCode::BadCommunicationError,
+                &format!("Expected a hello message, got {:?} instead", bad_msg),
+            )),
+            Some(Err(communication_err)) => Err(ErrorMessage::new(
+                StatusCode::BadCommunicationError,
+                &format!(
+                    "Communication error while waiting for Hello message: {}",
+                    communication_err
+                ),
+            )),
+            None => Err(ErrorMessage::new(
+                StatusCode::BadCommunicationError,
+                "Stream closed",
+            )),
+        }?;
+
+        let mut buffer = SendBuffer::new(
+            self.config.send_buffer_size,
+            self.config.max_message_size,
+            self.config.max_chunk_count,
+        );
+
+        let endpoints = info.endpoints(&hello.endpoint_url, &None);
+
+        if !endpoints.is_some_and(|e| hello.is_endpoint_url_valid(&e)) {
+            return Err(ErrorMessage::new(
+                StatusCode::BadTcpEndpointUrlInvalid,
+                "HELLO endpoint url is invalid",
+            ));
+        }
+        if !hello.is_valid_buffer_sizes() {
+            return Err(ErrorMessage::new(
+                StatusCode::BadCommunicationError,
+                "HELLO buffer sizes are invalid",
+            ));
+        }
+
+        let server_protocol_version = 0;
+        // Validate protocol version
+        if hello.protocol_version > server_protocol_version {
+            return Err(ErrorMessage::new(
+                StatusCode::BadProtocolVersionUnsupported,
+                "Client protocol version is unsupported.",
+            ));
+        }
+
+        let decoding_options = &self.decoding_options;
+
+        // Send acknowledge
+        let acknowledge = AcknowledgeMessage::new(
+            server_protocol_version,
+            (self.config.receive_buffer_size as u32).min(hello.send_buffer_size),
+            (buffer.send_buffer_size as u32).min(hello.receive_buffer_size),
+            min_zero_infinite(
+                decoding_options.max_message_size as u32,
+                hello.max_message_size,
+            ),
+            min_zero_infinite(
+                decoding_options.max_chunk_count as u32,
+                hello.max_chunk_count,
+            ),
+        );
+        buffer.revise(
+            acknowledge.send_buffer_size as usize,
+            acknowledge.max_message_size as usize,
+            acknowledge.max_chunk_count as usize,
+        );
+
+        let mut buf = Vec::with_capacity(acknowledge.byte_len());
+        acknowledge
+            .encode(&mut buf)
+            .map_err(|e| ErrorMessage::new(e.into(), "Failed to encode ack"))?;
+
+        self.write.write_all(&buf).await.map_err(|e| {
+            ErrorMessage::new(
+                StatusCode::BadCommunicationError,
+                &format!("Failed to send ack: {e}"),
+            )
+        })?;
+
+        Ok(buffer)
+    }
+}
+
+impl Connector for TcpConnector {
+    async fn connect(mut self, info: Arc<ServerInfo>) -> Result<TcpTransport, StatusCode> {
+        let err = tokio::select! {
+            _ = tokio::time::sleep_until(self.deadline.into()) => {
+                ErrorMessage::new(StatusCode::BadTimeout, "Timeout waiting for HELLO")
+            }
+            r = self.connect_inner(info) => {
+                match r {
+                    Ok(r) => return Ok(TcpTransport::new(self.read, self.write, r)),
+                    Err(e) => e,
+                }
+            }
+        };
+
+        // We want to send an error if connection failed for whatever reason, but
+        // there's a good chance the channel is closed, so just ignore any errors.
+        let mut buf = Vec::with_capacity(err.byte_len());
+        if err.encode(&mut buf).is_ok() {
+            let _ = self.write.write_all(&buf).await;
+        }
+
+        Err(StatusCode::from(err.error))
+    }
+}
+
+impl TcpTransport {
+    pub fn new(
+        read: FramedRead<ReadHalf<TcpStream>, TcpCodec>,
+        write: WriteHalf<TcpStream>,
+        send_buffer: SendBuffer,
+    ) -> Self {
         Self {
             read,
             write,
-            send_buffer: SendBuffer::new(
-                config.send_buffer_size,
-                config.max_message_size,
-                config.max_chunk_count,
-            ),
-            state: TransportState::WaitingForHello(Instant::now() + config.hello_timeout),
+            state: TransportState::Running,
             pending_chunks: Vec::new(),
             last_received_sequence_number: 0,
             client_protocol_version: 0,
-            info,
-            receive_buffer_size: config.receive_buffer_size,
+            send_buffer,
         }
     }
 
@@ -156,83 +284,7 @@ impl TcpTransport {
         }
     }
 
-    fn process_hello(
-        &mut self,
-        channel: &mut SecureChannel,
-        hello: HelloMessage,
-    ) -> Result<(), StatusCode> {
-        let endpoints = self.info.endpoints(&hello.endpoint_url, &None);
-
-        if !endpoints.is_some_and(|e| hello.is_endpoint_url_valid(&e)) {
-            error!("HELLO endpoint url is invalid");
-            return Err(StatusCode::BadTcpEndpointUrlInvalid);
-        }
-        if !hello.is_valid_buffer_sizes() {
-            error!("HELLO buffer sizes are invalid");
-            return Err(StatusCode::BadCommunicationError);
-        }
-
-        let server_protocol_version = 0;
-        // Validate protocol version
-        if hello.protocol_version > server_protocol_version {
-            return Err(StatusCode::BadProtocolVersionUnsupported);
-        }
-
-        self.client_protocol_version = hello.protocol_version;
-
-        let decoding_options = channel.decoding_options();
-
-        // Send acknowledge
-        let acknowledge = AcknowledgeMessage::new(
-            server_protocol_version,
-            (self.receive_buffer_size as u32).min(hello.send_buffer_size),
-            (self.send_buffer.send_buffer_size as u32).min(hello.receive_buffer_size),
-            min_zero_infinite(
-                decoding_options.max_message_size as u32,
-                hello.max_message_size,
-            ),
-            min_zero_infinite(
-                decoding_options.max_chunk_count as u32,
-                hello.max_chunk_count,
-            ),
-        );
-        self.send_buffer.revise(
-            acknowledge.send_buffer_size as usize,
-            acknowledge.max_message_size as usize,
-            acknowledge.max_chunk_count as usize,
-        );
-
-        self.send_buffer.write_ack(acknowledge);
-
-        self.state = TransportState::Running;
-
-        Ok(())
-    }
-
     pub async fn poll(&mut self, channel: &mut SecureChannel) -> TransportPollResult {
-        // If we're waiting for hello, just do that. We're not sending anything until
-        // we get it.
-        if let TransportState::WaitingForHello(deadline) = &self.state {
-            return tokio::select! {
-                _ = tokio::time::sleep_until((*deadline).into()) => {
-                    TransportPollResult::Error(StatusCode::BadTimeout)
-                }
-                r = self.wait_for_hello() => {
-                    match r {
-                        Ok(h) => {
-                            match self.process_hello(channel, h) {
-                                Ok(()) => TransportPollResult::IncomingHello,
-                                Err(e) => TransportPollResult::Error(e)
-                            }
-                        }
-                        Err(e) => {
-                            TransportPollResult::Error(e)
-                        }
-                    }
-                }
-            };
-        }
-
         // Either we've got something in the send buffer, which we can send,
         // or we're waiting for more outgoing messages.
         // We won't wait for outgoing messages while sending, since that
@@ -268,24 +320,6 @@ impl TcpTransport {
             }
             let incoming = self.read.next().await;
             self.handle_incoming_message(incoming, channel)
-        }
-    }
-
-    async fn wait_for_hello(&mut self) -> Result<HelloMessage, StatusCode> {
-        match self.read.next().await {
-            Some(Ok(Message::Hello(hello))) => Ok(hello),
-            Some(Ok(bad_msg)) => {
-                log::error!("Expected a hello message, got {:?} instead", bad_msg);
-                Err(StatusCode::BadCommunicationError)
-            }
-            Some(Err(communication_err)) => {
-                error!(
-                    "Communication error while waiting for Hello message: {}",
-                    communication_err
-                );
-                Err(StatusCode::BadCommunicationError)
-            }
-            None => Err(StatusCode::BadConnectionClosed),
         }
     }
 

--- a/samples/simple-client/Cargo.toml
+++ b/samples/simple-client/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2021"
 [dependencies]
 pico-args = "0.5"
 tokio = { version = "1.36.0", features = ["full"] }
+log = { workspace = true }
 
 [dependencies.opcua]
 path = "../../lib"
 version = "0.13.0" # OPCUARustVersion
 features = ["client", "console-logging"]
+default-features = false

--- a/samples/simple-server/Cargo.toml
+++ b/samples/simple-server/Cargo.toml
@@ -13,3 +13,4 @@ tokio = { version = "1.38.0", features = ["full"] }
 path = "../../lib"
 version = "0.13.0" # OPCUARustVersion
 features = ["server", "console-logging"]
+default-features = false


### PR DESCRIPTION
Doing it this way allows us to implement reverse connect in the future. We're a lot more free to use generics in the server, since user provided code never interacts with the transport layer directly.

Technically this approach might be a little better performance wise, since we dropped a check. In practice it is negligible.