### PR TITLE
Foundation for allowing custom namespaces in types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "chrono",
+ "hashbrown 0.14.5",
  "lazy_static",
  "log",
  "opcua-macros",

--- a/opcua-codegen/src/types/gen.rs
+++ b/opcua-codegen/src/types/gen.rs
@@ -286,7 +286,7 @@ impl CodeGenerator {
 
         impls.push(parse_quote! {
             impl opcua::types::AsVariantRef for #enum_ident {
-                fn as_variant(&self) -> opcua::types::Variant {
+                fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
                     self.bits().into()
                 }
             }
@@ -501,7 +501,7 @@ impl CodeGenerator {
 
         impls.push(parse_quote! {
             impl opcua::types::AsVariantRef for #enum_ident {
-                fn as_variant(&self) -> opcua::types::Variant {
+                fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
                     (*self as #ty).into()
                 }
             }

--- a/opcua-server/src/node_manager/utils/mod.rs
+++ b/opcua-server/src/node_manager/utils/mod.rs
@@ -4,6 +4,6 @@ mod result;
 mod sync_sampler;
 
 pub use opaque_node_id::*;
-pub use operations::get_node_metadata;
+pub use operations::{get_namespaces_for_user, get_node_metadata};
 pub(crate) use result::{consume_results, IntoResult};
 pub use sync_sampler::SyncSampler;

--- a/opcua-server/src/node_manager/utils/operations.rs
+++ b/opcua-server/src/node_manager/utils/operations.rs
@@ -2,7 +2,8 @@ use crate::node_manager::{
     view::{ExternalReferenceRequest, NodeMetadata},
     NodeManagerCollection, RequestContext,
 };
-use opcua_types::{BrowseDescriptionResultMask, NodeId};
+use hashbrown::HashMap;
+use opcua_types::{BrowseDescriptionResultMask, NamespaceMap, NodeId};
 
 pub async fn get_node_metadata(
     context: &RequestContext,
@@ -23,4 +24,17 @@ pub async fn get_node_metadata(
     }
 
     reqs.into_iter().map(|r| r.into_inner()).collect()
+}
+
+pub fn get_namespaces_for_user(
+    context: &RequestContext,
+    node_managers: &impl NodeManagerCollection,
+) -> NamespaceMap {
+    let nss: HashMap<_, _> = node_managers
+        .iter_node_managers()
+        .flat_map(|n| n.namespaces_for_user(context))
+        .map(|ns| (ns.namespace_uri, ns.namespace_index))
+        .collect();
+
+    NamespaceMap::new_full(nss)
 }

--- a/opcua-server/src/session/controller.rs
+++ b/opcua-server/src/session/controller.rs
@@ -300,8 +300,13 @@ impl SessionController {
             }
 
             RequestMessage::ActivateSession(request) => {
-                let res =
-                    activate_session(&self.session_manager, &mut self.channel, &request).await;
+                let res = activate_session(
+                    &self.session_manager,
+                    &mut self.channel,
+                    &request,
+                    &mut self.message_handler,
+                )
+                .await;
                 self.process_service_result(res, request.request_header.request_handle, id)
             }
 

--- a/opcua-server/src/subscriptions/mod.rs
+++ b/opcua-server/src/subscriptions/mod.rs
@@ -207,6 +207,7 @@ impl SubscriptionCache {
                     self.limits,
                     Self::get_key(session),
                     session.clone(),
+                    session.read().context().clone(),
                 )))
             })
             .clone();
@@ -682,6 +683,7 @@ impl SubscriptionCache {
                         self.limits,
                         key.clone(),
                         session.clone(),
+                        session.read().context().clone(),
                     )))
                 })
                 .clone();

--- a/opcua-server/src/subscriptions/monitored_item.rs
+++ b/opcua-server/src/subscriptions/monitored_item.rs
@@ -6,10 +6,10 @@ use opcua_nodes::{Event, ParsedEventFilter, TypeTree};
 use super::MonitoredItemHandle;
 use crate::{info::ServerInfo, node_manager::ParsedReadValueId};
 use opcua_types::{
-    DataChangeFilter, DataValue, DateTime, DecodingOptions, EventFieldList, EventFilter,
-    EventFilterResult, ExtensionObject, MonitoredItemCreateRequest, MonitoredItemModifyRequest,
-    MonitoredItemNotification, MonitoringMode, NumericRange, ObjectId, StatusCode,
-    TimestampsToReturn, Variant,
+    DataChangeFilter, DataValue, DateTime, DecodingOptions, EncodingContext, EventFieldList,
+    EventFilter, EventFilterResult, ExtensionObject, MonitoredItemCreateRequest,
+    MonitoredItemModifyRequest, MonitoredItemNotification, MonitoringMode, NumericRange, ObjectId,
+    StatusCode, TimestampsToReturn, Variant,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -455,7 +455,7 @@ impl MonitoredItem {
         true
     }
 
-    pub(super) fn notify_event(&mut self, event: &dyn Event) -> bool {
+    pub(super) fn notify_event(&mut self, event: &dyn Event, ctx: &EncodingContext) -> bool {
         if self.monitoring_mode == MonitoringMode::Disabled {
             return false;
         }
@@ -464,7 +464,7 @@ impl MonitoredItem {
             return false;
         };
 
-        let Some(notif) = filter.evaluate(event, self.client_handle) else {
+        let Some(notif) = filter.evaluate(event, self.client_handle, ctx) else {
             return false;
         };
 

--- a/opcua-server/src/subscriptions/session_subscriptions.rs
+++ b/opcua-server/src/subscriptions/session_subscriptions.rs
@@ -21,11 +21,12 @@ use crate::{
 use opcua_core::sync::RwLock;
 use opcua_types::{
     AttributeId, CreateSubscriptionRequest, CreateSubscriptionResponse, DataValue, DateTime,
-    DateTimeUtc, ExtensionObject, ModifySubscriptionRequest, ModifySubscriptionResponse,
-    MonitoredItemCreateResult, MonitoredItemModifyRequest, MonitoredItemModifyResult,
-    MonitoringMode, NodeId, NotificationMessage, ObjectId, PublishRequest, PublishResponse,
-    RepublishRequest, RepublishResponse, ResponseHeader, ServiceFault, SetPublishingModeRequest,
-    SetPublishingModeResponse, StatusCode, TimestampsToReturn,
+    DateTimeUtc, EncodingContext, ExtensionObject, ModifySubscriptionRequest,
+    ModifySubscriptionResponse, MonitoredItemCreateResult, MonitoredItemModifyRequest,
+    MonitoredItemModifyResult, MonitoringMode, NodeId, NotificationMessage, ObjectId,
+    PublishRequest, PublishResponse, RepublishRequest, RepublishResponse, ResponseHeader,
+    ServiceFault, SetPublishingModeRequest, SetPublishingModeResponse, StatusCode,
+    TimestampsToReturn,
 };
 
 /// Subscriptions belonging to a single session. Note that they are technically _owned_ by
@@ -44,6 +45,8 @@ pub struct SessionSubscriptions {
 
     /// Static reference to the session owning this, required to cleanly handle deletion.
     session: Arc<RwLock<Session>>,
+    /// Reference to the namespace map for the session
+    context: Arc<EncodingContext>,
 }
 
 impl SessionSubscriptions {
@@ -51,6 +54,7 @@ impl SessionSubscriptions {
         limits: SubscriptionLimits,
         user_token: PersistentSessionKey,
         session: Arc<RwLock<Session>>,
+        context: Arc<EncodingContext>,
     ) -> Self {
         Self {
             user_token,
@@ -59,6 +63,7 @@ impl SessionSubscriptions {
             retransmission_queue: VecDeque::new(),
             limits,
             session,
+            context,
         }
     }
 
@@ -776,7 +781,7 @@ impl SessionSubscriptions {
             let Some(sub) = self.subscriptions.get_mut(&handle.subscription_id) else {
                 continue;
             };
-            sub.notify_event(&handle.monitored_item_id, event);
+            sub.notify_event(&handle.monitored_item_id, event, &self.context);
         }
     }
 

--- a/opcua-server/src/subscriptions/subscription.rs
+++ b/opcua-server/src/subscriptions/subscription.rs
@@ -6,7 +6,9 @@ use std::{
 use log::{debug, trace, warn};
 use opcua_core::handle::Handle;
 use opcua_nodes::Event;
-use opcua_types::{DataValue, DateTime, DateTimeUtc, NotificationMessage, StatusCode};
+use opcua_types::{
+    DataValue, DateTime, DateTimeUtc, EncodingContext, NotificationMessage, StatusCode,
+};
 
 use super::monitored_item::{MonitoredItem, Notification};
 
@@ -221,9 +223,9 @@ impl Subscription {
     }
 
     /// Notify the given monitored item of a new event.
-    pub fn notify_event(&mut self, id: &u32, event: &dyn Event) {
+    pub fn notify_event(&mut self, id: &u32, event: &dyn Event, ctx: &EncodingContext) {
         if let Some(item) = self.monitored_items.get_mut(id) {
-            if item.notify_event(event) {
+            if item.notify_event(event, ctx) {
                 self.notified_monitored_items.insert(*id);
             }
         }

--- a/opcua-types/Cargo.toml
+++ b/opcua-types/Cargo.toml
@@ -24,6 +24,7 @@ bitflags = { workspace = true }
 log = { workspace = true }
 regex = { workspace = true }
 lazy_static = { workspace = true }
+hashbrown = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 byteorder = { workspace = true }

--- a/opcua-types/src/namespaces.rs
+++ b/opcua-types/src/namespaces.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 /// Utility for handling assignment of namespaces on server startup.
 #[derive(Debug, Default, Clone)]
@@ -12,6 +12,12 @@ impl NamespaceMap {
         known_namespaces.insert("http://opcfoundation.org/UA/".to_owned(), 0u16);
 
         Self { known_namespaces }
+    }
+
+    pub fn new_full(map: HashMap<String, u16>) -> Self {
+        Self {
+            known_namespaces: map,
+        }
     }
 
     pub fn add_namespace(&mut self, namespace: &str) -> u16 {

--- a/opcua-types/src/service_types/enums.rs
+++ b/opcua-types/src/service_types/enums.rs
@@ -6,7 +6,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
-mod opcua { pub use crate as types; }bitflags::bitflags! {
+mod opcua {
+    pub use crate as types;
+}
+bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct AccessLevelExType : i32 { const
     None = 0i32; const CurrentRead = 1i32; const CurrentWrite = 2i32; const HistoryRead =
     4i32; const HistoryWrite = 8i32; const SemanticChange = 16i32; const StatusWrite =
@@ -18,17 +21,17 @@ impl opcua::types::BinaryEncoder for AccessLevelExType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(i32::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(i32::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for AccessLevelExType {
@@ -42,7 +45,7 @@ impl From<AccessLevelExType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for AccessLevelExType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -65,10 +68,7 @@ impl<'de> serde::de::Deserialize<'de> for AccessLevelExType {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an i32")
             }
         }
@@ -99,17 +99,17 @@ impl opcua::types::BinaryEncoder for AccessLevelType {
     fn byte_len(&self) -> usize {
         1usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_u8(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(u8::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(u8::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for AccessLevelType {
@@ -123,7 +123,7 @@ impl From<AccessLevelType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for AccessLevelType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -146,10 +146,7 @@ impl<'de> serde::de::Deserialize<'de> for AccessLevelType {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = u8;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an u8")
             }
         }
@@ -179,17 +176,17 @@ impl opcua::types::BinaryEncoder for AccessRestrictionType {
     fn byte_len(&self) -> usize {
         2usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i16(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(i16::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(i16::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for AccessRestrictionType {
@@ -203,7 +200,7 @@ impl From<AccessRestrictionType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for AccessRestrictionType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -226,10 +223,7 @@ impl<'de> serde::de::Deserialize<'de> for AccessRestrictionType {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = i16;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an i16")
             }
         }
@@ -261,18 +255,16 @@ pub enum ApplicationType {
 impl TryFrom<i32> for ApplicationType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Server,
-                1i32 => Self::Client,
-                2i32 => Self::ClientAndServer,
-                3i32 => Self::DiscoveryServer,
-                r => {
-                    log::error!("Got unexpected value for enum ApplicationType: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Server,
+            1i32 => Self::Client,
+            2i32 => Self::ClientAndServer,
+            3i32 => Self::DiscoveryServer,
+            r => {
+                log::error!("Got unexpected value for enum ApplicationType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -282,12 +274,8 @@ impl opcua::types::xml::FromXml for ApplicationType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum ApplicationType: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum ApplicationType: {}", e))?)
     }
 }
 impl From<ApplicationType> for i32 {
@@ -301,7 +289,7 @@ impl From<ApplicationType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for ApplicationType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -315,18 +303,13 @@ impl<'de> serde::de::Deserialize<'de> for ApplicationType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -345,10 +328,7 @@ impl opcua::types::BinaryEncoder for ApplicationType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -376,17 +356,17 @@ impl opcua::types::BinaryEncoder for AttributeWriteMask {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(i32::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(i32::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for AttributeWriteMask {
@@ -400,7 +380,7 @@ impl From<AttributeWriteMask> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for AttributeWriteMask {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -423,10 +403,7 @@ impl<'de> serde::de::Deserialize<'de> for AttributeWriteMask {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an i32")
             }
         }
@@ -457,19 +434,15 @@ pub enum AxisScaleEnumeration {
 impl TryFrom<i32> for AxisScaleEnumeration {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Linear,
-                1i32 => Self::Log,
-                2i32 => Self::Ln,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum AxisScaleEnumeration: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Linear,
+            1i32 => Self::Log,
+            2i32 => Self::Ln,
+            r => {
+                log::error!("Got unexpected value for enum AxisScaleEnumeration: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -479,12 +452,8 @@ impl opcua::types::xml::FromXml for AxisScaleEnumeration {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum AxisScaleEnumeration: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum AxisScaleEnumeration: {}", e))?)
     }
 }
 impl From<AxisScaleEnumeration> for i32 {
@@ -498,7 +467,7 @@ impl From<AxisScaleEnumeration> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for AxisScaleEnumeration {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -512,18 +481,13 @@ impl<'de> serde::de::Deserialize<'de> for AxisScaleEnumeration {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -542,10 +506,7 @@ impl opcua::types::BinaryEncoder for AxisScaleEnumeration {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -568,22 +529,20 @@ pub enum BrokerTransportQualityOfService {
 impl TryFrom<i32> for BrokerTransportQualityOfService {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::NotSpecified,
-                1i32 => Self::BestEffort,
-                2i32 => Self::AtLeastOnce,
-                3i32 => Self::AtMostOnce,
-                4i32 => Self::ExactlyOnce,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum BrokerTransportQualityOfService: {}",
-                        r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::NotSpecified,
+            1i32 => Self::BestEffort,
+            2i32 => Self::AtLeastOnce,
+            3i32 => Self::AtMostOnce,
+            4i32 => Self::ExactlyOnce,
+            r => {
+                log::error!(
+                    "Got unexpected value for enum BrokerTransportQualityOfService: {}",
+                    r
+                );
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -593,15 +552,12 @@ impl opcua::types::xml::FromXml for BrokerTransportQualityOfService {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!(
-                        "Got unexpected value for enum BrokerTransportQualityOfService: {}",
-                        e
-                    )
-                })?,
-        )
+        Ok(Self::try_from(val).map_err(|e| {
+            format!(
+                "Got unexpected value for enum BrokerTransportQualityOfService: {}",
+                e
+            )
+        })?)
     }
 }
 impl From<BrokerTransportQualityOfService> for i32 {
@@ -615,7 +571,7 @@ impl From<BrokerTransportQualityOfService> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for BrokerTransportQualityOfService {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -629,18 +585,13 @@ impl<'de> serde::de::Deserialize<'de> for BrokerTransportQualityOfService {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -659,10 +610,7 @@ impl opcua::types::BinaryEncoder for BrokerTransportQualityOfService {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -684,21 +632,19 @@ pub enum BrowseDirection {
 impl TryFrom<i32> for BrowseDirection {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Forward,
-                1i32 => Self::Inverse,
-                2i32 => Self::Both,
-                3i32 => Self::Invalid,
-                r => {
-                    log::warn!(
-                        "Got unexpected value for enum BrowseDirection: {}. Falling back on Invalid",
-                        r
-                    );
-                    Self::Invalid
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Forward,
+            1i32 => Self::Inverse,
+            2i32 => Self::Both,
+            3i32 => Self::Invalid,
+            r => {
+                log::warn!(
+                    "Got unexpected value for enum BrowseDirection: {}. Falling back on Invalid",
+                    r
+                );
+                Self::Invalid
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -708,12 +654,8 @@ impl opcua::types::xml::FromXml for BrowseDirection {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum BrowseDirection: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum BrowseDirection: {}", e))?)
     }
 }
 impl From<BrowseDirection> for i32 {
@@ -727,7 +669,7 @@ impl From<BrowseDirection> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for BrowseDirection {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -741,18 +683,13 @@ impl<'de> serde::de::Deserialize<'de> for BrowseDirection {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -771,10 +708,7 @@ impl opcua::types::BinaryEncoder for BrowseDirection {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -802,24 +736,22 @@ pub enum BrowseResultMask {
 impl TryFrom<i32> for BrowseResultMask {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::None,
-                1i32 => Self::ReferenceTypeId,
-                2i32 => Self::IsForward,
-                4i32 => Self::NodeClass,
-                8i32 => Self::BrowseName,
-                16i32 => Self::DisplayName,
-                32i32 => Self::TypeDefinition,
-                63i32 => Self::All,
-                3i32 => Self::ReferenceTypeInfo,
-                60i32 => Self::TargetInfo,
-                r => {
-                    log::error!("Got unexpected value for enum BrowseResultMask: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::None,
+            1i32 => Self::ReferenceTypeId,
+            2i32 => Self::IsForward,
+            4i32 => Self::NodeClass,
+            8i32 => Self::BrowseName,
+            16i32 => Self::DisplayName,
+            32i32 => Self::TypeDefinition,
+            63i32 => Self::All,
+            3i32 => Self::ReferenceTypeInfo,
+            60i32 => Self::TargetInfo,
+            r => {
+                log::error!("Got unexpected value for enum BrowseResultMask: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -829,12 +761,8 @@ impl opcua::types::xml::FromXml for BrowseResultMask {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum BrowseResultMask: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum BrowseResultMask: {}", e))?)
     }
 }
 impl From<BrowseResultMask> for i32 {
@@ -848,7 +776,7 @@ impl From<BrowseResultMask> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for BrowseResultMask {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -862,18 +790,13 @@ impl<'de> serde::de::Deserialize<'de> for BrowseResultMask {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -892,10 +815,7 @@ impl opcua::types::BinaryEncoder for BrowseResultMask {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -916,19 +836,15 @@ pub enum DataChangeTrigger {
 impl TryFrom<i32> for DataChangeTrigger {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Status,
-                1i32 => Self::StatusValue,
-                2i32 => Self::StatusValueTimestamp,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum DataChangeTrigger: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Status,
+            1i32 => Self::StatusValue,
+            2i32 => Self::StatusValueTimestamp,
+            r => {
+                log::error!("Got unexpected value for enum DataChangeTrigger: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -938,12 +854,8 @@ impl opcua::types::xml::FromXml for DataChangeTrigger {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum DataChangeTrigger: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum DataChangeTrigger: {}", e))?)
     }
 }
 impl From<DataChangeTrigger> for i32 {
@@ -957,7 +869,7 @@ impl From<DataChangeTrigger> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for DataChangeTrigger {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -971,18 +883,13 @@ impl<'de> serde::de::Deserialize<'de> for DataChangeTrigger {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -1001,10 +908,7 @@ impl opcua::types::BinaryEncoder for DataChangeTrigger {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -1025,17 +929,17 @@ impl opcua::types::BinaryEncoder for DataSetFieldContentMask {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(i32::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(i32::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for DataSetFieldContentMask {
@@ -1049,7 +953,7 @@ impl From<DataSetFieldContentMask> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for DataSetFieldContentMask {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -1072,10 +976,7 @@ impl<'de> serde::de::Deserialize<'de> for DataSetFieldContentMask {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an i32")
             }
         }
@@ -1104,17 +1005,17 @@ impl opcua::types::BinaryEncoder for DataSetFieldFlags {
     fn byte_len(&self) -> usize {
         2usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i16(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(i16::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(i16::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for DataSetFieldFlags {
@@ -1128,7 +1029,7 @@ impl From<DataSetFieldFlags> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for DataSetFieldFlags {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -1151,10 +1052,7 @@ impl<'de> serde::de::Deserialize<'de> for DataSetFieldFlags {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = i16;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an i16")
             }
         }
@@ -1185,19 +1083,15 @@ pub enum DataSetOrderingType {
 impl TryFrom<i32> for DataSetOrderingType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Undefined,
-                1i32 => Self::AscendingWriterId,
-                2i32 => Self::AscendingWriterIdSingle,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum DataSetOrderingType: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Undefined,
+            1i32 => Self::AscendingWriterId,
+            2i32 => Self::AscendingWriterIdSingle,
+            r => {
+                log::error!("Got unexpected value for enum DataSetOrderingType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -1207,12 +1101,8 @@ impl opcua::types::xml::FromXml for DataSetOrderingType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum DataSetOrderingType: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum DataSetOrderingType: {}", e))?)
     }
 }
 impl From<DataSetOrderingType> for i32 {
@@ -1226,7 +1116,7 @@ impl From<DataSetOrderingType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for DataSetOrderingType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -1240,18 +1130,13 @@ impl<'de> serde::de::Deserialize<'de> for DataSetOrderingType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -1270,10 +1155,7 @@ impl opcua::types::BinaryEncoder for DataSetOrderingType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -1294,17 +1176,15 @@ pub enum DeadbandType {
 impl TryFrom<i32> for DeadbandType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::None,
-                1i32 => Self::Absolute,
-                2i32 => Self::Percent,
-                r => {
-                    log::error!("Got unexpected value for enum DeadbandType: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::None,
+            1i32 => Self::Absolute,
+            2i32 => Self::Percent,
+            r => {
+                log::error!("Got unexpected value for enum DeadbandType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -1314,12 +1194,8 @@ impl opcua::types::xml::FromXml for DeadbandType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum DeadbandType: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum DeadbandType: {}", e))?)
     }
 }
 impl From<DeadbandType> for i32 {
@@ -1333,7 +1209,7 @@ impl From<DeadbandType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for DeadbandType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -1347,18 +1223,13 @@ impl<'de> serde::de::Deserialize<'de> for DeadbandType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -1377,10 +1248,7 @@ impl opcua::types::BinaryEncoder for DeadbandType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -1403,19 +1271,17 @@ pub enum DiagnosticsLevel {
 impl TryFrom<i32> for DiagnosticsLevel {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Basic,
-                1i32 => Self::Advanced,
-                2i32 => Self::Info,
-                3i32 => Self::Log,
-                4i32 => Self::Debug,
-                r => {
-                    log::error!("Got unexpected value for enum DiagnosticsLevel: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Basic,
+            1i32 => Self::Advanced,
+            2i32 => Self::Info,
+            3i32 => Self::Log,
+            4i32 => Self::Debug,
+            r => {
+                log::error!("Got unexpected value for enum DiagnosticsLevel: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -1425,12 +1291,8 @@ impl opcua::types::xml::FromXml for DiagnosticsLevel {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum DiagnosticsLevel: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum DiagnosticsLevel: {}", e))?)
     }
 }
 impl From<DiagnosticsLevel> for i32 {
@@ -1444,7 +1306,7 @@ impl From<DiagnosticsLevel> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for DiagnosticsLevel {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -1458,18 +1320,13 @@ impl<'de> serde::de::Deserialize<'de> for DiagnosticsLevel {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -1488,10 +1345,7 @@ impl opcua::types::BinaryEncoder for DiagnosticsLevel {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -1511,17 +1365,17 @@ impl opcua::types::BinaryEncoder for EventNotifierType {
     fn byte_len(&self) -> usize {
         1usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_u8(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(u8::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(u8::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for EventNotifierType {
@@ -1535,7 +1389,7 @@ impl From<EventNotifierType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for EventNotifierType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -1558,10 +1412,7 @@ impl<'de> serde::de::Deserialize<'de> for EventNotifierType {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = u8;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an u8")
             }
         }
@@ -1594,21 +1445,20 @@ pub enum ExceptionDeviationFormat {
 impl TryFrom<i32> for ExceptionDeviationFormat {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::AbsoluteValue,
-                1i32 => Self::PercentOfValue,
-                2i32 => Self::PercentOfRange,
-                3i32 => Self::PercentOfEURange,
-                4i32 => Self::Unknown,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum ExceptionDeviationFormat: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::AbsoluteValue,
+            1i32 => Self::PercentOfValue,
+            2i32 => Self::PercentOfRange,
+            3i32 => Self::PercentOfEURange,
+            4i32 => Self::Unknown,
+            r => {
+                log::error!(
+                    "Got unexpected value for enum ExceptionDeviationFormat: {}",
+                    r
+                );
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -1618,14 +1468,12 @@ impl opcua::types::xml::FromXml for ExceptionDeviationFormat {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!(
-                        "Got unexpected value for enum ExceptionDeviationFormat: {}", e
-                    )
-                })?,
-        )
+        Ok(Self::try_from(val).map_err(|e| {
+            format!(
+                "Got unexpected value for enum ExceptionDeviationFormat: {}",
+                e
+            )
+        })?)
     }
 }
 impl From<ExceptionDeviationFormat> for i32 {
@@ -1639,7 +1487,7 @@ impl From<ExceptionDeviationFormat> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for ExceptionDeviationFormat {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -1653,18 +1501,13 @@ impl<'de> serde::de::Deserialize<'de> for ExceptionDeviationFormat {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -1683,10 +1526,7 @@ impl opcua::types::BinaryEncoder for ExceptionDeviationFormat {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -1722,32 +1562,30 @@ pub enum FilterOperator {
 impl TryFrom<i32> for FilterOperator {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Equals,
-                1i32 => Self::IsNull,
-                2i32 => Self::GreaterThan,
-                3i32 => Self::LessThan,
-                4i32 => Self::GreaterThanOrEqual,
-                5i32 => Self::LessThanOrEqual,
-                6i32 => Self::Like,
-                7i32 => Self::Not,
-                8i32 => Self::Between,
-                9i32 => Self::InList,
-                10i32 => Self::And,
-                11i32 => Self::Or,
-                12i32 => Self::Cast,
-                13i32 => Self::InView,
-                14i32 => Self::OfType,
-                15i32 => Self::RelatedTo,
-                16i32 => Self::BitwiseAnd,
-                17i32 => Self::BitwiseOr,
-                r => {
-                    log::error!("Got unexpected value for enum FilterOperator: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Equals,
+            1i32 => Self::IsNull,
+            2i32 => Self::GreaterThan,
+            3i32 => Self::LessThan,
+            4i32 => Self::GreaterThanOrEqual,
+            5i32 => Self::LessThanOrEqual,
+            6i32 => Self::Like,
+            7i32 => Self::Not,
+            8i32 => Self::Between,
+            9i32 => Self::InList,
+            10i32 => Self::And,
+            11i32 => Self::Or,
+            12i32 => Self::Cast,
+            13i32 => Self::InView,
+            14i32 => Self::OfType,
+            15i32 => Self::RelatedTo,
+            16i32 => Self::BitwiseAnd,
+            17i32 => Self::BitwiseOr,
+            r => {
+                log::error!("Got unexpected value for enum FilterOperator: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -1757,12 +1595,8 @@ impl opcua::types::xml::FromXml for FilterOperator {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum FilterOperator: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum FilterOperator: {}", e))?)
     }
 }
 impl From<FilterOperator> for i32 {
@@ -1776,7 +1610,7 @@ impl From<FilterOperator> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for FilterOperator {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -1790,18 +1624,13 @@ impl<'de> serde::de::Deserialize<'de> for FilterOperator {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -1820,10 +1649,7 @@ impl opcua::types::BinaryEncoder for FilterOperator {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -1845,20 +1671,16 @@ pub enum HistoryUpdateType {
 impl TryFrom<i32> for HistoryUpdateType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                1i32 => Self::Insert,
-                2i32 => Self::Replace,
-                3i32 => Self::Update,
-                4i32 => Self::Delete,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum HistoryUpdateType: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            1i32 => Self::Insert,
+            2i32 => Self::Replace,
+            3i32 => Self::Update,
+            4i32 => Self::Delete,
+            r => {
+                log::error!("Got unexpected value for enum HistoryUpdateType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -1868,12 +1690,8 @@ impl opcua::types::xml::FromXml for HistoryUpdateType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum HistoryUpdateType: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum HistoryUpdateType: {}", e))?)
     }
 }
 impl From<HistoryUpdateType> for i32 {
@@ -1887,7 +1705,7 @@ impl From<HistoryUpdateType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for HistoryUpdateType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -1901,18 +1719,13 @@ impl<'de> serde::de::Deserialize<'de> for HistoryUpdateType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -1931,10 +1744,7 @@ impl opcua::types::BinaryEncoder for HistoryUpdateType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -1958,22 +1768,18 @@ pub enum IdentityCriteriaType {
 impl TryFrom<i32> for IdentityCriteriaType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                1i32 => Self::UserName,
-                2i32 => Self::Thumbprint,
-                3i32 => Self::Role,
-                4i32 => Self::GroupId,
-                5i32 => Self::Anonymous,
-                6i32 => Self::AuthenticatedUser,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum IdentityCriteriaType: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            1i32 => Self::UserName,
+            2i32 => Self::Thumbprint,
+            3i32 => Self::Role,
+            4i32 => Self::GroupId,
+            5i32 => Self::Anonymous,
+            6i32 => Self::AuthenticatedUser,
+            r => {
+                log::error!("Got unexpected value for enum IdentityCriteriaType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -1983,12 +1789,8 @@ impl opcua::types::xml::FromXml for IdentityCriteriaType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum IdentityCriteriaType: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum IdentityCriteriaType: {}", e))?)
     }
 }
 impl From<IdentityCriteriaType> for i32 {
@@ -2002,7 +1804,7 @@ impl From<IdentityCriteriaType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for IdentityCriteriaType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -2016,18 +1818,13 @@ impl<'de> serde::de::Deserialize<'de> for IdentityCriteriaType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -2046,10 +1843,7 @@ impl opcua::types::BinaryEncoder for IdentityCriteriaType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -2071,18 +1865,16 @@ pub enum IdType {
 impl TryFrom<i32> for IdType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Numeric,
-                1i32 => Self::String,
-                2i32 => Self::Guid,
-                3i32 => Self::Opaque,
-                r => {
-                    log::error!("Got unexpected value for enum IdType: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Numeric,
+            1i32 => Self::String,
+            2i32 => Self::Guid,
+            3i32 => Self::Opaque,
+            r => {
+                log::error!("Got unexpected value for enum IdType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -2092,10 +1884,8 @@ impl opcua::types::xml::FromXml for IdType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| format!("Got unexpected value for enum IdType: {}", e))?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum IdType: {}", e))?)
     }
 }
 impl From<IdType> for i32 {
@@ -2109,7 +1899,7 @@ impl From<IdType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for IdType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -2123,18 +1913,13 @@ impl<'de> serde::de::Deserialize<'de> for IdType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -2153,10 +1938,7 @@ impl opcua::types::BinaryEncoder for IdType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -2176,17 +1958,17 @@ impl opcua::types::BinaryEncoder for JsonDataSetMessageContentMask {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(i32::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(i32::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for JsonDataSetMessageContentMask {
@@ -2200,7 +1982,7 @@ impl From<JsonDataSetMessageContentMask> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for JsonDataSetMessageContentMask {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -2223,10 +2005,7 @@ impl<'de> serde::de::Deserialize<'de> for JsonDataSetMessageContentMask {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an i32")
             }
         }
@@ -2257,17 +2036,17 @@ impl opcua::types::BinaryEncoder for JsonNetworkMessageContentMask {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(i32::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(i32::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for JsonNetworkMessageContentMask {
@@ -2281,7 +2060,7 @@ impl From<JsonNetworkMessageContentMask> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for JsonNetworkMessageContentMask {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -2304,10 +2083,7 @@ impl<'de> serde::de::Deserialize<'de> for JsonNetworkMessageContentMask {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an i32")
             }
         }
@@ -2339,21 +2115,19 @@ pub enum MessageSecurityMode {
 impl TryFrom<i32> for MessageSecurityMode {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Invalid,
-                1i32 => Self::None,
-                2i32 => Self::Sign,
-                3i32 => Self::SignAndEncrypt,
-                r => {
-                    log::warn!(
+        Ok(match value {
+            0i32 => Self::Invalid,
+            1i32 => Self::None,
+            2i32 => Self::Sign,
+            3i32 => Self::SignAndEncrypt,
+            r => {
+                log::warn!(
                         "Got unexpected value for enum MessageSecurityMode: {}. Falling back on Invalid",
                         r
                     );
-                    Self::Invalid
-                }
-            },
-        )
+                Self::Invalid
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -2363,12 +2137,8 @@ impl opcua::types::xml::FromXml for MessageSecurityMode {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum MessageSecurityMode: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum MessageSecurityMode: {}", e))?)
     }
 }
 impl From<MessageSecurityMode> for i32 {
@@ -2382,7 +2152,7 @@ impl From<MessageSecurityMode> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for MessageSecurityMode {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -2396,18 +2166,13 @@ impl<'de> serde::de::Deserialize<'de> for MessageSecurityMode {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -2426,10 +2191,7 @@ impl opcua::types::BinaryEncoder for MessageSecurityMode {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -2452,22 +2214,20 @@ pub enum ModelChangeStructureVerbMask {
 impl TryFrom<i32> for ModelChangeStructureVerbMask {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                1i32 => Self::NodeAdded,
-                2i32 => Self::NodeDeleted,
-                4i32 => Self::ReferenceAdded,
-                8i32 => Self::ReferenceDeleted,
-                16i32 => Self::DataTypeChanged,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum ModelChangeStructureVerbMask: {}",
-                        r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            1i32 => Self::NodeAdded,
+            2i32 => Self::NodeDeleted,
+            4i32 => Self::ReferenceAdded,
+            8i32 => Self::ReferenceDeleted,
+            16i32 => Self::DataTypeChanged,
+            r => {
+                log::error!(
+                    "Got unexpected value for enum ModelChangeStructureVerbMask: {}",
+                    r
+                );
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -2477,15 +2237,12 @@ impl opcua::types::xml::FromXml for ModelChangeStructureVerbMask {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!(
-                        "Got unexpected value for enum ModelChangeStructureVerbMask: {}",
-                        e
-                    )
-                })?,
-        )
+        Ok(Self::try_from(val).map_err(|e| {
+            format!(
+                "Got unexpected value for enum ModelChangeStructureVerbMask: {}",
+                e
+            )
+        })?)
     }
 }
 impl From<ModelChangeStructureVerbMask> for i32 {
@@ -2499,7 +2256,7 @@ impl From<ModelChangeStructureVerbMask> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for ModelChangeStructureVerbMask {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -2513,18 +2270,13 @@ impl<'de> serde::de::Deserialize<'de> for ModelChangeStructureVerbMask {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -2543,10 +2295,7 @@ impl opcua::types::BinaryEncoder for ModelChangeStructureVerbMask {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -2567,17 +2316,15 @@ pub enum MonitoringMode {
 impl TryFrom<i32> for MonitoringMode {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Disabled,
-                1i32 => Self::Sampling,
-                2i32 => Self::Reporting,
-                r => {
-                    log::error!("Got unexpected value for enum MonitoringMode: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Disabled,
+            1i32 => Self::Sampling,
+            2i32 => Self::Reporting,
+            r => {
+                log::error!("Got unexpected value for enum MonitoringMode: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -2587,12 +2334,8 @@ impl opcua::types::xml::FromXml for MonitoringMode {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum MonitoringMode: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum MonitoringMode: {}", e))?)
     }
 }
 impl From<MonitoringMode> for i32 {
@@ -2606,7 +2349,7 @@ impl From<MonitoringMode> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for MonitoringMode {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -2620,18 +2363,13 @@ impl<'de> serde::de::Deserialize<'de> for MonitoringMode {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -2650,10 +2388,7 @@ impl opcua::types::BinaryEncoder for MonitoringMode {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -2674,17 +2409,15 @@ pub enum NamingRuleType {
 impl TryFrom<i32> for NamingRuleType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                1i32 => Self::Mandatory,
-                2i32 => Self::Optional,
-                3i32 => Self::Constraint,
-                r => {
-                    log::error!("Got unexpected value for enum NamingRuleType: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            1i32 => Self::Mandatory,
+            2i32 => Self::Optional,
+            3i32 => Self::Constraint,
+            r => {
+                log::error!("Got unexpected value for enum NamingRuleType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -2694,12 +2427,8 @@ impl opcua::types::xml::FromXml for NamingRuleType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum NamingRuleType: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum NamingRuleType: {}", e))?)
     }
 }
 impl From<NamingRuleType> for i32 {
@@ -2713,7 +2442,7 @@ impl From<NamingRuleType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for NamingRuleType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -2727,18 +2456,13 @@ impl<'de> serde::de::Deserialize<'de> for NamingRuleType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -2757,10 +2481,7 @@ impl opcua::types::BinaryEncoder for NamingRuleType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -2813,51 +2534,47 @@ pub enum NodeAttributesMask {
 impl TryFrom<i32> for NodeAttributesMask {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::None,
-                1i32 => Self::AccessLevel,
-                2i32 => Self::ArrayDimensions,
-                4i32 => Self::BrowseName,
-                8i32 => Self::ContainsNoLoops,
-                16i32 => Self::DataType,
-                32i32 => Self::Description,
-                64i32 => Self::DisplayName,
-                128i32 => Self::EventNotifier,
-                256i32 => Self::Executable,
-                512i32 => Self::Historizing,
-                1024i32 => Self::InverseName,
-                2048i32 => Self::IsAbstract,
-                4096i32 => Self::MinimumSamplingInterval,
-                8192i32 => Self::NodeClass,
-                16384i32 => Self::NodeId,
-                32768i32 => Self::Symmetric,
-                65536i32 => Self::UserAccessLevel,
-                131072i32 => Self::UserExecutable,
-                262144i32 => Self::UserWriteMask,
-                524288i32 => Self::ValueRank,
-                1048576i32 => Self::WriteMask,
-                2097152i32 => Self::Value,
-                4194304i32 => Self::DataTypeDefinition,
-                8388608i32 => Self::RolePermissions,
-                16777216i32 => Self::AccessRestrictions,
-                33554431i32 => Self::All,
-                26501220i32 => Self::BaseNode,
-                26501348i32 => Self::Object,
-                26503268i32 => Self::ObjectType,
-                26571383i32 => Self::Variable,
-                28600438i32 => Self::VariableType,
-                26632548i32 => Self::Method,
-                26537060i32 => Self::ReferenceType,
-                26501356i32 => Self::View,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum NodeAttributesMask: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::None,
+            1i32 => Self::AccessLevel,
+            2i32 => Self::ArrayDimensions,
+            4i32 => Self::BrowseName,
+            8i32 => Self::ContainsNoLoops,
+            16i32 => Self::DataType,
+            32i32 => Self::Description,
+            64i32 => Self::DisplayName,
+            128i32 => Self::EventNotifier,
+            256i32 => Self::Executable,
+            512i32 => Self::Historizing,
+            1024i32 => Self::InverseName,
+            2048i32 => Self::IsAbstract,
+            4096i32 => Self::MinimumSamplingInterval,
+            8192i32 => Self::NodeClass,
+            16384i32 => Self::NodeId,
+            32768i32 => Self::Symmetric,
+            65536i32 => Self::UserAccessLevel,
+            131072i32 => Self::UserExecutable,
+            262144i32 => Self::UserWriteMask,
+            524288i32 => Self::ValueRank,
+            1048576i32 => Self::WriteMask,
+            2097152i32 => Self::Value,
+            4194304i32 => Self::DataTypeDefinition,
+            8388608i32 => Self::RolePermissions,
+            16777216i32 => Self::AccessRestrictions,
+            33554431i32 => Self::All,
+            26501220i32 => Self::BaseNode,
+            26501348i32 => Self::Object,
+            26503268i32 => Self::ObjectType,
+            26571383i32 => Self::Variable,
+            28600438i32 => Self::VariableType,
+            26632548i32 => Self::Method,
+            26537060i32 => Self::ReferenceType,
+            26501356i32 => Self::View,
+            r => {
+                log::error!("Got unexpected value for enum NodeAttributesMask: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -2867,12 +2584,8 @@ impl opcua::types::xml::FromXml for NodeAttributesMask {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum NodeAttributesMask: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum NodeAttributesMask: {}", e))?)
     }
 }
 impl From<NodeAttributesMask> for i32 {
@@ -2886,7 +2599,7 @@ impl From<NodeAttributesMask> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for NodeAttributesMask {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -2900,18 +2613,13 @@ impl<'de> serde::de::Deserialize<'de> for NodeAttributesMask {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -2930,10 +2638,7 @@ impl opcua::types::BinaryEncoder for NodeAttributesMask {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -2960,23 +2665,21 @@ pub enum NodeClass {
 impl TryFrom<i32> for NodeClass {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Unspecified,
-                1i32 => Self::Object,
-                2i32 => Self::Variable,
-                4i32 => Self::Method,
-                8i32 => Self::ObjectType,
-                16i32 => Self::VariableType,
-                32i32 => Self::ReferenceType,
-                64i32 => Self::DataType,
-                128i32 => Self::View,
-                r => {
-                    log::error!("Got unexpected value for enum NodeClass: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Unspecified,
+            1i32 => Self::Object,
+            2i32 => Self::Variable,
+            4i32 => Self::Method,
+            8i32 => Self::ObjectType,
+            16i32 => Self::VariableType,
+            32i32 => Self::ReferenceType,
+            64i32 => Self::DataType,
+            128i32 => Self::View,
+            r => {
+                log::error!("Got unexpected value for enum NodeClass: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -2986,10 +2689,8 @@ impl opcua::types::xml::FromXml for NodeClass {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| format!("Got unexpected value for enum NodeClass: {}", e))?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum NodeClass: {}", e))?)
     }
 }
 impl From<NodeClass> for i32 {
@@ -3003,7 +2704,7 @@ impl From<NodeClass> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for NodeClass {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -3017,18 +2718,13 @@ impl<'de> serde::de::Deserialize<'de> for NodeClass {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -3047,10 +2743,7 @@ impl opcua::types::BinaryEncoder for NodeClass {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -3075,20 +2768,18 @@ pub enum NodeIdType {
 impl TryFrom<u8> for NodeIdType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: u8) -> Result<Self, <Self as TryFrom<u8>>::Error> {
-        Ok(
-            match value {
-                0u8 => Self::TwoByte,
-                1u8 => Self::FourByte,
-                2u8 => Self::Numeric,
-                3u8 => Self::String,
-                4u8 => Self::Guid,
-                5u8 => Self::ByteString,
-                r => {
-                    log::error!("Got unexpected value for enum NodeIdType: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0u8 => Self::TwoByte,
+            1u8 => Self::FourByte,
+            2u8 => Self::Numeric,
+            3u8 => Self::String,
+            4u8 => Self::Guid,
+            5u8 => Self::ByteString,
+            r => {
+                log::error!("Got unexpected value for enum NodeIdType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -3098,10 +2789,8 @@ impl opcua::types::xml::FromXml for NodeIdType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = u8::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| format!("Got unexpected value for enum NodeIdType: {}", e))?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum NodeIdType: {}", e))?)
     }
 }
 impl From<NodeIdType> for u8 {
@@ -3115,7 +2804,7 @@ impl From<NodeIdType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for NodeIdType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as u8).into()
     }
 }
@@ -3129,18 +2818,13 @@ impl<'de> serde::de::Deserialize<'de> for NodeIdType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = u8;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "u8")
             }
         }
         let value = deserializer.deserialize_u8(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "u8", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "u8", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -3159,10 +2843,7 @@ impl opcua::types::BinaryEncoder for NodeIdType {
     fn byte_len(&self) -> usize {
         1usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_u8(stream, *self as u8)
     }
     fn decode<S: std::io::Read>(
@@ -3184,18 +2865,16 @@ pub enum OpenFileMode {
 impl TryFrom<i32> for OpenFileMode {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                1i32 => Self::Read,
-                2i32 => Self::Write,
-                4i32 => Self::EraseExisting,
-                8i32 => Self::Append,
-                r => {
-                    log::error!("Got unexpected value for enum OpenFileMode: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            1i32 => Self::Read,
+            2i32 => Self::Write,
+            4i32 => Self::EraseExisting,
+            8i32 => Self::Append,
+            r => {
+                log::error!("Got unexpected value for enum OpenFileMode: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -3205,12 +2884,8 @@ impl opcua::types::xml::FromXml for OpenFileMode {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum OpenFileMode: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum OpenFileMode: {}", e))?)
     }
 }
 impl From<OpenFileMode> for i32 {
@@ -3224,7 +2899,7 @@ impl From<OpenFileMode> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for OpenFileMode {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -3238,18 +2913,13 @@ impl<'de> serde::de::Deserialize<'de> for OpenFileMode {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -3268,10 +2938,7 @@ impl opcua::types::BinaryEncoder for OpenFileMode {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -3292,19 +2959,15 @@ pub enum OverrideValueHandling {
 impl TryFrom<i32> for OverrideValueHandling {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Disabled,
-                1i32 => Self::LastUsableValue,
-                2i32 => Self::OverrideValue,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum OverrideValueHandling: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Disabled,
+            1i32 => Self::LastUsableValue,
+            2i32 => Self::OverrideValue,
+            r => {
+                log::error!("Got unexpected value for enum OverrideValueHandling: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -3314,12 +2977,8 @@ impl opcua::types::xml::FromXml for OverrideValueHandling {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum OverrideValueHandling: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum OverrideValueHandling: {}", e))?)
     }
 }
 impl From<OverrideValueHandling> for i32 {
@@ -3333,7 +2992,7 @@ impl From<OverrideValueHandling> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for OverrideValueHandling {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -3347,18 +3006,13 @@ impl<'de> serde::de::Deserialize<'de> for OverrideValueHandling {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -3377,10 +3031,7 @@ impl opcua::types::BinaryEncoder for OverrideValueHandling {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -3402,20 +3053,16 @@ pub enum PerformUpdateType {
 impl TryFrom<i32> for PerformUpdateType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                1i32 => Self::Insert,
-                2i32 => Self::Replace,
-                3i32 => Self::Update,
-                4i32 => Self::Remove,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum PerformUpdateType: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            1i32 => Self::Insert,
+            2i32 => Self::Replace,
+            3i32 => Self::Update,
+            4i32 => Self::Remove,
+            r => {
+                log::error!("Got unexpected value for enum PerformUpdateType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -3425,12 +3072,8 @@ impl opcua::types::xml::FromXml for PerformUpdateType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum PerformUpdateType: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum PerformUpdateType: {}", e))?)
     }
 }
 impl From<PerformUpdateType> for i32 {
@@ -3444,7 +3087,7 @@ impl From<PerformUpdateType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for PerformUpdateType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -3458,18 +3101,13 @@ impl<'de> serde::de::Deserialize<'de> for PerformUpdateType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -3488,10 +3126,7 @@ impl opcua::types::BinaryEncoder for PerformUpdateType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -3515,17 +3150,17 @@ impl opcua::types::BinaryEncoder for PermissionType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(i32::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(i32::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for PermissionType {
@@ -3539,7 +3174,7 @@ impl From<PermissionType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for PermissionType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -3562,10 +3197,7 @@ impl<'de> serde::de::Deserialize<'de> for PermissionType {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an i32")
             }
         }
@@ -3595,19 +3227,17 @@ pub enum PubSubDiagnosticsCounterClassification {
 impl TryFrom<i32> for PubSubDiagnosticsCounterClassification {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Information,
-                1i32 => Self::Error,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum PubSubDiagnosticsCounterClassification: {}",
-                        r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Information,
+            1i32 => Self::Error,
+            r => {
+                log::error!(
+                    "Got unexpected value for enum PubSubDiagnosticsCounterClassification: {}",
+                    r
+                );
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -3617,15 +3247,12 @@ impl opcua::types::xml::FromXml for PubSubDiagnosticsCounterClassification {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!(
-                        "Got unexpected value for enum PubSubDiagnosticsCounterClassification: {}",
-                        e
-                    )
-                })?,
-        )
+        Ok(Self::try_from(val).map_err(|e| {
+            format!(
+                "Got unexpected value for enum PubSubDiagnosticsCounterClassification: {}",
+                e
+            )
+        })?)
     }
 }
 impl From<PubSubDiagnosticsCounterClassification> for i32 {
@@ -3639,7 +3266,7 @@ impl From<PubSubDiagnosticsCounterClassification> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for PubSubDiagnosticsCounterClassification {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -3653,18 +3280,13 @@ impl<'de> serde::de::Deserialize<'de> for PubSubDiagnosticsCounterClassification
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -3683,10 +3305,7 @@ impl opcua::types::BinaryEncoder for PubSubDiagnosticsCounterClassification {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -3708,18 +3327,16 @@ pub enum PubSubState {
 impl TryFrom<i32> for PubSubState {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Disabled,
-                1i32 => Self::Paused,
-                2i32 => Self::Operational,
-                3i32 => Self::Error,
-                r => {
-                    log::error!("Got unexpected value for enum PubSubState: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Disabled,
+            1i32 => Self::Paused,
+            2i32 => Self::Operational,
+            3i32 => Self::Error,
+            r => {
+                log::error!("Got unexpected value for enum PubSubState: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -3729,12 +3346,8 @@ impl opcua::types::xml::FromXml for PubSubState {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum PubSubState: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum PubSubState: {}", e))?)
     }
 }
 impl From<PubSubState> for i32 {
@@ -3748,7 +3361,7 @@ impl From<PubSubState> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for PubSubState {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -3762,18 +3375,13 @@ impl<'de> serde::de::Deserialize<'de> for PubSubState {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -3792,10 +3400,7 @@ impl opcua::types::BinaryEncoder for PubSubState {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -3819,22 +3424,18 @@ pub enum RedundancySupport {
 impl TryFrom<i32> for RedundancySupport {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::None,
-                1i32 => Self::Cold,
-                2i32 => Self::Warm,
-                3i32 => Self::Hot,
-                4i32 => Self::Transparent,
-                5i32 => Self::HotAndMirrored,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum RedundancySupport: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::None,
+            1i32 => Self::Cold,
+            2i32 => Self::Warm,
+            3i32 => Self::Hot,
+            4i32 => Self::Transparent,
+            5i32 => Self::HotAndMirrored,
+            r => {
+                log::error!("Got unexpected value for enum RedundancySupport: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -3844,12 +3445,8 @@ impl opcua::types::xml::FromXml for RedundancySupport {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum RedundancySupport: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum RedundancySupport: {}", e))?)
     }
 }
 impl From<RedundancySupport> for i32 {
@@ -3863,7 +3460,7 @@ impl From<RedundancySupport> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for RedundancySupport {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -3877,18 +3474,13 @@ impl<'de> serde::de::Deserialize<'de> for RedundancySupport {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -3907,10 +3499,7 @@ impl opcua::types::BinaryEncoder for RedundancySupport {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -3930,18 +3519,17 @@ pub enum SecurityTokenRequestType {
 impl TryFrom<i32> for SecurityTokenRequestType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Issue,
-                1i32 => Self::Renew,
-                r => {
-                    log::error!(
-                        "Got unexpected value for enum SecurityTokenRequestType: {}", r
-                    );
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Issue,
+            1i32 => Self::Renew,
+            r => {
+                log::error!(
+                    "Got unexpected value for enum SecurityTokenRequestType: {}",
+                    r
+                );
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -3951,14 +3539,12 @@ impl opcua::types::xml::FromXml for SecurityTokenRequestType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!(
-                        "Got unexpected value for enum SecurityTokenRequestType: {}", e
-                    )
-                })?,
-        )
+        Ok(Self::try_from(val).map_err(|e| {
+            format!(
+                "Got unexpected value for enum SecurityTokenRequestType: {}",
+                e
+            )
+        })?)
     }
 }
 impl From<SecurityTokenRequestType> for i32 {
@@ -3972,7 +3558,7 @@ impl From<SecurityTokenRequestType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for SecurityTokenRequestType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -3986,18 +3572,13 @@ impl<'de> serde::de::Deserialize<'de> for SecurityTokenRequestType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -4016,10 +3597,7 @@ impl opcua::types::BinaryEncoder for SecurityTokenRequestType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -4045,22 +3623,20 @@ pub enum ServerState {
 impl TryFrom<i32> for ServerState {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Running,
-                1i32 => Self::Failed,
-                2i32 => Self::NoConfiguration,
-                3i32 => Self::Suspended,
-                4i32 => Self::Shutdown,
-                5i32 => Self::Test,
-                6i32 => Self::CommunicationFault,
-                7i32 => Self::Unknown,
-                r => {
-                    log::error!("Got unexpected value for enum ServerState: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Running,
+            1i32 => Self::Failed,
+            2i32 => Self::NoConfiguration,
+            3i32 => Self::Suspended,
+            4i32 => Self::Shutdown,
+            5i32 => Self::Test,
+            6i32 => Self::CommunicationFault,
+            7i32 => Self::Unknown,
+            r => {
+                log::error!("Got unexpected value for enum ServerState: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -4070,12 +3646,8 @@ impl opcua::types::xml::FromXml for ServerState {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum ServerState: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum ServerState: {}", e))?)
     }
 }
 impl From<ServerState> for i32 {
@@ -4089,7 +3661,7 @@ impl From<ServerState> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for ServerState {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -4103,18 +3675,13 @@ impl<'de> serde::de::Deserialize<'de> for ServerState {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -4133,10 +3700,7 @@ impl opcua::types::BinaryEncoder for ServerState {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -4157,17 +3721,15 @@ pub enum StructureType {
 impl TryFrom<i32> for StructureType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Structure,
-                1i32 => Self::StructureWithOptionalFields,
-                2i32 => Self::Union,
-                r => {
-                    log::error!("Got unexpected value for enum StructureType: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Structure,
+            1i32 => Self::StructureWithOptionalFields,
+            2i32 => Self::Union,
+            r => {
+                log::error!("Got unexpected value for enum StructureType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -4177,12 +3739,8 @@ impl opcua::types::xml::FromXml for StructureType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum StructureType: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum StructureType: {}", e))?)
     }
 }
 impl From<StructureType> for i32 {
@@ -4196,7 +3754,7 @@ impl From<StructureType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for StructureType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -4210,18 +3768,13 @@ impl<'de> serde::de::Deserialize<'de> for StructureType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -4240,10 +3793,7 @@ impl opcua::types::BinaryEncoder for StructureType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -4266,22 +3816,20 @@ pub enum TimestampsToReturn {
 impl TryFrom<i32> for TimestampsToReturn {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Source,
-                1i32 => Self::Server,
-                2i32 => Self::Both,
-                3i32 => Self::Neither,
-                4i32 => Self::Invalid,
-                r => {
-                    log::warn!(
-                        "Got unexpected value for enum TimestampsToReturn: {}. Falling back on Invalid",
-                        r
-                    );
-                    Self::Invalid
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Source,
+            1i32 => Self::Server,
+            2i32 => Self::Both,
+            3i32 => Self::Neither,
+            4i32 => Self::Invalid,
+            r => {
+                log::warn!(
+                    "Got unexpected value for enum TimestampsToReturn: {}. Falling back on Invalid",
+                    r
+                );
+                Self::Invalid
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -4291,12 +3839,8 @@ impl opcua::types::xml::FromXml for TimestampsToReturn {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum TimestampsToReturn: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum TimestampsToReturn: {}", e))?)
     }
 }
 impl From<TimestampsToReturn> for i32 {
@@ -4310,7 +3854,7 @@ impl From<TimestampsToReturn> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for TimestampsToReturn {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -4324,18 +3868,13 @@ impl<'de> serde::de::Deserialize<'de> for TimestampsToReturn {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -4354,10 +3893,7 @@ impl opcua::types::BinaryEncoder for TimestampsToReturn {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -4381,20 +3917,18 @@ pub enum TrustListMasks {
 impl TryFrom<i32> for TrustListMasks {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::None,
-                1i32 => Self::TrustedCertificates,
-                2i32 => Self::TrustedCrls,
-                4i32 => Self::IssuerCertificates,
-                8i32 => Self::IssuerCrls,
-                15i32 => Self::All,
-                r => {
-                    log::error!("Got unexpected value for enum TrustListMasks: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::None,
+            1i32 => Self::TrustedCertificates,
+            2i32 => Self::TrustedCrls,
+            4i32 => Self::IssuerCertificates,
+            8i32 => Self::IssuerCrls,
+            15i32 => Self::All,
+            r => {
+                log::error!("Got unexpected value for enum TrustListMasks: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -4404,12 +3938,8 @@ impl opcua::types::xml::FromXml for TrustListMasks {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum TrustListMasks: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum TrustListMasks: {}", e))?)
     }
 }
 impl From<TrustListMasks> for i32 {
@@ -4423,7 +3953,7 @@ impl From<TrustListMasks> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for TrustListMasks {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -4437,18 +3967,13 @@ impl<'de> serde::de::Deserialize<'de> for TrustListMasks {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -4467,10 +3992,7 @@ impl opcua::types::BinaryEncoder for TrustListMasks {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(
@@ -4491,17 +4013,17 @@ impl opcua::types::BinaryEncoder for UadpDataSetMessageContentMask {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(i32::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(i32::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for UadpDataSetMessageContentMask {
@@ -4515,7 +4037,7 @@ impl From<UadpDataSetMessageContentMask> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for UadpDataSetMessageContentMask {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -4538,10 +4060,7 @@ impl<'de> serde::de::Deserialize<'de> for UadpDataSetMessageContentMask {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an i32")
             }
         }
@@ -4574,17 +4093,17 @@ impl opcua::types::BinaryEncoder for UadpNetworkMessageContentMask {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, self.bits())
     }
     fn decode<S: std::io::Read>(
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        Ok(Self::from_bits_truncate(i32::decode(stream, decoding_options)?))
+        Ok(Self::from_bits_truncate(i32::decode(
+            stream,
+            decoding_options,
+        )?))
     }
 }
 impl Default for UadpNetworkMessageContentMask {
@@ -4598,7 +4117,7 @@ impl From<UadpNetworkMessageContentMask> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for UadpNetworkMessageContentMask {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         self.bits().into()
     }
 }
@@ -4621,10 +4140,7 @@ impl<'de> serde::de::Deserialize<'de> for UadpNetworkMessageContentMask {
         struct BitFieldVisitor;
         impl<'de> serde::de::Visitor<'de> for BitFieldVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "an i32")
             }
         }
@@ -4656,18 +4172,16 @@ pub enum UserTokenType {
 impl TryFrom<i32> for UserTokenType {
     type Error = opcua::types::StatusCode;
     fn try_from(value: i32) -> Result<Self, <Self as TryFrom<i32>>::Error> {
-        Ok(
-            match value {
-                0i32 => Self::Anonymous,
-                1i32 => Self::UserName,
-                2i32 => Self::Certificate,
-                3i32 => Self::IssuedToken,
-                r => {
-                    log::error!("Got unexpected value for enum UserTokenType: {}", r);
-                    return Err(opcua::types::StatusCode::BadUnexpectedError);
-                }
-            },
-        )
+        Ok(match value {
+            0i32 => Self::Anonymous,
+            1i32 => Self::UserName,
+            2i32 => Self::Certificate,
+            3i32 => Self::IssuedToken,
+            r => {
+                log::error!("Got unexpected value for enum UserTokenType: {}", r);
+                return Err(opcua::types::StatusCode::BadUnexpectedError);
+            }
+        })
     }
 }
 #[cfg(feature = "xml")]
@@ -4677,12 +4191,8 @@ impl opcua::types::xml::FromXml for UserTokenType {
         ctx: &opcua::types::xml::XmlContext<'a>,
     ) -> Result<Self, opcua::types::xml::FromXmlError> {
         let val = i32::from_xml(element, ctx)?;
-        Ok(
-            Self::try_from(val)
-                .map_err(|e| {
-                    format!("Got unexpected value for enum UserTokenType: {}", e)
-                })?,
-        )
+        Ok(Self::try_from(val)
+            .map_err(|e| format!("Got unexpected value for enum UserTokenType: {}", e))?)
     }
 }
 impl From<UserTokenType> for i32 {
@@ -4696,7 +4206,7 @@ impl From<UserTokenType> for opcua::types::Variant {
     }
 }
 impl opcua::types::AsVariantRef for UserTokenType {
-    fn as_variant(&self) -> opcua::types::Variant {
+    fn as_variant(&self, _ctx: &opcua::types::EncodingContext) -> opcua::types::Variant {
         (*self as i32).into()
     }
 }
@@ -4710,18 +4220,13 @@ impl<'de> serde::de::Deserialize<'de> for UserTokenType {
         use serde::de::Error;
         impl<'de> serde::de::Visitor<'de> for EnumVisitor {
             type Value = i32;
-            fn expecting(
-                &self,
-                formatter: &mut core::fmt::Formatter,
-            ) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(formatter, "i32")
             }
         }
         let value = deserializer.deserialize_i32(EnumVisitor)?;
         Self::try_from(value)
-            .map_err(|e| D::Error::custom(
-                &format!("Failed to deserialize {}: {:?}", "i32", e),
-            ))
+            .map_err(|e| D::Error::custom(&format!("Failed to deserialize {}: {:?}", "i32", e)))
     }
 }
 #[cfg(feature = "json")]
@@ -4740,10 +4245,7 @@ impl opcua::types::BinaryEncoder for UserTokenType {
     fn byte_len(&self) -> usize {
         4usize
     }
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         opcua::types::write_i32(stream, *self as i32)
     }
     fn decode<S: std::io::Read>(

--- a/opcua-types/src/service_types/mod.rs
+++ b/opcua-types/src/service_types/mod.rs
@@ -591,16 +591,52 @@ impl opcua::types::xml::XmlLoader for TypesXmlLoader {
         };
         Some(
             match object_id {
-                opcua::types::ObjectId::BrowseResult_Encoding_DefaultXml => {
-                    BrowseResult::from_xml(body, ctx)
+                opcua::types::ObjectId::ViewAttributes_Encoding_DefaultXml => {
+                    ViewAttributes::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ModifyMonitoredItemsRequest_Encoding_DefaultXml => {
-                    ModifyMonitoredItemsRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::PublishedEventsDataType_Encoding_DefaultXml => {
+                    PublishedEventsDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::SetMonitoringModeRequest_Encoding_DefaultXml => {
-                    SetMonitoringModeRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::UadpDataSetWriterMessageDataType_Encoding_DefaultXml => {
+                    UadpDataSetWriterMessageDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::PublishRequest_Encoding_DefaultXml => {
+                    PublishRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrowsePathResult_Encoding_DefaultXml => {
+                    BrowsePathResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::HistoryUpdateResponse_Encoding_DefaultXml => {
+                    HistoryUpdateResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ReaderGroupDataType_Encoding_DefaultXml => {
+                    ReaderGroupDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CancelResponse_Encoding_DefaultXml => {
+                    CancelResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SetPublishingModeRequest_Encoding_DefaultXml => {
+                    SetPublishingModeRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::PublishedVariableDataType_Encoding_DefaultXml => {
+                    PublishedVariableDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ServerOnNetwork_Encoding_DefaultXml => {
+                    ServerOnNetwork::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::MonitoringFilterResult_Encoding_DefaultXml => {
+                    MonitoringFilterResult::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::BrowseResponse_Encoding_DefaultXml => {
@@ -611,288 +647,652 @@ impl opcua::types::xml::XmlLoader for TypesXmlLoader {
                     DeleteNodesResponse::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::HistoryEvent_Encoding_DefaultXml => {
-                    HistoryEvent::from_xml(body, ctx)
+                opcua::types::ObjectId::FindServersOnNetworkRequest_Encoding_DefaultXml => {
+                    FindServersOnNetworkRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::RegisterServer2Response_Encoding_DefaultXml => {
-                    RegisterServer2Response::from_xml(body, ctx)
+                opcua::types::ObjectId::RegisterServerRequest_Encoding_DefaultXml => {
+                    RegisterServerRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::EventFilterResult_Encoding_DefaultXml => {
-                    EventFilterResult::from_xml(body, ctx)
+                opcua::types::ObjectId::RelativePathElement_Encoding_DefaultXml => {
+                    RelativePathElement::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::CreateSessionRequest_Encoding_DefaultXml => {
-                    CreateSessionRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::QueryDataSet_Encoding_DefaultXml => {
-                    QueryDataSet::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SubscribedDataSetMirrorDataType_Encoding_DefaultXml => {
-                    SubscribedDataSetMirrorDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CloseSecureChannelResponse_Encoding_DefaultXml => {
-                    CloseSecureChannelResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::BrokerDataSetWriterTransportDataType_Encoding_DefaultXml => {
-                    BrokerDataSetWriterTransportDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::HistoryData_Encoding_DefaultXml => {
-                    HistoryData::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::BrowsePath_Encoding_DefaultXml => {
-                    BrowsePath::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::GenericAttributes_Encoding_DefaultXml => {
-                    GenericAttributes::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::FindServersRequest_Encoding_DefaultXml => {
-                    FindServersRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::SetMonitoringModeRequest_Encoding_DefaultXml => {
+                    SetMonitoringModeRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::PublishedDataSetSourceDataType_Encoding_DefaultXml => {
                     PublishedDataSetSourceDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ReadAtTimeDetails_Encoding_DefaultXml => {
-                    ReadAtTimeDetails::from_xml(body, ctx)
+                opcua::types::ObjectId::NotificationMessage_Encoding_DefaultXml => {
+                    NotificationMessage::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ObjectAttributes_Encoding_DefaultXml => {
-                    ObjectAttributes::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::RationalNumber_Encoding_DefaultXml => {
-                    RationalNumber::from_xml(body, ctx)
+                opcua::types::ObjectId::EUInformation_Encoding_DefaultXml => {
+                    EUInformation::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::BuildInfo_Encoding_DefaultXml => {
                     BuildInfo::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::HistoryUpdateDetails_Encoding_DefaultXml => {
-                    HistoryUpdateDetails::from_xml(body, ctx)
+                opcua::types::ObjectId::DeleteSubscriptionsRequest_Encoding_DefaultXml => {
+                    DeleteSubscriptionsRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::UserNameIdentityToken_Encoding_DefaultXml => {
-                    UserNameIdentityToken::from_xml(body, ctx)
+                opcua::types::ObjectId::ReadResponse_Encoding_DefaultXml => {
+                    ReadResponse::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::DeleteReferencesResponse_Encoding_DefaultXml => {
-                    DeleteReferencesResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::EnumValueType_Encoding_DefaultXml => {
+                    EnumValueType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ActivateSessionResponse_Encoding_DefaultXml => {
-                    ActivateSessionResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::ParsingResult_Encoding_DefaultXml => {
+                    ParsingResult::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::CreateSessionResponse_Encoding_DefaultXml => {
-                    CreateSessionResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::ActivateSessionRequest_Encoding_DefaultXml => {
+                    ActivateSessionRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::RelativePath_Encoding_DefaultXml => {
-                    RelativePath::from_xml(body, ctx)
+                opcua::types::ObjectId::MonitoredItemCreateRequest_Encoding_DefaultXml => {
+                    MonitoredItemCreateRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::TranslateBrowsePathsToNodeIdsResponse_Encoding_DefaultXml => {
-                    TranslateBrowsePathsToNodeIdsResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::AddReferencesItem_Encoding_DefaultXml => {
+                    AddReferencesItem::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ThreeDVector_Encoding_DefaultXml => {
-                    ThreeDVector::from_xml(body, ctx)
+                opcua::types::ObjectId::AddNodesResult_Encoding_DefaultXml => {
+                    AddNodesResult::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::JsonDataSetWriterMessageDataType_Encoding_DefaultXml => {
-                    JsonDataSetWriterMessageDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::SimpleTypeDescription_Encoding_DefaultXml => {
+                    SimpleTypeDescription::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::DeleteEventDetails_Encoding_DefaultXml => {
-                    DeleteEventDetails::from_xml(body, ctx)
+                opcua::types::ObjectId::CancelRequest_Encoding_DefaultXml => {
+                    CancelRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::DeleteNodesRequest_Encoding_DefaultXml => {
-                    DeleteNodesRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::StatusChangeNotification_Encoding_DefaultXml => {
+                    StatusChangeNotification::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::DataTypeSchemaHeader_Encoding_DefaultXml => {
-                    DataTypeSchemaHeader::from_xml(body, ctx)
+                opcua::types::ObjectId::AddNodesItem_Encoding_DefaultXml => {
+                    AddNodesItem::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ContentFilter_Encoding_DefaultXml => {
-                    ContentFilter::from_xml(body, ctx)
+                opcua::types::ObjectId::RegisterServer2Request_Encoding_DefaultXml => {
+                    RegisterServer2Request::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::FilterOperand_Encoding_DefaultXml => {
-                    FilterOperand::from_xml(body, ctx)
+                opcua::types::ObjectId::BrowsePathTarget_Encoding_DefaultXml => {
+                    BrowsePathTarget::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::OpenSecureChannelResponse_Encoding_DefaultXml => {
-                    OpenSecureChannelResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::WriteResponse_Encoding_DefaultXml => {
+                    WriteResponse::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::AnonymousIdentityToken_Encoding_DefaultXml => {
-                    AnonymousIdentityToken::from_xml(body, ctx)
+                opcua::types::ObjectId::RepublishResponse_Encoding_DefaultXml => {
+                    RepublishResponse::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::BrowseDescription_Encoding_DefaultXml => {
-                    BrowseDescription::from_xml(body, ctx)
+                opcua::types::ObjectId::WriterGroupDataType_Encoding_DefaultXml => {
+                    WriterGroupDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::UnregisterNodesResponse_Encoding_DefaultXml => {
-                    UnregisterNodesResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::GetEndpointsRequest_Encoding_DefaultXml => {
+                    GetEndpointsRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ReadValueId_Encoding_DefaultXml => {
-                    ReadValueId::from_xml(body, ctx)
+                opcua::types::ObjectId::CallMethodRequest_Encoding_DefaultXml => {
+                    CallMethodRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::BrokerDataSetReaderTransportDataType_Encoding_DefaultXml => {
-                    BrokerDataSetReaderTransportDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::ComplexNumberType_Encoding_DefaultXml => {
+                    ComplexNumberType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::AddReferencesRequest_Encoding_DefaultXml => {
-                    AddReferencesRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::ThreeDCartesianCoordinates_Encoding_DefaultXml => {
+                    ThreeDCartesianCoordinates::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::TranslateBrowsePathsToNodeIdsRequest_Encoding_DefaultXml => {
-                    TranslateBrowsePathsToNodeIdsRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::ChannelSecurityToken_Encoding_DefaultXml => {
+                    ChannelSecurityToken::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::TrustListDataType_Encoding_DefaultXml => {
-                    TrustListDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::ConnectionTransportDataType_Encoding_DefaultXml => {
+                    ConnectionTransportDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ModelChangeStructureDataType_Encoding_DefaultXml => {
-                    ModelChangeStructureDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::FindServersRequest_Encoding_DefaultXml => {
+                    FindServersRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::TransferResult_Encoding_DefaultXml => {
-                    TransferResult::from_xml(body, ctx)
+                opcua::types::ObjectId::SetTriggeringResponse_Encoding_DefaultXml => {
+                    SetTriggeringResponse::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::NetworkAddressUrlDataType_Encoding_DefaultXml => {
-                    NetworkAddressUrlDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::SimpleAttributeOperand_Encoding_DefaultXml => {
+                    SimpleAttributeOperand::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::HistoryUpdateResponse_Encoding_DefaultXml => {
-                    HistoryUpdateResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::HistoryModifiedData_Encoding_DefaultXml => {
+                    HistoryModifiedData::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::CallRequest_Encoding_DefaultXml => {
-                    CallRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::DataSetReaderMessageDataType_Encoding_DefaultXml => {
+                    DataSetReaderMessageDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::DataSetReaderTransportDataType_Encoding_DefaultXml => {
-                    DataSetReaderTransportDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::XVType_Encoding_DefaultXml => {
+                    XVType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::WriterGroupMessageDataType_Encoding_DefaultXml => {
-                    WriterGroupMessageDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::EphemeralKeyType_Encoding_DefaultXml => {
+                    EphemeralKeyType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::NodeReference_Encoding_DefaultXml => {
-                    NodeReference::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DeleteRawModifiedDetails_Encoding_DefaultXml => {
-                    DeleteRawModifiedDetails::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ContentFilterElementResult_Encoding_DefaultXml => {
-                    ContentFilterElementResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SubscribedDataSetDataType_Encoding_DefaultXml => {
-                    SubscribedDataSetDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::KeyValuePair_Encoding_DefaultXml => {
-                    KeyValuePair::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CloseSessionRequest_Encoding_DefaultXml => {
-                    CloseSessionRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::Annotation_Encoding_DefaultXml => {
-                    Annotation::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SetTriggeringRequest_Encoding_DefaultXml => {
-                    SetTriggeringRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::EndpointDescription_Encoding_DefaultXml => {
-                    EndpointDescription::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ReaderGroupMessageDataType_Encoding_DefaultXml => {
-                    ReaderGroupMessageDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::HistoryUpdateRequest_Encoding_DefaultXml => {
-                    HistoryUpdateRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::GenericAttributeValue_Encoding_DefaultXml => {
-                    GenericAttributeValue::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ServiceCounterDataType_Encoding_DefaultXml => {
-                    ServiceCounterDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::UserTokenPolicy_Encoding_DefaultXml => {
-                    UserTokenPolicy::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SignatureData_Encoding_DefaultXml => {
-                    SignatureData::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::TransferSubscriptionsResponse_Encoding_DefaultXml => {
-                    TransferSubscriptionsResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::ObjectTypeAttributes_Encoding_DefaultXml => {
+                    ObjectTypeAttributes::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::QueryDataDescription_Encoding_DefaultXml => {
                     QueryDataDescription::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::UadpDataSetWriterMessageDataType_Encoding_DefaultXml => {
-                    UadpDataSetWriterMessageDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::ModifySubscriptionResponse_Encoding_DefaultXml => {
+                    ModifySubscriptionResponse::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::EventNotificationList_Encoding_DefaultXml => {
-                    EventNotificationList::from_xml(body, ctx)
+                opcua::types::ObjectId::DataSetMetaDataType_Encoding_DefaultXml => {
+                    DataSetMetaDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::GetEndpointsResponse_Encoding_DefaultXml => {
-                    GetEndpointsResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::FieldTargetDataType_Encoding_DefaultXml => {
+                    FieldTargetDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ApplicationDescription_Encoding_DefaultXml => {
+                    ApplicationDescription::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::WriterGroupTransportDataType_Encoding_DefaultXml => {
+                    WriterGroupTransportDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::PubSubConfigurationDataType_Encoding_DefaultXml => {
+                    PubSubConfigurationDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::Annotation_Encoding_DefaultXml => {
+                    Annotation::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::CurrencyUnitType_Encoding_DefaultXml => {
                     CurrencyUnitType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::PublishedDataSetDataType_Encoding_DefaultXml => {
-                    PublishedDataSetDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::ModelChangeStructureDataType_Encoding_DefaultXml => {
+                    ModelChangeStructureDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::QueryNextRequest_Encoding_DefaultXml => {
+                    QueryNextRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ModifySubscriptionRequest_Encoding_DefaultXml => {
+                    ModifySubscriptionRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DecimalDataType_Encoding_DefaultXml => {
+                    DecimalDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SetMonitoringModeResponse_Encoding_DefaultXml => {
+                    SetMonitoringModeResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DiscoveryConfiguration_Encoding_DefaultXml => {
+                    DiscoveryConfiguration::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::EndpointConfiguration_Encoding_DefaultXml => {
+                    EndpointConfiguration::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::HistoryReadRequest_Encoding_DefaultXml => {
+                    HistoryReadRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DeleteMonitoredItemsResponse_Encoding_DefaultXml => {
+                    DeleteMonitoredItemsResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::QueryFirstResponse_Encoding_DefaultXml => {
+                    QueryFirstResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DataSetReaderTransportDataType_Encoding_DefaultXml => {
+                    DataSetReaderTransportDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::RelativePath_Encoding_DefaultXml => {
+                    RelativePath::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::Argument_Encoding_DefaultXml => {
+                    Argument::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::Vector_Encoding_DefaultXml => {
+                    Vector::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ThreeDVector_Encoding_DefaultXml => {
+                    ThreeDVector::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::OpenSecureChannelRequest_Encoding_DefaultXml => {
+                    OpenSecureChannelRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::StructureDescription_Encoding_DefaultXml => {
+                    StructureDescription::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ServiceFault_Encoding_DefaultXml => {
+                    ServiceFault::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ServerDiagnosticsSummaryDataType_Encoding_DefaultXml => {
+                    ServerDiagnosticsSummaryDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ModifyMonitoredItemsRequest_Encoding_DefaultXml => {
+                    ModifyMonitoredItemsRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ContentFilterElementResult_Encoding_DefaultXml => {
+                    ContentFilterElementResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ActivateSessionResponse_Encoding_DefaultXml => {
+                    ActivateSessionResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ProgramDiagnosticDataType_Encoding_DefaultXml => {
+                    ProgramDiagnosticDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SubscribedDataSetMirrorDataType_Encoding_DefaultXml => {
+                    SubscribedDataSetMirrorDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DoubleComplexNumberType_Encoding_DefaultXml => {
+                    DoubleComplexNumberType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::TrustListDataType_Encoding_DefaultXml => {
+                    TrustListDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrokerWriterGroupTransportDataType_Encoding_DefaultXml => {
+                    BrokerWriterGroupTransportDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ProgramDiagnostic2DataType_Encoding_DefaultXml => {
+                    ProgramDiagnostic2DataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::IssuedIdentityToken_Encoding_DefaultXml => {
+                    IssuedIdentityToken::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SemanticChangeStructureDataType_Encoding_DefaultXml => {
+                    SemanticChangeStructureDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::AddNodesRequest_Encoding_DefaultXml => {
+                    AddNodesRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ModificationInfo_Encoding_DefaultXml => {
+                    ModificationInfo::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::RegisterNodesRequest_Encoding_DefaultXml => {
+                    RegisterNodesRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::MonitoredItemNotification_Encoding_DefaultXml => {
+                    MonitoredItemNotification::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::UpdateDataDetails_Encoding_DefaultXml => {
+                    UpdateDataDetails::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::WriterGroupMessageDataType_Encoding_DefaultXml => {
+                    WriterGroupMessageDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::WriteRequest_Encoding_DefaultXml => {
+                    WriteRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DataSetWriterDataType_Encoding_DefaultXml => {
+                    DataSetWriterDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::NetworkGroupDataType_Encoding_DefaultXml => {
+                    NetworkGroupDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DeleteMonitoredItemsRequest_Encoding_DefaultXml => {
+                    DeleteMonitoredItemsRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::AttributeOperand_Encoding_DefaultXml => {
+                    AttributeOperand::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrowseNextRequest_Encoding_DefaultXml => {
+                    BrowseNextRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrowseNextResponse_Encoding_DefaultXml => {
+                    BrowseNextResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ReaderGroupMessageDataType_Encoding_DefaultXml => {
+                    ReaderGroupMessageDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::JsonWriterGroupMessageDataType_Encoding_DefaultXml => {
+                    JsonWriterGroupMessageDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::FindServersOnNetworkResponse_Encoding_DefaultXml => {
+                    FindServersOnNetworkResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ReadRawModifiedDetails_Encoding_DefaultXml => {
+                    ReadRawModifiedDetails::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::HistoryData_Encoding_DefaultXml => {
+                    HistoryData::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::TransferSubscriptionsResponse_Encoding_DefaultXml => {
+                    TransferSubscriptionsResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SignatureData_Encoding_DefaultXml => {
+                    SignatureData::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::SetPublishingModeResponse_Encoding_DefaultXml => {
                     SetPublishingModeResponse::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::DeleteMonitoredItemsRequest_Encoding_DefaultXml => {
-                    DeleteMonitoredItemsRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::RolePermissionType_Encoding_DefaultXml => {
+                    RolePermissionType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::TransferResult_Encoding_DefaultXml => {
+                    TransferResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ContentFilterResult_Encoding_DefaultXml => {
+                    ContentFilterResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::HistoryUpdateDetails_Encoding_DefaultXml => {
+                    HistoryUpdateDetails::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CloseSessionRequest_Encoding_DefaultXml => {
+                    CloseSessionRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrowseResult_Encoding_DefaultXml => {
+                    BrowseResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DataChangeNotification_Encoding_DefaultXml => {
+                    DataChangeNotification::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::StatusResult_Encoding_DefaultXml => {
+                    StatusResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ReaderGroupTransportDataType_Encoding_DefaultXml => {
+                    ReaderGroupTransportDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DeleteSubscriptionsResponse_Encoding_DefaultXml => {
+                    DeleteSubscriptionsResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SessionlessInvokeResponseType_Encoding_DefaultXml => {
+                    SessionlessInvokeResponseType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::TransferSubscriptionsRequest_Encoding_DefaultXml => {
+                    TransferSubscriptionsRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::UserTokenPolicy_Encoding_DefaultXml => {
+                    UserTokenPolicy::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DeleteReferencesResponse_Encoding_DefaultXml => {
+                    DeleteReferencesResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::UnregisterNodesResponse_Encoding_DefaultXml => {
+                    UnregisterNodesResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::MethodAttributes_Encoding_DefaultXml => {
+                    MethodAttributes::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::KeyValuePair_Encoding_DefaultXml => {
+                    KeyValuePair::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrowsePath_Encoding_DefaultXml => {
+                    BrowsePath::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::HistoryEvent_Encoding_DefaultXml => {
+                    HistoryEvent::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::AdditionalParametersType_Encoding_DefaultXml => {
+                    AdditionalParametersType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DataSetWriterTransportDataType_Encoding_DefaultXml => {
+                    DataSetWriterTransportDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SubscriptionDiagnosticsDataType_Encoding_DefaultXml => {
+                    SubscriptionDiagnosticsDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::MonitoredItemModifyResult_Encoding_DefaultXml => {
+                    MonitoredItemModifyResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SamplingIntervalDiagnosticsDataType_Encoding_DefaultXml => {
+                    SamplingIntervalDiagnosticsDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::EventFilter_Encoding_DefaultXml => {
+                    EventFilter::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DataTypeDescription_Encoding_DefaultXml => {
+                    DataTypeDescription::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DataTypeAttributes_Encoding_DefaultXml => {
+                    DataTypeAttributes::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::EndpointType_Encoding_DefaultXml => {
+                    EndpointType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrowseDescription_Encoding_DefaultXml => {
+                    BrowseDescription::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrokerDataSetReaderTransportDataType_Encoding_DefaultXml => {
+                    BrokerDataSetReaderTransportDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DeleteNodesRequest_Encoding_DefaultXml => {
+                    DeleteNodesRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ContentFilterElement_Encoding_DefaultXml => {
+                    ContentFilterElement::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::AddReferencesRequest_Encoding_DefaultXml => {
+                    AddReferencesRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::EventNotificationList_Encoding_DefaultXml => {
+                    EventNotificationList::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::AnonymousIdentityToken_Encoding_DefaultXml => {
+                    AnonymousIdentityToken::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CloseSecureChannelResponse_Encoding_DefaultXml => {
+                    CloseSecureChannelResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::MonitoredItemModifyRequest_Encoding_DefaultXml => {
+                    MonitoredItemModifyRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CreateSessionResponse_Encoding_DefaultXml => {
+                    CreateSessionResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::UnregisterNodesRequest_Encoding_DefaultXml => {
+                    UnregisterNodesRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::RationalNumber_Encoding_DefaultXml => {
+                    RationalNumber::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::UadpDataSetReaderMessageDataType_Encoding_DefaultXml => {
+                    UadpDataSetReaderMessageDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::OpenSecureChannelResponse_Encoding_DefaultXml => {
+                    OpenSecureChannelResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::TranslateBrowsePathsToNodeIdsResponse_Encoding_DefaultXml => {
+                    TranslateBrowsePathsToNodeIdsResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrowseRequest_Encoding_DefaultXml => {
+                    BrowseRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ReadRequest_Encoding_DefaultXml => {
+                    ReadRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::Orientation_Encoding_DefaultXml => {
+                    Orientation::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::NodeAttributes_Encoding_DefaultXml => {
+                    NodeAttributes::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::GenericAttributeValue_Encoding_DefaultXml => {
+                    GenericAttributeValue::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DatagramConnectionTransportDataType_Encoding_DefaultXml => {
+                    DatagramConnectionTransportDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrokerConnectionTransportDataType_Encoding_DefaultXml => {
+                    BrokerConnectionTransportDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::BrokerDataSetWriterTransportDataType_Encoding_DefaultXml => {
+                    BrokerDataSetWriterTransportDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CloseSessionResponse_Encoding_DefaultXml => {
+                    CloseSessionResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ModifyMonitoredItemsResponse_Encoding_DefaultXml => {
+                    ModifyMonitoredItemsResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::VariableAttributes_Encoding_DefaultXml => {
+                    VariableAttributes::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::EndpointDescription_Encoding_DefaultXml => {
+                    EndpointDescription::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::MonitoredItemCreateResult_Encoding_DefaultXml => {
+                    MonitoredItemCreateResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::RegisterServerResponse_Encoding_DefaultXml => {
+                    RegisterServerResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::UpdateStructureDataDetails_Encoding_DefaultXml => {
+                    UpdateStructureDataDetails::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::QueryDataSet_Encoding_DefaultXml => {
+                    QueryDataSet::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::HistoryUpdateResult_Encoding_DefaultXml => {
+                    HistoryUpdateResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::PubSubConnectionDataType_Encoding_DefaultXml => {
+                    PubSubConnectionDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ReferenceDescription_Encoding_DefaultXml => {
+                    ReferenceDescription::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::FieldMetaData_Encoding_DefaultXml => {
+                    FieldMetaData::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::EndpointUrlListDataType_Encoding_DefaultXml => {
@@ -903,808 +1303,408 @@ impl opcua::types::xml::XmlLoader for TypesXmlLoader {
                     DataSetReaderDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ComplexNumberType_Encoding_DefaultXml => {
-                    ComplexNumberType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SimpleAttributeOperand_Encoding_DefaultXml => {
-                    SimpleAttributeOperand::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ChannelSecurityToken_Encoding_DefaultXml => {
-                    ChannelSecurityToken::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CallMethodResult_Encoding_DefaultXml => {
-                    CallMethodResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DatagramConnectionTransportDataType_Encoding_DefaultXml => {
-                    DatagramConnectionTransportDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AggregateFilter_Encoding_DefaultXml => {
-                    AggregateFilter::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::UadpWriterGroupMessageDataType_Encoding_DefaultXml => {
-                    UadpWriterGroupMessageDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SetPublishingModeRequest_Encoding_DefaultXml => {
-                    SetPublishingModeRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::JsonWriterGroupMessageDataType_Encoding_DefaultXml => {
-                    JsonWriterGroupMessageDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::NodeAttributes_Encoding_DefaultXml => {
-                    NodeAttributes::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::QueryNextRequest_Encoding_DefaultXml => {
-                    QueryNextRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DeleteSubscriptionsRequest_Encoding_DefaultXml => {
-                    DeleteSubscriptionsRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::RelativePathElement_Encoding_DefaultXml => {
-                    RelativePathElement::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SimpleTypeDescription_Encoding_DefaultXml => {
-                    SimpleTypeDescription::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SessionSecurityDiagnosticsDataType_Encoding_DefaultXml => {
-                    SessionSecurityDiagnosticsDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SemanticChangeStructureDataType_Encoding_DefaultXml => {
-                    SemanticChangeStructureDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DeleteSubscriptionsResponse_Encoding_DefaultXml => {
-                    DeleteSubscriptionsResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::MonitoringFilter_Encoding_DefaultXml => {
-                    MonitoringFilter::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CancelRequest_Encoding_DefaultXml => {
-                    CancelRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SessionlessInvokeRequestType_Encoding_DefaultXml => {
-                    SessionlessInvokeRequestType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ConnectionTransportDataType_Encoding_DefaultXml => {
-                    ConnectionTransportDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ReadRawModifiedDetails_Encoding_DefaultXml => {
-                    ReadRawModifiedDetails::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ReadEventDetails_Encoding_DefaultXml => {
-                    ReadEventDetails::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DataSetWriterTransportDataType_Encoding_DefaultXml => {
-                    DataSetWriterTransportDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::HistoryReadResponse_Encoding_DefaultXml => {
-                    HistoryReadResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ActivateSessionRequest_Encoding_DefaultXml => {
-                    ActivateSessionRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AliasNameDataType_Encoding_DefaultXml => {
-                    AliasNameDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::EventFieldList_Encoding_DefaultXml => {
-                    EventFieldList::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CreateSubscriptionResponse_Encoding_DefaultXml => {
-                    CreateSubscriptionResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::RegisterNodesResponse_Encoding_DefaultXml => {
-                    RegisterNodesResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SessionlessInvokeResponseType_Encoding_DefaultXml => {
-                    SessionlessInvokeResponseType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ConfigurationVersionDataType_Encoding_DefaultXml => {
-                    ConfigurationVersionDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::EndpointConfiguration_Encoding_DefaultXml => {
-                    EndpointConfiguration::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DoubleComplexNumberType_Encoding_DefaultXml => {
-                    DoubleComplexNumberType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ThreeDCartesianCoordinates_Encoding_DefaultXml => {
-                    ThreeDCartesianCoordinates::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ModifySubscriptionRequest_Encoding_DefaultXml => {
-                    ModifySubscriptionRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ServerStatusDataType_Encoding_DefaultXml => {
-                    ServerStatusDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::WriteResponse_Encoding_DefaultXml => {
-                    WriteResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::QueryNextResponse_Encoding_DefaultXml => {
-                    QueryNextResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::PublishResponse_Encoding_DefaultXml => {
-                    PublishResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::EnumField_Encoding_DefaultXml => {
-                    EnumField::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::PublishedDataItemsDataType_Encoding_DefaultXml => {
-                    PublishedDataItemsDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::IssuedIdentityToken_Encoding_DefaultXml => {
-                    IssuedIdentityToken::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ReadAnnotationDataDetails_Encoding_DefaultXml => {
-                    ReadAnnotationDataDetails::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DeleteMonitoredItemsResponse_Encoding_DefaultXml => {
-                    DeleteMonitoredItemsResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AddNodesRequest_Encoding_DefaultXml => {
-                    AddNodesRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::BrowseNextRequest_Encoding_DefaultXml => {
-                    BrowseNextRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ModificationInfo_Encoding_DefaultXml => {
-                    ModificationInfo::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::MonitoringFilterResult_Encoding_DefaultXml => {
-                    MonitoringFilterResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::HistoryModifiedData_Encoding_DefaultXml => {
-                    HistoryModifiedData::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ApplicationDescription_Encoding_DefaultXml => {
-                    ApplicationDescription::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::UadpDataSetReaderMessageDataType_Encoding_DefaultXml => {
-                    UadpDataSetReaderMessageDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::BrokerWriterGroupTransportDataType_Encoding_DefaultXml => {
-                    BrokerWriterGroupTransportDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::EphemeralKeyType_Encoding_DefaultXml => {
-                    EphemeralKeyType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ThreeDFrame_Encoding_DefaultXml => {
-                    ThreeDFrame::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::RedundantServerDataType_Encoding_DefaultXml => {
-                    RedundantServerDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::RepublishResponse_Encoding_DefaultXml => {
-                    RepublishResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::X509IdentityToken_Encoding_DefaultXml => {
-                    X509IdentityToken::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::Argument_Encoding_DefaultXml => {
-                    Argument::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ContentFilterResult_Encoding_DefaultXml => {
-                    ContentFilterResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AddNodesResult_Encoding_DefaultXml => {
-                    AddNodesResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::StructureField_Encoding_DefaultXml => {
-                    StructureField::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DataSetMetaDataType_Encoding_DefaultXml => {
-                    DataSetMetaDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::FindServersOnNetworkResponse_Encoding_DefaultXml => {
-                    FindServersOnNetworkResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ServiceFault_Encoding_DefaultXml => {
-                    ServiceFault::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ProgramDiagnosticDataType_Encoding_DefaultXml => {
-                    ProgramDiagnosticDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DeleteNodesItem_Encoding_DefaultXml => {
-                    DeleteNodesItem::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SubscriptionAcknowledgement_Encoding_DefaultXml => {
-                    SubscriptionAcknowledgement::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::RegisterServerResponse_Encoding_DefaultXml => {
-                    RegisterServerResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::OpenSecureChannelRequest_Encoding_DefaultXml => {
-                    OpenSecureChannelRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AggregateConfiguration_Encoding_DefaultXml => {
-                    AggregateConfiguration::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ThreeDOrientation_Encoding_DefaultXml => {
-                    ThreeDOrientation::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AddReferencesResponse_Encoding_DefaultXml => {
-                    AddReferencesResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SessionDiagnosticsDataType_Encoding_DefaultXml => {
-                    SessionDiagnosticsDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::BrokerConnectionTransportDataType_Encoding_DefaultXml => {
-                    BrokerConnectionTransportDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::UnregisterNodesRequest_Encoding_DefaultXml => {
-                    UnregisterNodesRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::Orientation_Encoding_DefaultXml => {
-                    Orientation::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::RepublishRequest_Encoding_DefaultXml => {
-                    RepublishRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DataSetReaderMessageDataType_Encoding_DefaultXml => {
-                    DataSetReaderMessageDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::QueryFirstResponse_Encoding_DefaultXml => {
-                    QueryFirstResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::HistoryReadResult_Encoding_DefaultXml => {
-                    HistoryReadResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ReadProcessedDetails_Encoding_DefaultXml => {
-                    ReadProcessedDetails::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::NetworkGroupDataType_Encoding_DefaultXml => {
-                    NetworkGroupDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::FieldMetaData_Encoding_DefaultXml => {
-                    FieldMetaData::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DataTypeDescription_Encoding_DefaultXml => {
-                    DataTypeDescription::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::MonitoredItemCreateRequest_Encoding_DefaultXml => {
-                    MonitoredItemCreateRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DeleteReferencesRequest_Encoding_DefaultXml => {
-                    DeleteReferencesRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::PubSubGroupDataType_Encoding_DefaultXml => {
-                    PubSubGroupDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::LiteralOperand_Encoding_DefaultXml => {
-                    LiteralOperand::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ProgramDiagnostic2DataType_Encoding_DefaultXml => {
-                    ProgramDiagnostic2DataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ReferenceTypeAttributes_Encoding_DefaultXml => {
-                    ReferenceTypeAttributes::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CreateMonitoredItemsRequest_Encoding_DefaultXml => {
-                    CreateMonitoredItemsRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::WriteRequest_Encoding_DefaultXml => {
-                    WriteRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::TransferSubscriptionsRequest_Encoding_DefaultXml => {
-                    TransferSubscriptionsRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::RegisteredServer_Encoding_DefaultXml => {
-                    RegisteredServer::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SignedSoftwareCertificate_Encoding_DefaultXml => {
-                    SignedSoftwareCertificate::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::UpdateEventDetails_Encoding_DefaultXml => {
-                    UpdateEventDetails::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::NodeTypeDescription_Encoding_DefaultXml => {
-                    NodeTypeDescription::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::FindServersOnNetworkRequest_Encoding_DefaultXml => {
-                    FindServersOnNetworkRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::MonitoredItemCreateResult_Encoding_DefaultXml => {
-                    MonitoredItemCreateResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::BrowseRequest_Encoding_DefaultXml => {
-                    BrowseRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ElementOperand_Encoding_DefaultXml => {
-                    ElementOperand::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ModifySubscriptionResponse_Encoding_DefaultXml => {
-                    ModifySubscriptionResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::HistoryEventFieldList_Encoding_DefaultXml => {
-                    HistoryEventFieldList::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::GetEndpointsRequest_Encoding_DefaultXml => {
-                    GetEndpointsRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::VariableAttributes_Encoding_DefaultXml => {
-                    VariableAttributes::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::PubSubConfigurationDataType_Encoding_DefaultXml => {
-                    PubSubConfigurationDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::PublishedVariableDataType_Encoding_DefaultXml => {
-                    PublishedVariableDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::EnumValueType_Encoding_DefaultXml => {
-                    EnumValueType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AggregateFilterResult_Encoding_DefaultXml => {
-                    AggregateFilterResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CreateMonitoredItemsResponse_Encoding_DefaultXml => {
-                    CreateMonitoredItemsResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ObjectTypeAttributes_Encoding_DefaultXml => {
-                    ObjectTypeAttributes::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::RegisterServer2Request_Encoding_DefaultXml => {
-                    RegisterServer2Request::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DecimalDataType_Encoding_DefaultXml => {
-                    DecimalDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DeleteReferencesItem_Encoding_DefaultXml => {
-                    DeleteReferencesItem::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CloseSecureChannelRequest_Encoding_DefaultXml => {
-                    CloseSecureChannelRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::MonitoredItemModifyResult_Encoding_DefaultXml => {
-                    MonitoredItemModifyResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::Vector_Encoding_DefaultXml => {
-                    Vector::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::NetworkAddressDataType_Encoding_DefaultXml => {
-                    NetworkAddressDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DataSetWriterDataType_Encoding_DefaultXml => {
-                    DataSetWriterDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::EndpointType_Encoding_DefaultXml => {
-                    EndpointType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::UserIdentityToken_Encoding_DefaultXml => {
-                    UserIdentityToken::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CartesianCoordinates_Encoding_DefaultXml => {
-                    CartesianCoordinates::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::PubSubConnectionDataType_Encoding_DefaultXml => {
-                    PubSubConnectionDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::MonitoringParameters_Encoding_DefaultXml => {
-                    MonitoringParameters::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SubscriptionDiagnosticsDataType_Encoding_DefaultXml => {
-                    SubscriptionDiagnosticsDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DatagramWriterGroupTransportDataType_Encoding_DefaultXml => {
-                    DatagramWriterGroupTransportDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::BrowsePathResult_Encoding_DefaultXml => {
-                    BrowsePathResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::EnumDescription_Encoding_DefaultXml => {
-                    EnumDescription::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::UpdateDataDetails_Encoding_DefaultXml => {
-                    UpdateDataDetails::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::StatusChangeNotification_Encoding_DefaultXml => {
-                    StatusChangeNotification::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ModifyMonitoredItemsResponse_Encoding_DefaultXml => {
-                    ModifyMonitoredItemsResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::NotificationData_Encoding_DefaultXml => {
-                    NotificationData::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CreateSubscriptionRequest_Encoding_DefaultXml => {
-                    CreateSubscriptionRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::QueryFirstRequest_Encoding_DefaultXml => {
-                    QueryFirstRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::EventFilter_Encoding_DefaultXml => {
-                    EventFilter::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::TargetVariablesDataType_Encoding_DefaultXml => {
-                    TargetVariablesDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::BrowsePathTarget_Encoding_DefaultXml => {
-                    BrowsePathTarget::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CallMethodRequest_Encoding_DefaultXml => {
-                    CallMethodRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::StatusResult_Encoding_DefaultXml => {
-                    StatusResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::WriteValue_Encoding_DefaultXml => {
-                    WriteValue::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::StructureDescription_Encoding_DefaultXml => {
-                    StructureDescription::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::HistoryReadValueId_Encoding_DefaultXml => {
-                    HistoryReadValueId::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::WriterGroupDataType_Encoding_DefaultXml => {
-                    WriterGroupDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AddNodesItem_Encoding_DefaultXml => {
-                    AddNodesItem::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CancelResponse_Encoding_DefaultXml => {
-                    CancelResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::RegisterServerRequest_Encoding_DefaultXml => {
-                    RegisterServerRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::HistoryUpdateResult_Encoding_DefaultXml => {
-                    HistoryUpdateResult::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::BrowseNextResponse_Encoding_DefaultXml => {
-                    BrowseNextResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AdditionalParametersType_Encoding_DefaultXml => {
-                    AdditionalParametersType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::SetMonitoringModeResponse_Encoding_DefaultXml => {
-                    SetMonitoringModeResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DataChangeFilter_Encoding_DefaultXml => {
-                    DataChangeFilter::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ReadResponse_Encoding_DefaultXml => {
-                    ReadResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DiscoveryConfiguration_Encoding_DefaultXml => {
-                    DiscoveryConfiguration::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ReaderGroupTransportDataType_Encoding_DefaultXml => {
-                    ReaderGroupTransportDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::FieldTargetDataType_Encoding_DefaultXml => {
-                    FieldTargetDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::HistoryReadRequest_Encoding_DefaultXml => {
-                    HistoryReadRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ParsingResult_Encoding_DefaultXml => {
-                    ParsingResult::from_xml(body, ctx)
+                opcua::types::ObjectId::AddNodesResponse_Encoding_DefaultXml => {
+                    AddNodesResponse::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::TimeZoneDataType_Encoding_DefaultXml => {
                     TimeZoneDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::WriterGroupTransportDataType_Encoding_DefaultXml => {
-                    WriterGroupTransportDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::CreateMonitoredItemsRequest_Encoding_DefaultXml => {
+                    CreateMonitoredItemsRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ContentFilterElement_Encoding_DefaultXml => {
-                    ContentFilterElement::from_xml(body, ctx)
+                opcua::types::ObjectId::ConfigurationVersionDataType_Encoding_DefaultXml => {
+                    ConfigurationVersionDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ServerOnNetwork_Encoding_DefaultXml => {
-                    ServerOnNetwork::from_xml(body, ctx)
+                opcua::types::ObjectId::GenericAttributes_Encoding_DefaultXml => {
+                    GenericAttributes::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::MdnsDiscoveryConfiguration_Encoding_DefaultXml => {
-                    MdnsDiscoveryConfiguration::from_xml(body, ctx)
+                opcua::types::ObjectId::TranslateBrowsePathsToNodeIdsRequest_Encoding_DefaultXml => {
+                    TranslateBrowsePathsToNodeIdsRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ReaderGroupDataType_Encoding_DefaultXml => {
-                    ReaderGroupDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::LiteralOperand_Encoding_DefaultXml => {
+                    LiteralOperand::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::UpdateStructureDataDetails_Encoding_DefaultXml => {
-                    UpdateStructureDataDetails::from_xml(body, ctx)
+                opcua::types::ObjectId::HistoryReadResult_Encoding_DefaultXml => {
+                    HistoryReadResult::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::IdentityMappingRuleType_Encoding_DefaultXml => {
-                    IdentityMappingRuleType::from_xml(body, ctx)
+                opcua::types::ObjectId::FilterOperand_Encoding_DefaultXml => {
+                    FilterOperand::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::RolePermissionType_Encoding_DefaultXml => {
-                    RolePermissionType::from_xml(body, ctx)
+                opcua::types::ObjectId::RedundantServerDataType_Encoding_DefaultXml => {
+                    RedundantServerDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::DataChangeNotification_Encoding_DefaultXml => {
-                    DataChangeNotification::from_xml(body, ctx)
+                opcua::types::ObjectId::DeleteReferencesRequest_Encoding_DefaultXml => {
+                    DeleteReferencesRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::SetTriggeringResponse_Encoding_DefaultXml => {
-                    SetTriggeringResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::SignedSoftwareCertificate_Encoding_DefaultXml => {
+                    SignedSoftwareCertificate::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::MethodAttributes_Encoding_DefaultXml => {
-                    MethodAttributes::from_xml(body, ctx)
+                opcua::types::ObjectId::SubscribedDataSetDataType_Encoding_DefaultXml => {
+                    SubscribedDataSetDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::NotificationMessage_Encoding_DefaultXml => {
-                    NotificationMessage::from_xml(body, ctx)
+                opcua::types::ObjectId::CreateSubscriptionRequest_Encoding_DefaultXml => {
+                    CreateSubscriptionRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ReadRequest_Encoding_DefaultXml => {
-                    ReadRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::TargetVariablesDataType_Encoding_DefaultXml => {
+                    TargetVariablesDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::JsonDataSetReaderMessageDataType_Encoding_DefaultXml => {
-                    JsonDataSetReaderMessageDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::SubscriptionAcknowledgement_Encoding_DefaultXml => {
+                    SubscriptionAcknowledgement::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::AddNodesResponse_Encoding_DefaultXml => {
-                    AddNodesResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::UadpWriterGroupMessageDataType_Encoding_DefaultXml => {
+                    UadpWriterGroupMessageDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::EUInformation_Encoding_DefaultXml => {
-                    EUInformation::from_xml(body, ctx)
+                opcua::types::ObjectId::PublishedDataSetDataType_Encoding_DefaultXml => {
+                    PublishedDataSetDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::PublishedEventsDataType_Encoding_DefaultXml => {
-                    PublishedEventsDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::ReadEventDetails_Encoding_DefaultXml => {
+                    ReadEventDetails::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::RegisterNodesRequest_Encoding_DefaultXml => {
-                    RegisterNodesRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::ReadAtTimeDetails_Encoding_DefaultXml => {
+                    ReadAtTimeDetails::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::FindServersResponse_Encoding_DefaultXml => {
-                    FindServersResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::OptionSet_Encoding_DefaultXml => {
-                    OptionSet::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AttributeOperand_Encoding_DefaultXml => {
-                    AttributeOperand::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::MonitoredItemNotification_Encoding_DefaultXml => {
-                    MonitoredItemNotification::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DataSetWriterMessageDataType_Encoding_DefaultXml => {
-                    DataSetWriterMessageDataType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ViewAttributes_Encoding_DefaultXml => {
-                    ViewAttributes::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DataTypeAttributes_Encoding_DefaultXml => {
-                    DataTypeAttributes::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::CallResponse_Encoding_DefaultXml => {
-                    CallResponse::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::XVType_Encoding_DefaultXml => {
-                    XVType::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::PublishRequest_Encoding_DefaultXml => {
-                    PublishRequest::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AxisInformation_Encoding_DefaultXml => {
-                    AxisInformation::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::ReferenceDescription_Encoding_DefaultXml => {
-                    ReferenceDescription::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::DeleteAtTimeDetails_Encoding_DefaultXml => {
-                    DeleteAtTimeDetails::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::AddReferencesItem_Encoding_DefaultXml => {
-                    AddReferencesItem::from_xml(body, ctx)
-                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
-                }
-                opcua::types::ObjectId::VariableTypeAttributes_Encoding_DefaultXml => {
-                    VariableTypeAttributes::from_xml(body, ctx)
+                opcua::types::ObjectId::AggregateFilterResult_Encoding_DefaultXml => {
+                    AggregateFilterResult::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::ViewDescription_Encoding_DefaultXml => {
                     ViewDescription::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::CloseSessionResponse_Encoding_DefaultXml => {
-                    CloseSessionResponse::from_xml(body, ctx)
+                opcua::types::ObjectId::CreateMonitoredItemsResponse_Encoding_DefaultXml => {
+                    CreateMonitoredItemsResponse::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::SamplingIntervalDiagnosticsDataType_Encoding_DefaultXml => {
-                    SamplingIntervalDiagnosticsDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::HistoryUpdateRequest_Encoding_DefaultXml => {
+                    HistoryUpdateRequest::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::MonitoredItemModifyRequest_Encoding_DefaultXml => {
-                    MonitoredItemModifyRequest::from_xml(body, ctx)
+                opcua::types::ObjectId::DatagramWriterGroupTransportDataType_Encoding_DefaultXml => {
+                    DatagramWriterGroupTransportDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::ServerDiagnosticsSummaryDataType_Encoding_DefaultXml => {
-                    ServerDiagnosticsSummaryDataType::from_xml(body, ctx)
+                opcua::types::ObjectId::SessionDiagnosticsDataType_Encoding_DefaultXml => {
+                    SessionDiagnosticsDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DeleteNodesItem_Encoding_DefaultXml => {
+                    DeleteNodesItem::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::PublishedDataItemsDataType_Encoding_DefaultXml => {
+                    PublishedDataItemsDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ThreeDFrame_Encoding_DefaultXml => {
+                    ThreeDFrame::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::IdentityMappingRuleType_Encoding_DefaultXml => {
+                    IdentityMappingRuleType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::RegisteredServer_Encoding_DefaultXml => {
+                    RegisteredServer::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::FindServersResponse_Encoding_DefaultXml => {
+                    FindServersResponse::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::Range_Encoding_DefaultXml => {
                     Range::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
+                opcua::types::ObjectId::CallResponse_Encoding_DefaultXml => {
+                    CallResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::Frame_Encoding_DefaultXml => {
+                    Frame::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::EventFilterResult_Encoding_DefaultXml => {
+                    EventFilterResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CartesianCoordinates_Encoding_DefaultXml => {
+                    CartesianCoordinates::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::PubSubGroupDataType_Encoding_DefaultXml => {
+                    PubSubGroupDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::NodeTypeDescription_Encoding_DefaultXml => {
+                    NodeTypeDescription::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::AggregateConfiguration_Encoding_DefaultXml => {
+                    AggregateConfiguration::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::StructureField_Encoding_DefaultXml => {
+                    StructureField::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::HistoryEventFieldList_Encoding_DefaultXml => {
+                    HistoryEventFieldList::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ReferenceTypeAttributes_Encoding_DefaultXml => {
+                    ReferenceTypeAttributes::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::EnumDescription_Encoding_DefaultXml => {
+                    EnumDescription::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::JsonDataSetReaderMessageDataType_Encoding_DefaultXml => {
+                    JsonDataSetReaderMessageDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DeleteRawModifiedDetails_Encoding_DefaultXml => {
+                    DeleteRawModifiedDetails::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::MdnsDiscoveryConfiguration_Encoding_DefaultXml => {
+                    MdnsDiscoveryConfiguration::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::UserIdentityToken_Encoding_DefaultXml => {
+                    UserIdentityToken::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ContentFilter_Encoding_DefaultXml => {
+                    ContentFilter::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CloseSecureChannelRequest_Encoding_DefaultXml => {
+                    CloseSecureChannelRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::X509IdentityToken_Encoding_DefaultXml => {
+                    X509IdentityToken::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::UserNameIdentityToken_Encoding_DefaultXml => {
+                    UserNameIdentityToken::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DeleteReferencesItem_Encoding_DefaultXml => {
+                    DeleteReferencesItem::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::QueryNextResponse_Encoding_DefaultXml => {
+                    QueryNextResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::EnumField_Encoding_DefaultXml => {
+                    EnumField::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SessionlessInvokeRequestType_Encoding_DefaultXml => {
+                    SessionlessInvokeRequestType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::NetworkAddressDataType_Encoding_DefaultXml => {
+                    NetworkAddressDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::NotificationData_Encoding_DefaultXml => {
+                    NotificationData::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::NodeReference_Encoding_DefaultXml => {
+                    NodeReference::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::JsonDataSetWriterMessageDataType_Encoding_DefaultXml => {
+                    JsonDataSetWriterMessageDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ReadAnnotationDataDetails_Encoding_DefaultXml => {
+                    ReadAnnotationDataDetails::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::WriteValue_Encoding_DefaultXml => {
+                    WriteValue::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::VariableTypeAttributes_Encoding_DefaultXml => {
+                    VariableTypeAttributes::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::RegisterNodesResponse_Encoding_DefaultXml => {
+                    RegisterNodesResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ThreeDOrientation_Encoding_DefaultXml => {
+                    ThreeDOrientation::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DataTypeSchemaHeader_Encoding_DefaultXml => {
+                    DataTypeSchemaHeader::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CreateSessionRequest_Encoding_DefaultXml => {
+                    CreateSessionRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CallRequest_Encoding_DefaultXml => {
+                    CallRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ObjectAttributes_Encoding_DefaultXml => {
+                    ObjectAttributes::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DeleteEventDetails_Encoding_DefaultXml => {
+                    DeleteEventDetails::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::RegisterServer2Response_Encoding_DefaultXml => {
+                    RegisterServer2Response::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::AxisInformation_Encoding_DefaultXml => {
+                    AxisInformation::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::RepublishRequest_Encoding_DefaultXml => {
+                    RepublishRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::MonitoringFilter_Encoding_DefaultXml => {
+                    MonitoringFilter::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ElementOperand_Encoding_DefaultXml => {
+                    ElementOperand::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::AddReferencesResponse_Encoding_DefaultXml => {
+                    AddReferencesResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DeleteAtTimeDetails_Encoding_DefaultXml => {
+                    DeleteAtTimeDetails::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::AggregateFilter_Encoding_DefaultXml => {
+                    AggregateFilter::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::MonitoringParameters_Encoding_DefaultXml => {
+                    MonitoringParameters::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::HistoryReadResponse_Encoding_DefaultXml => {
+                    HistoryReadResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CallMethodResult_Encoding_DefaultXml => {
+                    CallMethodResult::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ServerStatusDataType_Encoding_DefaultXml => {
+                    ServerStatusDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
                 opcua::types::ObjectId::UABinaryFileDataType_Encoding_DefaultXml => {
                     UABinaryFileDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::EventFieldList_Encoding_DefaultXml => {
+                    EventFieldList::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DataSetWriterMessageDataType_Encoding_DefaultXml => {
+                    DataSetWriterMessageDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::QueryFirstRequest_Encoding_DefaultXml => {
+                    QueryFirstRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::NetworkAddressUrlDataType_Encoding_DefaultXml => {
+                    NetworkAddressUrlDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ReadProcessedDetails_Encoding_DefaultXml => {
+                    ReadProcessedDetails::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::GetEndpointsResponse_Encoding_DefaultXml => {
+                    GetEndpointsResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::HistoryReadValueId_Encoding_DefaultXml => {
+                    HistoryReadValueId::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ReadValueId_Encoding_DefaultXml => {
+                    ReadValueId::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::DataChangeFilter_Encoding_DefaultXml => {
+                    DataChangeFilter::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 opcua::types::ObjectId::HistoryReadDetails_Encoding_DefaultXml => {
                     HistoryReadDetails::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
-                opcua::types::ObjectId::Frame_Encoding_DefaultXml => {
-                    Frame::from_xml(body, ctx)
+                opcua::types::ObjectId::AliasNameDataType_Encoding_DefaultXml => {
+                    AliasNameDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::ServiceCounterDataType_Encoding_DefaultXml => {
+                    ServiceCounterDataType::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::OptionSet_Encoding_DefaultXml => {
+                    OptionSet::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SetTriggeringRequest_Encoding_DefaultXml => {
+                    SetTriggeringRequest::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::PublishResponse_Encoding_DefaultXml => {
+                    PublishResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::UpdateEventDetails_Encoding_DefaultXml => {
+                    UpdateEventDetails::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::CreateSubscriptionResponse_Encoding_DefaultXml => {
+                    CreateSubscriptionResponse::from_xml(body, ctx)
+                        .map(|v| opcua::types::ExtensionObject::from_message(&v))
+                }
+                opcua::types::ObjectId::SessionSecurityDiagnosticsDataType_Encoding_DefaultXml => {
+                    SessionSecurityDiagnosticsDataType::from_xml(body, ctx)
                         .map(|v| opcua::types::ExtensionObject::from_message(&v))
                 }
                 _ => return None,

--- a/opcua-types/src/tests/json.rs
+++ b/opcua-types/src/tests/json.rs
@@ -7,7 +7,7 @@ use crate::{
     diagnostic_info::DiagnosticInfo, expanded_node_id::ExpandedNodeId, guid::Guid,
     localized_text::LocalizedText, node_id::NodeId, qualified_name::QualifiedName,
     status_code::StatusCode, string::UAString, variant::Variant, Argument, Array, DataTypeId,
-    VariantScalarTypeId,
+    ObjectId, VariantScalarTypeId,
 };
 
 use super::ExtensionObject;
@@ -207,7 +207,7 @@ fn serialize_extension_object() {
         json,
         json!({
             "TypeId": {
-                "Id": 298
+                "Id": ObjectId::Argument_Encoding_DefaultJson as i32
             },
             "Body": {
                 "Name": "Arg",
@@ -536,7 +536,7 @@ fn serialize_variant_extension_object() {
             "Type": 22,
             "Body": {
                 "TypeId": {
-                    "Id": 298
+                    "Id": ObjectId::Argument_Encoding_DefaultJson as i32
                 },
                 "Body": {
                     "Name": "Arg",


### PR DESCRIPTION
Create an alternative MessageInfo for types that aren't in the core namespace. This is the first step towards true codegen support for non-core types.

This does change an assumption slightly: It is now assumed that the namespace array for a session is static, at least for namespaces that cover types. This is generally a very safe assumption.