### PR TITLE
Rename BinaryEncoder to BinaryEncodable

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -66,7 +66,7 @@ for something that adds variables to the address space and changes their values.
 
 OPC UA defines a lot of types. Some of those correspond to Rust primitives while others are types, structures or enums which are used by the protocol. All types are defined in the [`opcua-types`](../types) crate.
 
-All types can be encoded / decoded to a stream according to the opc.tcp:// binary transport. They do so by implementing a `BinaryEncoder` trait. The three functions on this trait allow a struct to be deserialized, serialized, or the byte size of it to be calculated.
+All types can be encoded / decoded to a stream according to the opc.tcp:// binary transport. They do so by implementing a `BinaryEncodable` trait. The three functions on this trait allow a struct to be deserialized, serialized, or the byte size of it to be calculated.
 
 Typically encoding will begin with a structure, e.g. `CreateSubscriptionRequest` whose implementation will encode each member in turn.
 

--- a/lib/fuzz/fuzz_targets/fuzz_deserialize.rs
+++ b/lib/fuzz/fuzz_targets/fuzz_deserialize.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use opcua::types::{BinaryEncoder, DecodingOptions, StatusCode, Variant};
+use opcua::types::{BinaryEncodable, DecodingOptions, StatusCode, Variant};
 use std::io::Cursor;
 
 pub fn deserialize(data: &[u8], decoding_options: &DecodingOptions) -> Result<Variant, StatusCode> {

--- a/opcua-client/src/transport/tcp.rs
+++ b/opcua-client/src/transport/tcp.rs
@@ -17,7 +17,7 @@ use opcua_core::{
     },
     trace_read_lock,
 };
-use opcua_types::{encoding::BinaryEncoder, StatusCode};
+use opcua_types::{encoding::BinaryEncodable, StatusCode};
 use parking_lot::RwLock;
 use tokio::io::{AsyncWriteExt, ReadHalf, WriteHalf};
 use tokio::net::TcpStream;

--- a/opcua-codegen/src/types/gen.rs
+++ b/opcua-codegen/src/types/gen.rs
@@ -253,7 +253,7 @@ impl CodeGenerator {
         let write_method = Ident::new(&format!("write_{}", item.typ), Span::call_site());
 
         impls.push(parse_quote! {
-            impl opcua::types::BinaryEncoder for #enum_ident {
+            impl opcua::types::BinaryEncodable for #enum_ident {
                 fn byte_len(&self) -> usize {
                     #size
                 }
@@ -551,7 +551,7 @@ impl CodeGenerator {
             }
         });
 
-        // BinaryEncoder impl
+        // BinaryEncodable impl
         let size: usize = item.size.try_into().map_err(|_| {
             CodeGenError::Other(format!("Value {} does not fit in a usize", item.size))
         })?;
@@ -559,7 +559,7 @@ impl CodeGenerator {
         let read_method = Ident::new(&format!("read_{}", item.typ), Span::call_site());
 
         impls.push(parse_quote! {
-            impl opcua::types::BinaryEncoder for #enum_ident {
+            impl opcua::types::BinaryEncodable for #enum_ident {
                 fn byte_len(&self) -> usize {
                     #size
                 }
@@ -744,12 +744,12 @@ impl CodeGenerator {
                 });
                 if has_context {
                     decode_impl.extend(quote! {
-                        let #ident = <#ty as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+                        let #ident = <#ty as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
                             .map_err(|e| e.with_request_handle(__request_handle))?;
                     })
                 } else {
                     decode_impl.extend(quote! {
-                        let #ident = <#ty as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+                        let #ident = <#ty as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
                     });
                 }
 
@@ -783,7 +783,7 @@ impl CodeGenerator {
         }
 
         impls.push(parse_quote! {
-            impl opcua::types::BinaryEncoder for #struct_ident {
+            impl opcua::types::BinaryEncodable for #struct_ident {
                 fn byte_len(&self) -> usize {
                     #len_impl
                 }

--- a/opcua-core/src/comms/buffer.rs
+++ b/opcua-core/src/comms/buffer.rs
@@ -11,7 +11,7 @@ use crate::{
     Message,
 };
 
-use opcua_types::{BinaryEncoder, EncodingError, StatusCode};
+use opcua_types::{BinaryEncodable, EncodingError, StatusCode};
 
 use super::tcp_types::{AcknowledgeMessage, ErrorMessage};
 

--- a/opcua-core/src/comms/chunker.rs
+++ b/opcua-core/src/comms/chunker.rs
@@ -17,7 +17,7 @@ use crate::{
 use log::{debug, error, trace};
 use opcua_crypto::SecurityPolicy;
 use opcua_types::{
-    encoding::BinaryEncoder, node_id::NodeId, node_ids::ObjectId, status_code::StatusCode,
+    encoding::BinaryEncodable, node_id::NodeId, node_ids::ObjectId, status_code::StatusCode,
     EncodingError,
 };
 

--- a/opcua-core/src/comms/message_chunk.rs
+++ b/opcua-core/src/comms/message_chunk.rs
@@ -10,7 +10,7 @@ use std::io::{Cursor, Read, Write};
 use log::{error, trace};
 use opcua_types::{
     process_decode_io_result, process_encode_io_result, read_u32, read_u8, status_code::StatusCode,
-    write_u32, write_u8, BinaryEncoder, DecodingOptions, EncodingResult,
+    write_u32, write_u8, BinaryEncodable, DecodingOptions, EncodingResult,
 };
 
 use super::{
@@ -63,7 +63,7 @@ pub struct MessageChunkHeader {
     pub secure_channel_id: u32,
 }
 
-impl BinaryEncoder for MessageChunkHeader {
+impl BinaryEncodable for MessageChunkHeader {
     fn byte_len(&self) -> usize {
         MESSAGE_CHUNK_HEADER_SIZE
     }
@@ -138,7 +138,7 @@ pub struct MessageChunk {
     pub data: Vec<u8>,
 }
 
-impl BinaryEncoder for MessageChunk {
+impl BinaryEncodable for MessageChunk {
     fn byte_len(&self) -> usize {
         self.data.len()
     }

--- a/opcua-core/src/comms/message_chunk_info.rs
+++ b/opcua-core/src/comms/message_chunk_info.rs
@@ -6,7 +6,7 @@ use std::io::Cursor;
 
 use log::error;
 use opcua_crypto::SecurityPolicy;
-use opcua_types::{BinaryEncoder, StatusCode};
+use opcua_types::{BinaryEncodable, StatusCode};
 
 use super::{
     message_chunk::{MessageChunk, MessageChunkHeader},

--- a/opcua-core/src/comms/message_writer.rs
+++ b/opcua-core/src/comms/message_writer.rs
@@ -5,7 +5,7 @@
 use std::io::{Cursor, Write};
 
 use log::{error, trace};
-use opcua_types::{status_code::StatusCode, BinaryEncoder, EncodingResult};
+use opcua_types::{status_code::StatusCode, BinaryEncodable, EncodingResult};
 
 use super::{chunker::Chunker, secure_channel::SecureChannel, tcp_types::AcknowledgeMessage};
 

--- a/opcua-core/src/comms/secure_channel.rs
+++ b/opcua-core/src/comms/secure_channel.rs
@@ -19,7 +19,7 @@ use opcua_crypto::{
 };
 use opcua_types::{
     service_types::ChannelSecurityToken, status_code::StatusCode, write_bytes, write_u8,
-    BinaryEncoder, ByteString, DecodingOptions, MessageSecurityMode,
+    BinaryEncodable, ByteString, DecodingOptions, MessageSecurityMode,
 };
 use parking_lot::RwLock;
 

--- a/opcua-core/src/comms/security_header.rs
+++ b/opcua-core/src/comms/security_header.rs
@@ -5,7 +5,7 @@
 use std::io::{Read, Write};
 
 use log::error;
-use opcua_types::BinaryEncoder;
+use opcua_types::BinaryEncodable;
 
 use opcua_types::{constants, status_code::StatusCode, *};
 
@@ -19,7 +19,7 @@ pub enum SecurityHeader {
     Symmetric(SymmetricSecurityHeader),
 }
 
-impl BinaryEncoder for SecurityHeader {
+impl BinaryEncodable for SecurityHeader {
     fn byte_len(&self) -> usize {
         match self {
             SecurityHeader::Asymmetric(value) => value.byte_len(),
@@ -44,7 +44,7 @@ pub struct SymmetricSecurityHeader {
     pub token_id: u32,
 }
 
-impl BinaryEncoder for SymmetricSecurityHeader {
+impl BinaryEncodable for SymmetricSecurityHeader {
     fn byte_len(&self) -> usize {
         4
     }
@@ -66,7 +66,7 @@ pub struct AsymmetricSecurityHeader {
     pub receiver_certificate_thumbprint: ByteString,
 }
 
-impl BinaryEncoder for AsymmetricSecurityHeader {
+impl BinaryEncodable for AsymmetricSecurityHeader {
     fn byte_len(&self) -> usize {
         let mut size = 0;
         size += self.security_policy_uri.byte_len();
@@ -155,7 +155,7 @@ pub struct SequenceHeader {
     pub request_id: u32,
 }
 
-impl BinaryEncoder for SequenceHeader {
+impl BinaryEncodable for SequenceHeader {
     fn byte_len(&self) -> usize {
         8
     }

--- a/opcua-core/src/comms/tcp_codec.rs
+++ b/opcua-core/src/comms/tcp_codec.rs
@@ -18,7 +18,7 @@ use log::error;
 use tokio_util::codec::{Decoder, Encoder};
 
 use opcua_types::{
-    encoding::{BinaryEncoder, DecodingOptions},
+    encoding::{BinaryEncodable, DecodingOptions},
     status_code::StatusCode,
 };
 
@@ -106,7 +106,7 @@ impl TcpCodec {
     // Writes the encodable thing into the buffer.
     fn write<T>(&self, msg: T, buf: &mut BytesMut) -> Result<(), io::Error>
     where
-        T: BinaryEncoder + std::fmt::Debug,
+        T: BinaryEncodable + std::fmt::Debug,
     {
         buf.reserve(msg.byte_len());
         msg.encode(&mut buf.writer()).map(|_| ()).map_err(|err| {

--- a/opcua-core/src/comms/tcp_types.rs
+++ b/opcua-core/src/comms/tcp_types.rs
@@ -46,7 +46,7 @@ pub struct MessageHeader {
     pub message_size: u32,
 }
 
-impl BinaryEncoder for MessageHeader {
+impl BinaryEncodable for MessageHeader {
     fn byte_len(&self) -> usize {
         MESSAGE_HEADER_LEN
     }
@@ -183,7 +183,7 @@ pub struct HelloMessage {
     pub endpoint_url: UAString,
 }
 
-impl BinaryEncoder for HelloMessage {
+impl BinaryEncodable for HelloMessage {
     fn byte_len(&self) -> usize {
         // 5 * u32 = 20
         self.message_header.byte_len() + 20 + self.endpoint_url.byte_len()
@@ -291,7 +291,7 @@ pub struct AcknowledgeMessage {
     pub max_chunk_count: u32,
 }
 
-impl BinaryEncoder for AcknowledgeMessage {
+impl BinaryEncodable for AcknowledgeMessage {
     fn byte_len(&self) -> usize {
         self.message_header.byte_len() + 20
     }
@@ -354,7 +354,7 @@ pub struct ErrorMessage {
     pub reason: UAString,
 }
 
-impl BinaryEncoder for ErrorMessage {
+impl BinaryEncodable for ErrorMessage {
     fn byte_len(&self) -> usize {
         self.message_header.byte_len() + self.error.byte_len() + self.reason.byte_len()
     }
@@ -400,7 +400,7 @@ mod tests {
     use std::io::Cursor;
 
     use crate::comms::tcp_types::{
-        AcknowledgeMessage, BinaryEncoder, HelloMessage, MessageHeader, MessageType,
+        AcknowledgeMessage, BinaryEncodable, HelloMessage, MessageHeader, MessageType,
     };
     use opcua_types::{
         ApplicationDescription, ByteString, DecodingOptions, EndpointDescription,

--- a/opcua-core/src/messages/mod.rs
+++ b/opcua-core/src/messages/mod.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 
-use opcua_types::{BinaryEncoder, DecodingOptions, EncodingResult, NodeId, ObjectId};
+use opcua_types::{BinaryEncodable, DecodingOptions, EncodingResult, NodeId, ObjectId};
 
 mod request;
 mod response;
@@ -14,7 +14,7 @@ pub trait MessageType {
     fn message_type(&self) -> MessageChunkType;
 }
 
-pub trait Message: BinaryEncoder + MessageType {
+pub trait Message: BinaryEncodable + MessageType {
     fn request_handle(&self) -> u32;
 
     fn decode_by_object_id<S: Read>(

--- a/opcua-core/src/messages/request.rs
+++ b/opcua-core/src/messages/request.rs
@@ -18,7 +18,7 @@ macro_rules! request_enum {
                 }
             }
         )*
-        impl BinaryEncoder for RequestMessage {
+        impl BinaryEncodable for RequestMessage {
             fn byte_len(&self) -> usize {
                 match self {
                     $( Self::$name(value) => value.byte_len(), )*

--- a/opcua-core/src/messages/response.rs
+++ b/opcua-core/src/messages/response.rs
@@ -18,7 +18,7 @@ macro_rules! response_enum {
                 }
             }
         )*
-        impl BinaryEncoder for ResponseMessage {
+        impl BinaryEncodable for ResponseMessage {
             fn byte_len(&self) -> usize {
                 match self {
                     $( Self::$name(value) => value.byte_len(), )*

--- a/opcua-core/src/tests/mod.rs
+++ b/opcua-core/src/tests/mod.rs
@@ -8,7 +8,7 @@ use opcua_crypto::{
     x509::{X509Data, X509},
 };
 use opcua_types::{
-    status_code::StatusCode, BinaryEncoder, ByteString, ChannelSecurityToken, DateTime,
+    status_code::StatusCode, BinaryEncodable, ByteString, ChannelSecurityToken, DateTime,
     DecodingOptions, DiagnosticBits, DiagnosticInfo, ExtensionObject, GetEndpointsRequest,
     MessageSecurityMode, NodeId, OpenSecureChannelResponse, RequestHeader, ResponseHeader,
     UAString,
@@ -18,7 +18,7 @@ use crate::{comms::secure_channel::SecureChannel, RequestMessage};
 
 pub fn serialize_test_and_return<T>(value: T) -> T
 where
-    T: BinaryEncoder + Debug + PartialEq,
+    T: BinaryEncodable + Debug + PartialEq,
 {
     // Ask the struct for its byte length
     let byte_len = value.byte_len();
@@ -50,7 +50,7 @@ where
 
 pub fn serialize_test<T>(value: T)
 where
-    T: BinaryEncoder + Debug + PartialEq,
+    T: BinaryEncodable + Debug + PartialEq,
 {
     let _ = serialize_test_and_return(value);
 }

--- a/opcua-server/src/node_manager/history.rs
+++ b/opcua-server/src/node_manager/history.rs
@@ -1,7 +1,7 @@
 use crate::session::{continuation_points::ContinuationPoint, instance::Session};
 use opcua_crypto::random;
 use opcua_types::{
-    BinaryEncoder, ByteString, DecodingOptions, DeleteAtTimeDetails, DeleteEventDetails,
+    BinaryEncodable, ByteString, DecodingOptions, DeleteAtTimeDetails, DeleteEventDetails,
     DeleteRawModifiedDetails, ExtensionObject, HistoryData, HistoryEvent, HistoryModifiedData,
     HistoryReadResult, HistoryReadValueId, HistoryUpdateResult, NodeId, NumericRange, ObjectId,
     QualifiedName, ReadAnnotationDataDetails, ReadAtTimeDetails, ReadEventDetails,
@@ -114,7 +114,7 @@ impl HistoryUpdateDetails {
 }
 
 /// Trait for values storable as history data.
-pub trait HistoryResult: BinaryEncoder + Sized {
+pub trait HistoryResult: BinaryEncodable + Sized {
     /// The object ID of the object encoding.
     const OBJECT_ID: ObjectId;
 

--- a/opcua-server/src/transport/tcp.rs
+++ b/opcua-server/src/transport/tcp.rs
@@ -19,7 +19,7 @@ use opcua_core::{
 
 use crate::info::ServerInfo;
 use opcua_types::{
-    BinaryEncoder, DecodingOptions, EncodingError, ResponseHeader, ServiceFault, StatusCode,
+    BinaryEncodable, DecodingOptions, EncodingError, ResponseHeader, ServiceFault, StatusCode,
 };
 
 use futures::StreamExt;

--- a/opcua-types/src/argument.rs
+++ b/opcua-types/src/argument.rs
@@ -26,7 +26,7 @@ pub struct Argument {
     pub description: LocalizedText,
 }
 
-impl BinaryEncoder for Argument {
+impl BinaryEncodable for Argument {
     fn byte_len(&self) -> usize {
         let mut size = 0;
         size += self.name.byte_len();

--- a/opcua-types/src/basic_types.rs
+++ b/opcua-types/src/basic_types.rs
@@ -23,7 +23,7 @@ use crate::encoding::*;
 // Float    -> f32
 // Double   -> f64
 
-impl BinaryEncoder for bool {
+impl BinaryEncodable for bool {
     fn byte_len(&self) -> usize {
         1
     }
@@ -38,7 +38,7 @@ impl BinaryEncoder for bool {
     }
 }
 
-impl BinaryEncoder for i8 {
+impl BinaryEncodable for i8 {
     fn byte_len(&self) -> usize {
         1
     }
@@ -53,7 +53,7 @@ impl BinaryEncoder for i8 {
 }
 
 /// An unsigned byt integer value between 0 and 255.
-impl BinaryEncoder for u8 {
+impl BinaryEncodable for u8 {
     fn byte_len(&self) -> usize {
         1
     }
@@ -68,7 +68,7 @@ impl BinaryEncoder for u8 {
 }
 
 /// A signed integer value between −32768 and 32767.
-impl BinaryEncoder for i16 {
+impl BinaryEncodable for i16 {
     fn byte_len(&self) -> usize {
         2
     }
@@ -83,7 +83,7 @@ impl BinaryEncoder for i16 {
 }
 
 /// An unsigned integer value between 0 and 65535.
-impl BinaryEncoder for u16 {
+impl BinaryEncodable for u16 {
     fn byte_len(&self) -> usize {
         2
     }
@@ -98,7 +98,7 @@ impl BinaryEncoder for u16 {
 }
 
 /// A signed integer value between −2147483648 and 2147483647.
-impl BinaryEncoder for i32 {
+impl BinaryEncodable for i32 {
     fn byte_len(&self) -> usize {
         4
     }
@@ -113,7 +113,7 @@ impl BinaryEncoder for i32 {
 }
 
 /// An unsigned integer value between 0 and 4294967295.
-impl BinaryEncoder for u32 {
+impl BinaryEncodable for u32 {
     fn byte_len(&self) -> usize {
         4
     }
@@ -128,7 +128,7 @@ impl BinaryEncoder for u32 {
 }
 
 /// A signed integer value between −9223372036854775808 and 9223372036854775807.
-impl BinaryEncoder for i64 {
+impl BinaryEncodable for i64 {
     fn byte_len(&self) -> usize {
         8
     }
@@ -143,7 +143,7 @@ impl BinaryEncoder for i64 {
 }
 
 /// An unsigned integer value between 0 and 18446744073709551615.
-impl BinaryEncoder for u64 {
+impl BinaryEncodable for u64 {
     fn byte_len(&self) -> usize {
         8
     }
@@ -158,7 +158,7 @@ impl BinaryEncoder for u64 {
 }
 
 /// An IEEE single precision (32 bit) floating point value.
-impl BinaryEncoder for f32 {
+impl BinaryEncodable for f32 {
     fn byte_len(&self) -> usize {
         4
     }
@@ -173,7 +173,7 @@ impl BinaryEncoder for f32 {
 }
 
 /// An IEEE double precision (64 bit) floating point value.
-impl BinaryEncoder for f64 {
+impl BinaryEncodable for f64 {
     fn byte_len(&self) -> usize {
         8
     }

--- a/opcua-types/src/byte_string.rs
+++ b/opcua-types/src/byte_string.rs
@@ -14,7 +14,7 @@ use log::error;
 
 use crate::{
     encoding::{
-        process_decode_io_result, process_encode_io_result, write_i32, BinaryEncoder,
+        process_decode_io_result, process_encode_io_result, write_i32, BinaryEncodable,
         DecodingOptions, EncodingResult,
     },
     status_code::StatusCode,
@@ -70,7 +70,7 @@ mod json {
     }
 }
 
-impl BinaryEncoder for ByteString {
+impl BinaryEncodable for ByteString {
     fn byte_len(&self) -> usize {
         // Length plus the actual length of bytes (if not null)
         4 + if self.value.is_none() {

--- a/opcua-types/src/data_value.rs
+++ b/opcua-types/src/data_value.rs
@@ -59,7 +59,7 @@ pub struct DataValue {
     pub server_picoseconds: Option<u16>,
 }
 
-impl BinaryEncoder for DataValue {
+impl BinaryEncodable for DataValue {
     fn byte_len(&self) -> usize {
         let mut size = 1;
         let encoding_mask = self.encoding_mask();

--- a/opcua-types/src/date_time.rs
+++ b/opcua-types/src/date_time.rs
@@ -61,7 +61,7 @@ mod json {
 }
 
 /// DateTime encoded as 64-bit signed int
-impl BinaryEncoder for DateTime {
+impl BinaryEncodable for DateTime {
     fn byte_len(&self) -> usize {
         8
     }

--- a/opcua-types/src/diagnostic_info.rs
+++ b/opcua-types/src/diagnostic_info.rs
@@ -118,7 +118,7 @@ pub struct DiagnosticInfo {
     pub inner_diagnostic_info: Option<Box<DiagnosticInfo>>,
 }
 
-impl BinaryEncoder for DiagnosticInfo {
+impl BinaryEncodable for DiagnosticInfo {
     fn byte_len(&self) -> usize {
         let mut size: usize = 0;
         size += 1; // self.encoding_mask())

--- a/opcua-types/src/encoding.rs
+++ b/opcua-types/src/encoding.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Adam Lock
 
-//! Contains the `BinaryEncoder` trait and helpers for reading and writing of scalar values and
+//! Contains the `BinaryEncodable` trait and helpers for reading and writing of scalar values and
 //! other primitives.
 
 use std::{
@@ -236,7 +236,7 @@ impl DecodingOptions {
 /// OPC UA Binary Encoding interface. Anything that encodes to binary must implement this. It provides
 /// functions to calculate the size in bytes of the struct (for allocating memory), encoding to a stream
 /// and decoding from a stream.
-pub trait BinaryEncoder: Sized {
+pub trait BinaryEncodable: Sized {
     /// Returns the exact byte length of the structure as it would be if `encode` were called.
     /// This may be called prior to writing to ensure the correct amount of space is available.
     fn byte_len(&self) -> usize;
@@ -275,9 +275,9 @@ where
     })
 }
 
-impl<T> BinaryEncoder for Option<Vec<T>>
+impl<T> BinaryEncodable for Option<Vec<T>>
 where
-    T: BinaryEncoder,
+    T: BinaryEncodable,
 {
     fn byte_len(&self) -> usize {
         let mut size = 4;
@@ -327,7 +327,7 @@ where
 }
 
 /// Calculates the length in bytes of an array of encoded type
-pub fn byte_len_array<T: BinaryEncoder>(values: &Option<Vec<T>>) -> usize {
+pub fn byte_len_array<T: BinaryEncodable>(values: &Option<Vec<T>>) -> usize {
     let mut size = 4;
     if let Some(ref values) = values {
         size += values.iter().map(|v| v.byte_len()).sum::<usize>();
@@ -336,7 +336,7 @@ pub fn byte_len_array<T: BinaryEncoder>(values: &Option<Vec<T>>) -> usize {
 }
 
 /// Write an array of the encoded type to stream, preserving distinction between null array and empty array
-pub fn write_array<S: Write, T: BinaryEncoder>(
+pub fn write_array<S: Write, T: BinaryEncodable>(
     stream: &mut S,
     values: &Option<Vec<T>>,
 ) -> EncodingResult<usize> {
@@ -353,7 +353,7 @@ pub fn write_array<S: Write, T: BinaryEncoder>(
 }
 
 /// Reads an array of the encoded type from a stream, preserving distinction between null array and empty array
-pub fn read_array<S: Read, T: BinaryEncoder>(
+pub fn read_array<S: Read, T: BinaryEncodable>(
     stream: &mut S,
     decoding_options: &DecodingOptions,
 ) -> EncodingResult<Option<Vec<T>>> {

--- a/opcua-types/src/expanded_node_id.rs
+++ b/opcua-types/src/expanded_node_id.rs
@@ -206,7 +206,7 @@ mod json {
     }
 }
 
-impl BinaryEncoder for ExpandedNodeId {
+impl BinaryEncodable for ExpandedNodeId {
     fn byte_len(&self) -> usize {
         let mut size = self.node_id.byte_len();
         if !self.namespace_uri.is_null() {

--- a/opcua-types/src/extension_object.rs
+++ b/opcua-types/src/extension_object.rs
@@ -207,7 +207,7 @@ impl Default for ExtensionObject {
     }
 }
 
-impl BinaryEncoder for ExtensionObject {
+impl BinaryEncodable for ExtensionObject {
     fn byte_len(&self) -> usize {
         let mut size = self.node_id.byte_len();
         size += match self.body {
@@ -310,7 +310,7 @@ impl ExtensionObject {
     pub fn from_encodable<N, T>(node_id: N, encodable: &T) -> ExtensionObject
     where
         N: Into<NodeId>,
-        T: BinaryEncoder,
+        T: BinaryEncodable,
     {
         // Serialize to extension object
         let mut stream = Cursor::new(vec![0u8; encodable.byte_len()]);
@@ -323,7 +323,7 @@ impl ExtensionObject {
 
     pub fn from_message<T>(encodable: &T) -> ExtensionObject
     where
-        T: BinaryEncoder + MessageInfo,
+        T: BinaryEncodable + MessageInfo,
     {
         Self::from_encodable(encodable.type_id(), encodable)
     }
@@ -344,7 +344,7 @@ impl ExtensionObject {
         ctx: &EncodingContext,
     ) -> Result<ExtensionObject, StatusCode>
     where
-        T: BinaryEncoder + ExpandedMessageInfo,
+        T: BinaryEncodable + ExpandedMessageInfo,
     {
         let id = ctx
             .resolve_node_id(&encodable.full_type_id())
@@ -376,7 +376,7 @@ impl ExtensionObject {
     /// the data. Errors result in a decoding error.
     pub fn decode_inner<T>(&self, decoding_options: &DecodingOptions) -> EncodingResult<T>
     where
-        T: BinaryEncoder,
+        T: BinaryEncodable,
     {
         match self.body {
             ExtensionObjectEncoding::ByteString(ref byte_string) => {

--- a/opcua-types/src/guid.rs
+++ b/opcua-types/src/guid.rs
@@ -61,7 +61,7 @@ impl fmt::Debug for Guid {
     }
 }
 
-impl BinaryEncoder for Guid {
+impl BinaryEncodable for Guid {
     fn byte_len(&self) -> usize {
         16
     }

--- a/opcua-types/src/localized_text.rs
+++ b/opcua-types/src/localized_text.rs
@@ -67,7 +67,7 @@ impl fmt::Display for LocalizedText {
     }
 }
 
-impl BinaryEncoder for LocalizedText {
+impl BinaryEncodable for LocalizedText {
     fn byte_len(&self) -> usize {
         let mut size = 1;
         if !self.locale.is_empty() {

--- a/opcua-types/src/node_id.rs
+++ b/opcua-types/src/node_id.rs
@@ -309,7 +309,7 @@ mod json {
     }
 }
 
-impl BinaryEncoder for NodeId {
+impl BinaryEncodable for NodeId {
     fn byte_len(&self) -> usize {
         // Type determines the byte code
         let size: usize = match self.identifier {

--- a/opcua-types/src/qualified_name.rs
+++ b/opcua-types/src/qualified_name.rs
@@ -79,7 +79,7 @@ impl From<String> for QualifiedName {
     }
 }
 
-impl BinaryEncoder for QualifiedName {
+impl BinaryEncodable for QualifiedName {
     fn byte_len(&self) -> usize {
         let mut size: usize = 0;
         size += self.namespace_index.byte_len();

--- a/opcua-types/src/request_header.rs
+++ b/opcua-types/src/request_header.rs
@@ -109,7 +109,7 @@ impl Default for RequestHeader {
     }
 }
 
-impl BinaryEncoder for RequestHeader {
+impl BinaryEncodable for RequestHeader {
     fn byte_len(&self) -> usize {
         let mut size: usize = 0;
         size += self.authentication_token.byte_len();

--- a/opcua-types/src/response_header.rs
+++ b/opcua-types/src/response_header.rs
@@ -33,7 +33,7 @@ pub struct ResponseHeader {
     pub additional_header: ExtensionObject,
 }
 
-impl BinaryEncoder for ResponseHeader {
+impl BinaryEncodable for ResponseHeader {
     fn byte_len(&self) -> usize {
         let mut size = 0;
         size += self.timestamp.byte_len();

--- a/opcua-types/src/service_types/activate_session_request.rs
+++ b/opcua-types/src/service_types/activate_session_request.rs
@@ -6,7 +6,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
-mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
+mod opcua {
+    pub use crate as types;
+}
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "json", serde_with::skip_serializing_none)]
 #[cfg_attr(feature = "json", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "json", serde(rename_all = "PascalCase"))]
@@ -15,9 +18,8 @@ mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
 pub struct ActivateSessionRequest {
     pub request_header: opcua::types::request_header::RequestHeader,
     pub client_signature: super::signature_data::SignatureData,
-    pub client_software_certificates: Option<
-        Vec<super::signed_software_certificate::SignedSoftwareCertificate>,
-    >,
+    pub client_software_certificates:
+        Option<Vec<super::signed_software_certificate::SignedSoftwareCertificate>>,
     pub locale_ids: Option<Vec<opcua::types::string::UAString>>,
     pub user_identity_token: opcua::types::extension_object::ExtensionObject,
     pub user_token_signature: super::signature_data::SignatureData,
@@ -33,7 +35,7 @@ impl opcua::types::MessageInfo for ActivateSessionRequest {
         opcua::types::ObjectId::ActivateSessionRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ActivateSessionRequest {
+impl opcua::types::BinaryEncodable for ActivateSessionRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -45,10 +47,7 @@ impl opcua::types::BinaryEncoder for ActivateSessionRequest {
         size
     }
     #[allow(unused_variables)]
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         let mut size = 0usize;
         size += self.request_header.encode(stream)?;
         size += self.client_signature.encode(stream)?;
@@ -63,30 +62,37 @@ impl opcua::types::BinaryEncoder for ActivateSessionRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
-            stream,
-            decoding_options,
-        )?;
+        let request_header =
+            <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
+                stream,
+                decoding_options,
+            )?;
         let __request_handle = request_header.request_handle;
-        let client_signature = <super::signature_data::SignatureData as opcua::types::BinaryEncoder>::decode(
+        let client_signature =
+            <super::signature_data::SignatureData as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let client_software_certificates = <Option<
             Vec<super::signed_software_certificate::SignedSoftwareCertificate>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
-            .map_err(|e| e.with_request_handle(__request_handle))?;
-        let locale_ids = <Option<
-            Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
-            .map_err(|e| e.with_request_handle(__request_handle))?;
-        let user_identity_token = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(
+            stream, decoding_options
+        )
+        .map_err(|e| e.with_request_handle(__request_handle))?;
+        let locale_ids =
+            <Option<Vec<opcua::types::string::UAString>> as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let user_token_signature = <super::signature_data::SignatureData as opcua::types::BinaryEncoder>::decode(
+        let user_identity_token = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
+                stream,
+                decoding_options,
+            )
+            .map_err(|e| e.with_request_handle(__request_handle))?;
+        let user_token_signature =
+            <super::signature_data::SignatureData as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/activate_session_response.rs
+++ b/opcua-types/src/service_types/activate_session_response.rs
@@ -6,7 +6,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2024 Adam Lock, Einar Omang
 #[allow(unused)]
-mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
+mod opcua {
+    pub use crate as types;
+}
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "json", serde_with::skip_serializing_none)]
 #[cfg_attr(feature = "json", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "json", serde(rename_all = "PascalCase"))]
@@ -29,7 +32,7 @@ impl opcua::types::MessageInfo for ActivateSessionResponse {
         opcua::types::ObjectId::ActivateSessionResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ActivateSessionResponse {
+impl opcua::types::BinaryEncodable for ActivateSessionResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -39,10 +42,7 @@ impl opcua::types::BinaryEncoder for ActivateSessionResponse {
         size
     }
     #[allow(unused_variables)]
-    fn encode<S: std::io::Write>(
-        &self,
-        stream: &mut S,
-    ) -> opcua::types::EncodingResult<usize> {
+    fn encode<S: std::io::Write>(&self, stream: &mut S) -> opcua::types::EncodingResult<usize> {
         let mut size = 0usize;
         size += self.response_header.encode(stream)?;
         size += self.server_nonce.encode(stream)?;
@@ -55,23 +55,24 @@ impl opcua::types::BinaryEncoder for ActivateSessionResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
-        let server_nonce = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let server_nonce =
+            <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/add_nodes_item.rs
+++ b/opcua-types/src/service_types/add_nodes_item.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for AddNodesItem {
         opcua::types::ObjectId::AddNodesItem_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AddNodesItem {
+impl opcua::types::BinaryEncodable for AddNodesItem {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.parent_node_id.byte_len();
@@ -63,31 +63,31 @@ impl opcua::types::BinaryEncoder for AddNodesItem {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let parent_node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let parent_node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let requested_new_node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let requested_new_node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let browse_name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let browse_name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let node_class = <super::enums::NodeClass as opcua::types::BinaryEncoder>::decode(
+        let node_class = <super::enums::NodeClass as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let node_attributes = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let node_attributes = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let type_definition = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let type_definition = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/add_nodes_request.rs
+++ b/opcua-types/src/service_types/add_nodes_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for AddNodesRequest {
         opcua::types::ObjectId::AddNodesRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AddNodesRequest {
+impl opcua::types::BinaryEncodable for AddNodesRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for AddNodesRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let nodes_to_add = <Option<
             Vec<super::add_nodes_item::AddNodesItem>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/add_nodes_response.rs
+++ b/opcua-types/src/service_types/add_nodes_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for AddNodesResponse {
         opcua::types::ObjectId::AddNodesResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AddNodesResponse {
+impl opcua::types::BinaryEncodable for AddNodesResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for AddNodesResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<super::add_nodes_result::AddNodesResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/add_nodes_result.rs
+++ b/opcua-types/src/service_types/add_nodes_result.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for AddNodesResult {
         opcua::types::ObjectId::AddNodesResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AddNodesResult {
+impl opcua::types::BinaryEncodable for AddNodesResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for AddNodesResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let added_node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let added_node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/add_references_item.rs
+++ b/opcua-types/src/service_types/add_references_item.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for AddReferencesItem {
         opcua::types::ObjectId::AddReferencesItem_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AddReferencesItem {
+impl opcua::types::BinaryEncodable for AddReferencesItem {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.source_node_id.byte_len();
@@ -60,27 +60,27 @@ impl opcua::types::BinaryEncoder for AddReferencesItem {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let source_node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let source_node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_forward = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_forward = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let target_server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let target_server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let target_node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let target_node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let target_node_class = <super::enums::NodeClass as opcua::types::BinaryEncoder>::decode(
+        let target_node_class = <super::enums::NodeClass as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/add_references_request.rs
+++ b/opcua-types/src/service_types/add_references_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for AddReferencesRequest {
         opcua::types::ObjectId::AddReferencesRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AddReferencesRequest {
+impl opcua::types::BinaryEncodable for AddReferencesRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for AddReferencesRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let references_to_add = <Option<
             Vec<super::add_references_item::AddReferencesItem>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/add_references_response.rs
+++ b/opcua-types/src/service_types/add_references_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for AddReferencesResponse {
         opcua::types::ObjectId::AddReferencesResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AddReferencesResponse {
+impl opcua::types::BinaryEncodable for AddReferencesResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for AddReferencesResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/additional_parameters_type.rs
+++ b/opcua-types/src/service_types/additional_parameters_type.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for AdditionalParametersType {
         opcua::types::ObjectId::AdditionalParametersType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AdditionalParametersType {
+impl opcua::types::BinaryEncodable for AdditionalParametersType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.parameters.byte_len();
@@ -48,7 +48,7 @@ impl opcua::types::BinaryEncoder for AdditionalParametersType {
     ) -> opcua::types::EncodingResult<Self> {
         let parameters = <Option<
             Vec<super::key_value_pair::KeyValuePair>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { parameters })
     }
 }

--- a/opcua-types/src/service_types/aggregate_configuration.rs
+++ b/opcua-types/src/service_types/aggregate_configuration.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for AggregateConfiguration {
         opcua::types::ObjectId::AggregateConfiguration_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AggregateConfiguration {
+impl opcua::types::BinaryEncodable for AggregateConfiguration {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.use_server_capabilities_defaults.byte_len();
@@ -58,23 +58,23 @@ impl opcua::types::BinaryEncoder for AggregateConfiguration {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let use_server_capabilities_defaults = <bool as opcua::types::BinaryEncoder>::decode(
+        let use_server_capabilities_defaults = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let treat_uncertain_as_bad = <bool as opcua::types::BinaryEncoder>::decode(
+        let treat_uncertain_as_bad = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let percent_data_bad = <u8 as opcua::types::BinaryEncoder>::decode(
+        let percent_data_bad = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let percent_data_good = <u8 as opcua::types::BinaryEncoder>::decode(
+        let percent_data_good = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let use_sloped_extrapolation = <bool as opcua::types::BinaryEncoder>::decode(
+        let use_sloped_extrapolation = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/aggregate_filter.rs
+++ b/opcua-types/src/service_types/aggregate_filter.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for AggregateFilter {
         opcua::types::ObjectId::AggregateFilter_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AggregateFilter {
+impl opcua::types::BinaryEncodable for AggregateFilter {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.start_time.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for AggregateFilter {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let aggregate_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let aggregate_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let processing_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let processing_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let aggregate_configuration = <super::aggregate_configuration::AggregateConfiguration as opcua::types::BinaryEncoder>::decode(
+        let aggregate_configuration = <super::aggregate_configuration::AggregateConfiguration as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/aggregate_filter_result.rs
+++ b/opcua-types/src/service_types/aggregate_filter_result.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for AggregateFilterResult {
         opcua::types::ObjectId::AggregateFilterResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AggregateFilterResult {
+impl opcua::types::BinaryEncodable for AggregateFilterResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.revised_start_time.byte_len();
@@ -52,15 +52,15 @@ impl opcua::types::BinaryEncoder for AggregateFilterResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let revised_start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let revised_start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let revised_processing_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let revised_processing_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let revised_aggregate_configuration = <super::aggregate_configuration::AggregateConfiguration as opcua::types::BinaryEncoder>::decode(
+        let revised_aggregate_configuration = <super::aggregate_configuration::AggregateConfiguration as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/alias_name_data_type.rs
+++ b/opcua-types/src/service_types/alias_name_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for AliasNameDataType {
         opcua::types::ObjectId::AliasNameDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AliasNameDataType {
+impl opcua::types::BinaryEncodable for AliasNameDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.alias_name.byte_len();
@@ -49,13 +49,13 @@ impl opcua::types::BinaryEncoder for AliasNameDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let alias_name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let alias_name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let referenced_nodes = <Option<
             Vec<opcua::types::expanded_node_id::ExpandedNodeId>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             alias_name,
             referenced_nodes,

--- a/opcua-types/src/service_types/annotation.rs
+++ b/opcua-types/src/service_types/annotation.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for Annotation {
         opcua::types::ObjectId::Annotation_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for Annotation {
+impl opcua::types::BinaryEncodable for Annotation {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.message.byte_len();
@@ -52,15 +52,15 @@ impl opcua::types::BinaryEncoder for Annotation {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let message = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let message = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let user_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let annotation_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let annotation_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/anonymous_identity_token.rs
+++ b/opcua-types/src/service_types/anonymous_identity_token.rs
@@ -25,7 +25,7 @@ impl opcua::types::MessageInfo for AnonymousIdentityToken {
         opcua::types::ObjectId::AnonymousIdentityToken_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AnonymousIdentityToken {
+impl opcua::types::BinaryEncodable for AnonymousIdentityToken {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.policy_id.byte_len();
@@ -45,7 +45,7 @@ impl opcua::types::BinaryEncoder for AnonymousIdentityToken {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/application_description.rs
+++ b/opcua-types/src/service_types/application_description.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for ApplicationDescription {
         opcua::types::ObjectId::ApplicationDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ApplicationDescription {
+impl opcua::types::BinaryEncodable for ApplicationDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.application_uri.byte_len();
@@ -63,33 +63,33 @@ impl opcua::types::BinaryEncoder for ApplicationDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let application_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let application_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let product_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let product_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let application_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let application_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let application_type = <super::enums::ApplicationType as opcua::types::BinaryEncoder>::decode(
+        let application_type = <super::enums::ApplicationType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let gateway_server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let gateway_server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let discovery_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let discovery_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let discovery_urls = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             application_uri,
             product_uri,

--- a/opcua-types/src/service_types/argument.rs
+++ b/opcua-types/src/service_types/argument.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for Argument {
         opcua::types::ObjectId::Argument_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for Argument {
+impl opcua::types::BinaryEncodable for Argument {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.name.byte_len();
@@ -58,22 +58,22 @@ impl opcua::types::BinaryEncoder for Argument {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value_rank = <i32 as opcua::types::BinaryEncoder>::decode(
+        let value_rank = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let array_dimensions = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/attribute_operand.rs
+++ b/opcua-types/src/service_types/attribute_operand.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for AttributeOperand {
         opcua::types::ObjectId::AttributeOperand_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AttributeOperand {
+impl opcua::types::BinaryEncodable for AttributeOperand {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -58,23 +58,23 @@ impl opcua::types::BinaryEncoder for AttributeOperand {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let alias = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let alias = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let browse_path = <super::relative_path::RelativePath as opcua::types::BinaryEncoder>::decode(
+        let browse_path = <super::relative_path::RelativePath as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let attribute_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let attribute_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/axis_information.rs
+++ b/opcua-types/src/service_types/axis_information.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for AxisInformation {
         opcua::types::ObjectId::AxisInformation_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for AxisInformation {
+impl opcua::types::BinaryEncodable for AxisInformation {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.engineering_units.byte_len();
@@ -57,25 +57,25 @@ impl opcua::types::BinaryEncoder for AxisInformation {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let engineering_units = <super::eu_information::EUInformation as opcua::types::BinaryEncoder>::decode(
+        let engineering_units = <super::eu_information::EUInformation as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let eu_range = <super::range::Range as opcua::types::BinaryEncoder>::decode(
+        let eu_range = <super::range::Range as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let title = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let title = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let axis_scale_type = <super::enums::AxisScaleEnumeration as opcua::types::BinaryEncoder>::decode(
+        let axis_scale_type = <super::enums::AxisScaleEnumeration as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let axis_steps = <Option<
             Vec<f64>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             engineering_units,
             eu_range,

--- a/opcua-types/src/service_types/broker_connection_transport_data_type.rs
+++ b/opcua-types/src/service_types/broker_connection_transport_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for BrokerConnectionTransportDataType {
         opcua::types::ObjectId::BrokerConnectionTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrokerConnectionTransportDataType {
+impl opcua::types::BinaryEncodable for BrokerConnectionTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.resource_uri.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for BrokerConnectionTransportDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let resource_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let resource_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let authentication_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let authentication_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/broker_data_set_reader_transport_data_type.rs
+++ b/opcua-types/src/service_types/broker_data_set_reader_transport_data_type.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for BrokerDataSetReaderTransportDataType {
         opcua::types::ObjectId::BrokerDataSetReaderTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrokerDataSetReaderTransportDataType {
+impl opcua::types::BinaryEncodable for BrokerDataSetReaderTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.queue_name.byte_len();
@@ -57,23 +57,23 @@ impl opcua::types::BinaryEncoder for BrokerDataSetReaderTransportDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let queue_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let queue_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let resource_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let resource_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let authentication_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let authentication_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let requested_delivery_guarantee = <super::enums::BrokerTransportQualityOfService as opcua::types::BinaryEncoder>::decode(
+        let requested_delivery_guarantee = <super::enums::BrokerTransportQualityOfService as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let meta_data_queue_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let meta_data_queue_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/broker_data_set_writer_transport_data_type.rs
+++ b/opcua-types/src/service_types/broker_data_set_writer_transport_data_type.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for BrokerDataSetWriterTransportDataType {
         opcua::types::ObjectId::BrokerDataSetWriterTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrokerDataSetWriterTransportDataType {
+impl opcua::types::BinaryEncodable for BrokerDataSetWriterTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.queue_name.byte_len();
@@ -60,27 +60,27 @@ impl opcua::types::BinaryEncoder for BrokerDataSetWriterTransportDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let queue_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let queue_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let resource_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let resource_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let authentication_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let authentication_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let requested_delivery_guarantee = <super::enums::BrokerTransportQualityOfService as opcua::types::BinaryEncoder>::decode(
+        let requested_delivery_guarantee = <super::enums::BrokerTransportQualityOfService as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let meta_data_queue_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let meta_data_queue_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let meta_data_update_time = <f64 as opcua::types::BinaryEncoder>::decode(
+        let meta_data_update_time = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/broker_writer_group_transport_data_type.rs
+++ b/opcua-types/src/service_types/broker_writer_group_transport_data_type.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for BrokerWriterGroupTransportDataType {
         opcua::types::ObjectId::BrokerWriterGroupTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrokerWriterGroupTransportDataType {
+impl opcua::types::BinaryEncodable for BrokerWriterGroupTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.queue_name.byte_len();
@@ -54,19 +54,19 @@ impl opcua::types::BinaryEncoder for BrokerWriterGroupTransportDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let queue_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let queue_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let resource_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let resource_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let authentication_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let authentication_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let requested_delivery_guarantee = <super::enums::BrokerTransportQualityOfService as opcua::types::BinaryEncoder>::decode(
+        let requested_delivery_guarantee = <super::enums::BrokerTransportQualityOfService as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/browse_description.rs
+++ b/opcua-types/src/service_types/browse_description.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for BrowseDescription {
         opcua::types::ObjectId::BrowseDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrowseDescription {
+impl opcua::types::BinaryEncodable for BrowseDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -60,27 +60,27 @@ impl opcua::types::BinaryEncoder for BrowseDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let browse_direction = <super::enums::BrowseDirection as opcua::types::BinaryEncoder>::decode(
+        let browse_direction = <super::enums::BrowseDirection as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let include_subtypes = <bool as opcua::types::BinaryEncoder>::decode(
+        let include_subtypes = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let node_class_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let node_class_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let result_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let result_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/browse_next_request.rs
+++ b/opcua-types/src/service_types/browse_next_request.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for BrowseNextRequest {
         opcua::types::ObjectId::BrowseNextRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrowseNextRequest {
+impl opcua::types::BinaryEncodable for BrowseNextRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -52,19 +52,19 @@ impl opcua::types::BinaryEncoder for BrowseNextRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let release_continuation_points = <bool as opcua::types::BinaryEncoder>::decode(
+        let release_continuation_points = <bool as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let continuation_points = <Option<
             Vec<opcua::types::byte_string::ByteString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/browse_next_response.rs
+++ b/opcua-types/src/service_types/browse_next_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for BrowseNextResponse {
         opcua::types::ObjectId::BrowseNextResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrowseNextResponse {
+impl opcua::types::BinaryEncodable for BrowseNextResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for BrowseNextResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<super::browse_result::BrowseResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/browse_path.rs
+++ b/opcua-types/src/service_types/browse_path.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for BrowsePath {
         opcua::types::ObjectId::BrowsePath_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrowsePath {
+impl opcua::types::BinaryEncodable for BrowsePath {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.starting_node.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for BrowsePath {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let starting_node = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let starting_node = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let relative_path = <super::relative_path::RelativePath as opcua::types::BinaryEncoder>::decode(
+        let relative_path = <super::relative_path::RelativePath as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/browse_path_result.rs
+++ b/opcua-types/src/service_types/browse_path_result.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for BrowsePathResult {
         opcua::types::ObjectId::BrowsePathResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrowsePathResult {
+impl opcua::types::BinaryEncodable for BrowsePathResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -49,13 +49,13 @@ impl opcua::types::BinaryEncoder for BrowsePathResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let targets = <Option<
             Vec<super::browse_path_target::BrowsePathTarget>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { status_code, targets })
     }
 }

--- a/opcua-types/src/service_types/browse_path_target.rs
+++ b/opcua-types/src/service_types/browse_path_target.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for BrowsePathTarget {
         opcua::types::ObjectId::BrowsePathTarget_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrowsePathTarget {
+impl opcua::types::BinaryEncodable for BrowsePathTarget {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.target_id.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for BrowsePathTarget {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let target_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let target_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let remaining_path_index = <u32 as opcua::types::BinaryEncoder>::decode(
+        let remaining_path_index = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/browse_request.rs
+++ b/opcua-types/src/service_types/browse_request.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for BrowseRequest {
         opcua::types::ObjectId::BrowseRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrowseRequest {
+impl opcua::types::BinaryEncodable for BrowseRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -55,24 +55,24 @@ impl opcua::types::BinaryEncoder for BrowseRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let view = <super::view_description::ViewDescription as opcua::types::BinaryEncoder>::decode(
+        let view = <super::view_description::ViewDescription as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let requested_max_references_per_node = <u32 as opcua::types::BinaryEncoder>::decode(
+        let requested_max_references_per_node = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let nodes_to_browse = <Option<
             Vec<super::browse_description::BrowseDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/browse_response.rs
+++ b/opcua-types/src/service_types/browse_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for BrowseResponse {
         opcua::types::ObjectId::BrowseResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrowseResponse {
+impl opcua::types::BinaryEncodable for BrowseResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for BrowseResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<super::browse_result::BrowseResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/browse_result.rs
+++ b/opcua-types/src/service_types/browse_result.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for BrowseResult {
         opcua::types::ObjectId::BrowseResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BrowseResult {
+impl opcua::types::BinaryEncodable for BrowseResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -52,17 +52,17 @@ impl opcua::types::BinaryEncoder for BrowseResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let references = <Option<
             Vec<super::reference_description::ReferenceDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             status_code,
             continuation_point,

--- a/opcua-types/src/service_types/build_info.rs
+++ b/opcua-types/src/service_types/build_info.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for BuildInfo {
         opcua::types::ObjectId::BuildInfo_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for BuildInfo {
+impl opcua::types::BinaryEncodable for BuildInfo {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.product_uri.byte_len();
@@ -61,27 +61,27 @@ impl opcua::types::BinaryEncoder for BuildInfo {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let product_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let product_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let manufacturer_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let manufacturer_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let product_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let product_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let software_version = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let software_version = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let build_number = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let build_number = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let build_date = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let build_date = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/call_method_request.rs
+++ b/opcua-types/src/service_types/call_method_request.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for CallMethodRequest {
         opcua::types::ObjectId::CallMethodRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CallMethodRequest {
+impl opcua::types::BinaryEncodable for CallMethodRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.object_id.byte_len();
@@ -52,17 +52,17 @@ impl opcua::types::BinaryEncoder for CallMethodRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let object_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let object_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let method_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let method_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let input_arguments = <Option<
             Vec<opcua::types::variant::Variant>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             object_id,
             method_id,

--- a/opcua-types/src/service_types/call_method_result.rs
+++ b/opcua-types/src/service_types/call_method_result.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for CallMethodResult {
         opcua::types::ObjectId::CallMethodResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CallMethodResult {
+impl opcua::types::BinaryEncodable for CallMethodResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -57,19 +57,19 @@ impl opcua::types::BinaryEncoder for CallMethodResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let input_argument_results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let input_argument_diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let output_arguments = <Option<
             Vec<opcua::types::variant::Variant>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             status_code,
             input_argument_results,

--- a/opcua-types/src/service_types/call_request.rs
+++ b/opcua-types/src/service_types/call_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for CallRequest {
         opcua::types::ObjectId::CallRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CallRequest {
+impl opcua::types::BinaryEncodable for CallRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for CallRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let methods_to_call = <Option<
             Vec<super::call_method_request::CallMethodRequest>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/call_response.rs
+++ b/opcua-types/src/service_types/call_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for CallResponse {
         opcua::types::ObjectId::CallResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CallResponse {
+impl opcua::types::BinaryEncodable for CallResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for CallResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<super::call_method_result::CallMethodResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/cancel_request.rs
+++ b/opcua-types/src/service_types/cancel_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for CancelRequest {
         opcua::types::ObjectId::CancelRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CancelRequest {
+impl opcua::types::BinaryEncodable for CancelRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,12 +49,12 @@ impl opcua::types::BinaryEncoder for CancelRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let request_handle = <u32 as opcua::types::BinaryEncoder>::decode(
+        let request_handle = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/cancel_response.rs
+++ b/opcua-types/src/service_types/cancel_response.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for CancelResponse {
         opcua::types::ObjectId::CancelResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CancelResponse {
+impl opcua::types::BinaryEncodable for CancelResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -49,12 +49,12 @@ impl opcua::types::BinaryEncoder for CancelResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
-        let cancel_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let cancel_count = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/cartesian_coordinates.rs
+++ b/opcua-types/src/service_types/cartesian_coordinates.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for CartesianCoordinates {
         opcua::types::ObjectId::CartesianCoordinates_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CartesianCoordinates {
+impl opcua::types::BinaryEncodable for CartesianCoordinates {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/channel_security_token.rs
+++ b/opcua-types/src/service_types/channel_security_token.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for ChannelSecurityToken {
         opcua::types::ObjectId::ChannelSecurityToken_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ChannelSecurityToken {
+impl opcua::types::BinaryEncodable for ChannelSecurityToken {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.channel_id.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for ChannelSecurityToken {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let channel_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let channel_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let token_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let token_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let created_at = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let created_at = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let revised_lifetime = <u32 as opcua::types::BinaryEncoder>::decode(
+        let revised_lifetime = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/close_secure_channel_request.rs
+++ b/opcua-types/src/service_types/close_secure_channel_request.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for CloseSecureChannelRequest {
         opcua::types::ObjectId::CloseSecureChannelRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CloseSecureChannelRequest {
+impl opcua::types::BinaryEncodable for CloseSecureChannelRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for CloseSecureChannelRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/close_secure_channel_response.rs
+++ b/opcua-types/src/service_types/close_secure_channel_response.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for CloseSecureChannelResponse {
         opcua::types::ObjectId::CloseSecureChannelResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CloseSecureChannelResponse {
+impl opcua::types::BinaryEncodable for CloseSecureChannelResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for CloseSecureChannelResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/close_session_request.rs
+++ b/opcua-types/src/service_types/close_session_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for CloseSessionRequest {
         opcua::types::ObjectId::CloseSessionRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CloseSessionRequest {
+impl opcua::types::BinaryEncodable for CloseSessionRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,12 +49,12 @@ impl opcua::types::BinaryEncoder for CloseSessionRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let delete_subscriptions = <bool as opcua::types::BinaryEncoder>::decode(
+        let delete_subscriptions = <bool as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/close_session_response.rs
+++ b/opcua-types/src/service_types/close_session_response.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for CloseSessionResponse {
         opcua::types::ObjectId::CloseSessionResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CloseSessionResponse {
+impl opcua::types::BinaryEncodable for CloseSessionResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for CloseSessionResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/complex_number_type.rs
+++ b/opcua-types/src/service_types/complex_number_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for ComplexNumberType {
         opcua::types::ObjectId::ComplexNumberType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ComplexNumberType {
+impl opcua::types::BinaryEncodable for ComplexNumberType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.real.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for ComplexNumberType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let real = <f32 as opcua::types::BinaryEncoder>::decode(
+        let real = <f32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let imaginary = <f32 as opcua::types::BinaryEncoder>::decode(
+        let imaginary = <f32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/configuration_version_data_type.rs
+++ b/opcua-types/src/service_types/configuration_version_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for ConfigurationVersionDataType {
         opcua::types::ObjectId::ConfigurationVersionDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ConfigurationVersionDataType {
+impl opcua::types::BinaryEncodable for ConfigurationVersionDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.major_version.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for ConfigurationVersionDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let major_version = <u32 as opcua::types::BinaryEncoder>::decode(
+        let major_version = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let minor_version = <u32 as opcua::types::BinaryEncoder>::decode(
+        let minor_version = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/connection_transport_data_type.rs
+++ b/opcua-types/src/service_types/connection_transport_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for ConnectionTransportDataType {
         opcua::types::ObjectId::ConnectionTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ConnectionTransportDataType {
+impl opcua::types::BinaryEncodable for ConnectionTransportDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/content_filter.rs
+++ b/opcua-types/src/service_types/content_filter.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for ContentFilter {
         opcua::types::ObjectId::ContentFilter_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ContentFilter {
+impl opcua::types::BinaryEncodable for ContentFilter {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.elements.byte_len();
@@ -48,7 +48,7 @@ impl opcua::types::BinaryEncoder for ContentFilter {
     ) -> opcua::types::EncodingResult<Self> {
         let elements = <Option<
             Vec<super::content_filter_element::ContentFilterElement>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { elements })
     }
 }

--- a/opcua-types/src/service_types/content_filter_element.rs
+++ b/opcua-types/src/service_types/content_filter_element.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for ContentFilterElement {
         opcua::types::ObjectId::ContentFilterElement_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ContentFilterElement {
+impl opcua::types::BinaryEncodable for ContentFilterElement {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.filter_operator.byte_len();
@@ -48,13 +48,13 @@ impl opcua::types::BinaryEncoder for ContentFilterElement {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let filter_operator = <super::enums::FilterOperator as opcua::types::BinaryEncoder>::decode(
+        let filter_operator = <super::enums::FilterOperator as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let filter_operands = <Option<
             Vec<opcua::types::extension_object::ExtensionObject>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             filter_operator,
             filter_operands,

--- a/opcua-types/src/service_types/content_filter_element_result.rs
+++ b/opcua-types/src/service_types/content_filter_element_result.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for ContentFilterElementResult {
         opcua::types::ObjectId::ContentFilterElementResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ContentFilterElementResult {
+impl opcua::types::BinaryEncodable for ContentFilterElementResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -54,16 +54,16 @@ impl opcua::types::BinaryEncoder for ContentFilterElementResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let operand_status_codes = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let operand_diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             status_code,
             operand_status_codes,

--- a/opcua-types/src/service_types/content_filter_result.rs
+++ b/opcua-types/src/service_types/content_filter_result.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for ContentFilterResult {
         opcua::types::ObjectId::ContentFilterResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ContentFilterResult {
+impl opcua::types::BinaryEncodable for ContentFilterResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.element_results.byte_len();
@@ -55,10 +55,10 @@ impl opcua::types::BinaryEncoder for ContentFilterResult {
     ) -> opcua::types::EncodingResult<Self> {
         let element_results = <Option<
             Vec<super::content_filter_element_result::ContentFilterElementResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let element_diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             element_results,
             element_diagnostic_infos,

--- a/opcua-types/src/service_types/create_monitored_items_request.rs
+++ b/opcua-types/src/service_types/create_monitored_items_request.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for CreateMonitoredItemsRequest {
         opcua::types::ObjectId::CreateMonitoredItemsRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CreateMonitoredItemsRequest {
+impl opcua::types::BinaryEncodable for CreateMonitoredItemsRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -56,24 +56,24 @@ impl opcua::types::BinaryEncoder for CreateMonitoredItemsRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let timestamps_to_return = <super::enums::TimestampsToReturn as opcua::types::BinaryEncoder>::decode(
+        let timestamps_to_return = <super::enums::TimestampsToReturn as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let items_to_create = <Option<
             Vec<super::monitored_item_create_request::MonitoredItemCreateRequest>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/create_monitored_items_response.rs
+++ b/opcua-types/src/service_types/create_monitored_items_response.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for CreateMonitoredItemsResponse {
         opcua::types::ObjectId::CreateMonitoredItemsResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CreateMonitoredItemsResponse {
+impl opcua::types::BinaryEncodable for CreateMonitoredItemsResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -54,18 +54,18 @@ impl opcua::types::BinaryEncoder for CreateMonitoredItemsResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<super::monitored_item_create_result::MonitoredItemCreateResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/create_session_request.rs
+++ b/opcua-types/src/service_types/create_session_request.rs
@@ -33,7 +33,7 @@ impl opcua::types::MessageInfo for CreateSessionRequest {
         opcua::types::ObjectId::CreateSessionRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CreateSessionRequest {
+impl opcua::types::BinaryEncodable for CreateSessionRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -69,47 +69,47 @@ impl opcua::types::BinaryEncoder for CreateSessionRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let client_description = <super::application_description::ApplicationDescription as opcua::types::BinaryEncoder>::decode(
+        let client_description = <super::application_description::ApplicationDescription as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let session_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let session_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let client_nonce = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let client_nonce = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let client_certificate = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let client_certificate = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let requested_session_timeout = <f64 as opcua::types::BinaryEncoder>::decode(
+        let requested_session_timeout = <f64 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let max_response_message_size = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_response_message_size = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/create_session_response.rs
+++ b/opcua-types/src/service_types/create_session_response.rs
@@ -37,7 +37,7 @@ impl opcua::types::MessageInfo for CreateSessionResponse {
         opcua::types::ObjectId::CreateSessionResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CreateSessionResponse {
+impl opcua::types::BinaryEncodable for CreateSessionResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -75,50 +75,50 @@ impl opcua::types::BinaryEncoder for CreateSessionResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
-        let session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let authentication_token = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let authentication_token = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let revised_session_timeout = <f64 as opcua::types::BinaryEncoder>::decode(
+        let revised_session_timeout = <f64 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let server_nonce = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let server_nonce = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let server_certificate = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let server_certificate = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let server_endpoints = <Option<
             Vec<super::endpoint_description::EndpointDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let server_software_certificates = <Option<
             Vec<super::signed_software_certificate::SignedSoftwareCertificate>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let server_signature = <super::signature_data::SignatureData as opcua::types::BinaryEncoder>::decode(
+        let server_signature = <super::signature_data::SignatureData as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let max_request_message_size = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_request_message_size = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/create_subscription_request.rs
+++ b/opcua-types/src/service_types/create_subscription_request.rs
@@ -32,7 +32,7 @@ impl opcua::types::MessageInfo for CreateSubscriptionRequest {
         opcua::types::ObjectId::CreateSubscriptionRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CreateSubscriptionRequest {
+impl opcua::types::BinaryEncodable for CreateSubscriptionRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -64,37 +64,37 @@ impl opcua::types::BinaryEncoder for CreateSubscriptionRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let requested_publishing_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let requested_publishing_interval = <f64 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let requested_lifetime_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let requested_lifetime_count = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let requested_max_keep_alive_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let requested_max_keep_alive_count = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let max_notifications_per_publish = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_notifications_per_publish = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let publishing_enabled = <bool as opcua::types::BinaryEncoder>::decode(
+        let publishing_enabled = <bool as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let priority = <u8 as opcua::types::BinaryEncoder>::decode(
+        let priority = <u8 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/create_subscription_response.rs
+++ b/opcua-types/src/service_types/create_subscription_response.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for CreateSubscriptionResponse {
         opcua::types::ObjectId::CreateSubscriptionResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CreateSubscriptionResponse {
+impl opcua::types::BinaryEncodable for CreateSubscriptionResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -58,27 +58,27 @@ impl opcua::types::BinaryEncoder for CreateSubscriptionResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let revised_publishing_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let revised_publishing_interval = <f64 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let revised_lifetime_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let revised_lifetime_count = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let revised_max_keep_alive_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let revised_max_keep_alive_count = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/currency_unit_type.rs
+++ b/opcua-types/src/service_types/currency_unit_type.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for CurrencyUnitType {
         opcua::types::ObjectId::CurrencyUnitType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for CurrencyUnitType {
+impl opcua::types::BinaryEncodable for CurrencyUnitType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.numeric_code.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for CurrencyUnitType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let numeric_code = <i16 as opcua::types::BinaryEncoder>::decode(
+        let numeric_code = <i16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let exponent = <i8 as opcua::types::BinaryEncoder>::decode(
+        let exponent = <i8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let alphabetic_code = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let alphabetic_code = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let currency = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let currency = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/data_change_filter.rs
+++ b/opcua-types/src/service_types/data_change_filter.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for DataChangeFilter {
         opcua::types::ObjectId::DataChangeFilter_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataChangeFilter {
+impl opcua::types::BinaryEncodable for DataChangeFilter {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.trigger.byte_len();
@@ -51,15 +51,15 @@ impl opcua::types::BinaryEncoder for DataChangeFilter {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let trigger = <super::enums::DataChangeTrigger as opcua::types::BinaryEncoder>::decode(
+        let trigger = <super::enums::DataChangeTrigger as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let deadband_type = <u32 as opcua::types::BinaryEncoder>::decode(
+        let deadband_type = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let deadband_value = <f64 as opcua::types::BinaryEncoder>::decode(
+        let deadband_value = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/data_change_notification.rs
+++ b/opcua-types/src/service_types/data_change_notification.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for DataChangeNotification {
         opcua::types::ObjectId::DataChangeNotification_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataChangeNotification {
+impl opcua::types::BinaryEncodable for DataChangeNotification {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.monitored_items.byte_len();
@@ -53,10 +53,10 @@ impl opcua::types::BinaryEncoder for DataChangeNotification {
     ) -> opcua::types::EncodingResult<Self> {
         let monitored_items = <Option<
             Vec<super::monitored_item_notification::MonitoredItemNotification>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             monitored_items,
             diagnostic_infos,

--- a/opcua-types/src/service_types/data_set_meta_data_type.rs
+++ b/opcua-types/src/service_types/data_set_meta_data_type.rs
@@ -38,7 +38,7 @@ impl opcua::types::MessageInfo for DataSetMetaDataType {
         opcua::types::ObjectId::DataSetMetaDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataSetMetaDataType {
+impl opcua::types::BinaryEncodable for DataSetMetaDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.namespaces.byte_len();
@@ -76,32 +76,32 @@ impl opcua::types::BinaryEncoder for DataSetMetaDataType {
     ) -> opcua::types::EncodingResult<Self> {
         let namespaces = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let structure_data_types = <Option<
             Vec<super::structure_description::StructureDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let enum_data_types = <Option<
             Vec<super::enum_description::EnumDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let simple_data_types = <Option<
             Vec<super::simple_type_description::SimpleTypeDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let fields = <Option<
             Vec<super::field_meta_data::FieldMetaData>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let data_set_class_id = <opcua::types::guid::Guid as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let data_set_class_id = <opcua::types::guid::Guid as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let configuration_version = <super::configuration_version_data_type::ConfigurationVersionDataType as opcua::types::BinaryEncoder>::decode(
+        let configuration_version = <super::configuration_version_data_type::ConfigurationVersionDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/data_set_reader_data_type.rs
+++ b/opcua-types/src/service_types/data_set_reader_data_type.rs
@@ -43,7 +43,7 @@ impl opcua::types::MessageInfo for DataSetReaderDataType {
         opcua::types::ObjectId::DataSetReaderDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataSetReaderDataType {
+impl opcua::types::BinaryEncodable for DataSetReaderDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.name.byte_len();
@@ -95,69 +95,69 @@ impl opcua::types::BinaryEncoder for DataSetReaderDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let enabled = <bool as opcua::types::BinaryEncoder>::decode(
+        let enabled = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let publisher_id = <opcua::types::variant::Variant as opcua::types::BinaryEncoder>::decode(
+        let publisher_id = <opcua::types::variant::Variant as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let writer_group_id = <u16 as opcua::types::BinaryEncoder>::decode(
+        let writer_group_id = <u16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_writer_id = <u16 as opcua::types::BinaryEncoder>::decode(
+        let data_set_writer_id = <u16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_meta_data = <super::data_set_meta_data_type::DataSetMetaDataType as opcua::types::BinaryEncoder>::decode(
+        let data_set_meta_data = <super::data_set_meta_data_type::DataSetMetaDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_field_content_mask = <super::enums::DataSetFieldContentMask as opcua::types::BinaryEncoder>::decode(
+        let data_set_field_content_mask = <super::enums::DataSetFieldContentMask as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let message_receive_timeout = <f64 as opcua::types::BinaryEncoder>::decode(
+        let message_receive_timeout = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let key_frame_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let key_frame_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let header_layout_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let header_layout_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncoder>::decode(
+        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_group_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let security_group_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let security_key_services = <Option<
             Vec<super::endpoint_description::EndpointDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let data_set_reader_properties = <Option<
             Vec<super::key_value_pair::KeyValuePair>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let transport_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let transport_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let message_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let message_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let subscribed_data_set = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let subscribed_data_set = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/data_set_reader_message_data_type.rs
+++ b/opcua-types/src/service_types/data_set_reader_message_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for DataSetReaderMessageDataType {
         opcua::types::ObjectId::DataSetReaderMessageDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataSetReaderMessageDataType {
+impl opcua::types::BinaryEncodable for DataSetReaderMessageDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/data_set_reader_transport_data_type.rs
+++ b/opcua-types/src/service_types/data_set_reader_transport_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for DataSetReaderTransportDataType {
         opcua::types::ObjectId::DataSetReaderTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataSetReaderTransportDataType {
+impl opcua::types::BinaryEncodable for DataSetReaderTransportDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/data_set_writer_data_type.rs
+++ b/opcua-types/src/service_types/data_set_writer_data_type.rs
@@ -34,7 +34,7 @@ impl opcua::types::MessageInfo for DataSetWriterDataType {
         opcua::types::ObjectId::DataSetWriterDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataSetWriterDataType {
+impl opcua::types::BinaryEncodable for DataSetWriterDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.name.byte_len();
@@ -70,38 +70,38 @@ impl opcua::types::BinaryEncoder for DataSetWriterDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let enabled = <bool as opcua::types::BinaryEncoder>::decode(
+        let enabled = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_writer_id = <u16 as opcua::types::BinaryEncoder>::decode(
+        let data_set_writer_id = <u16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_field_content_mask = <super::enums::DataSetFieldContentMask as opcua::types::BinaryEncoder>::decode(
+        let data_set_field_content_mask = <super::enums::DataSetFieldContentMask as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let key_frame_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let key_frame_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let data_set_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let data_set_writer_properties = <Option<
             Vec<super::key_value_pair::KeyValuePair>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let transport_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let transport_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let message_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let message_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/data_set_writer_message_data_type.rs
+++ b/opcua-types/src/service_types/data_set_writer_message_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for DataSetWriterMessageDataType {
         opcua::types::ObjectId::DataSetWriterMessageDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataSetWriterMessageDataType {
+impl opcua::types::BinaryEncodable for DataSetWriterMessageDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/data_set_writer_transport_data_type.rs
+++ b/opcua-types/src/service_types/data_set_writer_transport_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for DataSetWriterTransportDataType {
         opcua::types::ObjectId::DataSetWriterTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataSetWriterTransportDataType {
+impl opcua::types::BinaryEncodable for DataSetWriterTransportDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/data_type_attributes.rs
+++ b/opcua-types/src/service_types/data_type_attributes.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for DataTypeAttributes {
         opcua::types::ObjectId::DataTypeAttributes_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataTypeAttributes {
+impl opcua::types::BinaryEncodable for DataTypeAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_attributes.byte_len();
@@ -61,27 +61,27 @@ impl opcua::types::BinaryEncoder for DataTypeAttributes {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_attributes = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_attributes = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let user_write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_abstract = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_abstract = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/data_type_description.rs
+++ b/opcua-types/src/service_types/data_type_description.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for DataTypeDescription {
         opcua::types::ObjectId::DataTypeDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataTypeDescription {
+impl opcua::types::BinaryEncodable for DataTypeDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.data_type_id.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for DataTypeDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let data_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let data_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/data_type_schema_header.rs
+++ b/opcua-types/src/service_types/data_type_schema_header.rs
@@ -33,7 +33,7 @@ impl opcua::types::MessageInfo for DataTypeSchemaHeader {
         opcua::types::ObjectId::DataTypeSchemaHeader_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DataTypeSchemaHeader {
+impl opcua::types::BinaryEncodable for DataTypeSchemaHeader {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.namespaces.byte_len();
@@ -61,16 +61,16 @@ impl opcua::types::BinaryEncoder for DataTypeSchemaHeader {
     ) -> opcua::types::EncodingResult<Self> {
         let namespaces = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let structure_data_types = <Option<
             Vec<super::structure_description::StructureDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let enum_data_types = <Option<
             Vec<super::enum_description::EnumDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let simple_data_types = <Option<
             Vec<super::simple_type_description::SimpleTypeDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             namespaces,
             structure_data_types,

--- a/opcua-types/src/service_types/datagram_connection_transport_data_type.rs
+++ b/opcua-types/src/service_types/datagram_connection_transport_data_type.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for DatagramConnectionTransportDataType {
         opcua::types::ObjectId::DatagramConnectionTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DatagramConnectionTransportDataType {
+impl opcua::types::BinaryEncodable for DatagramConnectionTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.discovery_address.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for DatagramConnectionTransportDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let discovery_address = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let discovery_address = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/datagram_writer_group_transport_data_type.rs
+++ b/opcua-types/src/service_types/datagram_writer_group_transport_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for DatagramWriterGroupTransportDataType {
         opcua::types::ObjectId::DatagramWriterGroupTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DatagramWriterGroupTransportDataType {
+impl opcua::types::BinaryEncodable for DatagramWriterGroupTransportDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.message_repeat_count.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for DatagramWriterGroupTransportDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let message_repeat_count = <u8 as opcua::types::BinaryEncoder>::decode(
+        let message_repeat_count = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let message_repeat_delay = <f64 as opcua::types::BinaryEncoder>::decode(
+        let message_repeat_delay = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/decimal_data_type.rs
+++ b/opcua-types/src/service_types/decimal_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for DecimalDataType {
         opcua::types::ObjectId::DecimalDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DecimalDataType {
+impl opcua::types::BinaryEncodable for DecimalDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.scale.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for DecimalDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let scale = <i16 as opcua::types::BinaryEncoder>::decode(
+        let scale = <i16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let value = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/delete_at_time_details.rs
+++ b/opcua-types/src/service_types/delete_at_time_details.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for DeleteAtTimeDetails {
         opcua::types::ObjectId::DeleteAtTimeDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteAtTimeDetails {
+impl opcua::types::BinaryEncodable for DeleteAtTimeDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -49,13 +49,13 @@ impl opcua::types::BinaryEncoder for DeleteAtTimeDetails {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let req_times = <Option<
             Vec<opcua::types::date_time::DateTime>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { node_id, req_times })
     }
 }

--- a/opcua-types/src/service_types/delete_event_details.rs
+++ b/opcua-types/src/service_types/delete_event_details.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for DeleteEventDetails {
         opcua::types::ObjectId::DeleteEventDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteEventDetails {
+impl opcua::types::BinaryEncodable for DeleteEventDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -49,13 +49,13 @@ impl opcua::types::BinaryEncoder for DeleteEventDetails {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let event_ids = <Option<
             Vec<opcua::types::byte_string::ByteString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { node_id, event_ids })
     }
 }

--- a/opcua-types/src/service_types/delete_monitored_items_request.rs
+++ b/opcua-types/src/service_types/delete_monitored_items_request.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for DeleteMonitoredItemsRequest {
         opcua::types::ObjectId::DeleteMonitoredItemsRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteMonitoredItemsRequest {
+impl opcua::types::BinaryEncodable for DeleteMonitoredItemsRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -52,19 +52,19 @@ impl opcua::types::BinaryEncoder for DeleteMonitoredItemsRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let monitored_item_ids = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/delete_monitored_items_response.rs
+++ b/opcua-types/src/service_types/delete_monitored_items_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for DeleteMonitoredItemsResponse {
         opcua::types::ObjectId::DeleteMonitoredItemsResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteMonitoredItemsResponse {
+impl opcua::types::BinaryEncodable for DeleteMonitoredItemsResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for DeleteMonitoredItemsResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/delete_nodes_item.rs
+++ b/opcua-types/src/service_types/delete_nodes_item.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for DeleteNodesItem {
         opcua::types::ObjectId::DeleteNodesItem_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteNodesItem {
+impl opcua::types::BinaryEncodable for DeleteNodesItem {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for DeleteNodesItem {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let delete_target_references = <bool as opcua::types::BinaryEncoder>::decode(
+        let delete_target_references = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/delete_nodes_request.rs
+++ b/opcua-types/src/service_types/delete_nodes_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for DeleteNodesRequest {
         opcua::types::ObjectId::DeleteNodesRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteNodesRequest {
+impl opcua::types::BinaryEncodable for DeleteNodesRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for DeleteNodesRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let nodes_to_delete = <Option<
             Vec<super::delete_nodes_item::DeleteNodesItem>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/delete_nodes_response.rs
+++ b/opcua-types/src/service_types/delete_nodes_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for DeleteNodesResponse {
         opcua::types::ObjectId::DeleteNodesResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteNodesResponse {
+impl opcua::types::BinaryEncodable for DeleteNodesResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for DeleteNodesResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/delete_raw_modified_details.rs
+++ b/opcua-types/src/service_types/delete_raw_modified_details.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for DeleteRawModifiedDetails {
         opcua::types::ObjectId::DeleteRawModifiedDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteRawModifiedDetails {
+impl opcua::types::BinaryEncodable for DeleteRawModifiedDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for DeleteRawModifiedDetails {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_delete_modified = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_delete_modified = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let end_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let end_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/delete_references_item.rs
+++ b/opcua-types/src/service_types/delete_references_item.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for DeleteReferencesItem {
         opcua::types::ObjectId::DeleteReferencesItem_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteReferencesItem {
+impl opcua::types::BinaryEncodable for DeleteReferencesItem {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.source_node_id.byte_len();
@@ -58,23 +58,23 @@ impl opcua::types::BinaryEncoder for DeleteReferencesItem {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let source_node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let source_node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_forward = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_forward = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let target_node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let target_node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let delete_bidirectional = <bool as opcua::types::BinaryEncoder>::decode(
+        let delete_bidirectional = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/delete_references_request.rs
+++ b/opcua-types/src/service_types/delete_references_request.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for DeleteReferencesRequest {
         opcua::types::ObjectId::DeleteReferencesRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteReferencesRequest {
+impl opcua::types::BinaryEncodable for DeleteReferencesRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -51,14 +51,14 @@ impl opcua::types::BinaryEncoder for DeleteReferencesRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let references_to_delete = <Option<
             Vec<super::delete_references_item::DeleteReferencesItem>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/delete_references_response.rs
+++ b/opcua-types/src/service_types/delete_references_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for DeleteReferencesResponse {
         opcua::types::ObjectId::DeleteReferencesResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteReferencesResponse {
+impl opcua::types::BinaryEncodable for DeleteReferencesResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for DeleteReferencesResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/delete_subscriptions_request.rs
+++ b/opcua-types/src/service_types/delete_subscriptions_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for DeleteSubscriptionsRequest {
         opcua::types::ObjectId::DeleteSubscriptionsRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteSubscriptionsRequest {
+impl opcua::types::BinaryEncodable for DeleteSubscriptionsRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for DeleteSubscriptionsRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let subscription_ids = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/delete_subscriptions_response.rs
+++ b/opcua-types/src/service_types/delete_subscriptions_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for DeleteSubscriptionsResponse {
         opcua::types::ObjectId::DeleteSubscriptionsResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DeleteSubscriptionsResponse {
+impl opcua::types::BinaryEncodable for DeleteSubscriptionsResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for DeleteSubscriptionsResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/discovery_configuration.rs
+++ b/opcua-types/src/service_types/discovery_configuration.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for DiscoveryConfiguration {
         opcua::types::ObjectId::DiscoveryConfiguration_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DiscoveryConfiguration {
+impl opcua::types::BinaryEncodable for DiscoveryConfiguration {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/double_complex_number_type.rs
+++ b/opcua-types/src/service_types/double_complex_number_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for DoubleComplexNumberType {
         opcua::types::ObjectId::DoubleComplexNumberType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for DoubleComplexNumberType {
+impl opcua::types::BinaryEncodable for DoubleComplexNumberType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.real.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for DoubleComplexNumberType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let real = <f64 as opcua::types::BinaryEncoder>::decode(
+        let real = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let imaginary = <f64 as opcua::types::BinaryEncoder>::decode(
+        let imaginary = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/element_operand.rs
+++ b/opcua-types/src/service_types/element_operand.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for ElementOperand {
         opcua::types::ObjectId::ElementOperand_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ElementOperand {
+impl opcua::types::BinaryEncodable for ElementOperand {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.index.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for ElementOperand {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let index = <u32 as opcua::types::BinaryEncoder>::decode(
+        let index = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/endpoint_configuration.rs
+++ b/opcua-types/src/service_types/endpoint_configuration.rs
@@ -34,7 +34,7 @@ impl opcua::types::MessageInfo for EndpointConfiguration {
         opcua::types::ObjectId::EndpointConfiguration_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EndpointConfiguration {
+impl opcua::types::BinaryEncodable for EndpointConfiguration {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.operation_timeout.byte_len();
@@ -70,39 +70,39 @@ impl opcua::types::BinaryEncoder for EndpointConfiguration {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let operation_timeout = <i32 as opcua::types::BinaryEncoder>::decode(
+        let operation_timeout = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let use_binary_encoding = <bool as opcua::types::BinaryEncoder>::decode(
+        let use_binary_encoding = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let max_string_length = <i32 as opcua::types::BinaryEncoder>::decode(
+        let max_string_length = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let max_byte_string_length = <i32 as opcua::types::BinaryEncoder>::decode(
+        let max_byte_string_length = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let max_array_length = <i32 as opcua::types::BinaryEncoder>::decode(
+        let max_array_length = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let max_message_size = <i32 as opcua::types::BinaryEncoder>::decode(
+        let max_message_size = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let max_buffer_size = <i32 as opcua::types::BinaryEncoder>::decode(
+        let max_buffer_size = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let channel_lifetime = <i32 as opcua::types::BinaryEncoder>::decode(
+        let channel_lifetime = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_token_lifetime = <i32 as opcua::types::BinaryEncoder>::decode(
+        let security_token_lifetime = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/endpoint_description.rs
+++ b/opcua-types/src/service_types/endpoint_description.rs
@@ -32,7 +32,7 @@ impl opcua::types::MessageInfo for EndpointDescription {
         opcua::types::ObjectId::EndpointDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EndpointDescription {
+impl opcua::types::BinaryEncodable for EndpointDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.endpoint_url.byte_len();
@@ -66,34 +66,34 @@ impl opcua::types::BinaryEncoder for EndpointDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let server = <super::application_description::ApplicationDescription as opcua::types::BinaryEncoder>::decode(
+        let server = <super::application_description::ApplicationDescription as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let server_certificate = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let server_certificate = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncoder>::decode(
+        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_policy_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let security_policy_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let user_identity_tokens = <Option<
             Vec<super::user_token_policy::UserTokenPolicy>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let transport_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let transport_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_level = <u8 as opcua::types::BinaryEncoder>::decode(
+        let security_level = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/endpoint_type.rs
+++ b/opcua-types/src/service_types/endpoint_type.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for EndpointType {
         opcua::types::ObjectId::EndpointType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EndpointType {
+impl opcua::types::BinaryEncodable for EndpointType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.endpoint_url.byte_len();
@@ -54,19 +54,19 @@ impl opcua::types::BinaryEncoder for EndpointType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncoder>::decode(
+        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_policy_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let security_policy_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let transport_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let transport_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/endpoint_url_list_data_type.rs
+++ b/opcua-types/src/service_types/endpoint_url_list_data_type.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for EndpointUrlListDataType {
         opcua::types::ObjectId::EndpointUrlListDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EndpointUrlListDataType {
+impl opcua::types::BinaryEncodable for EndpointUrlListDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.endpoint_url_list.byte_len();
@@ -48,7 +48,7 @@ impl opcua::types::BinaryEncoder for EndpointUrlListDataType {
     ) -> opcua::types::EncodingResult<Self> {
         let endpoint_url_list = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { endpoint_url_list })
     }
 }

--- a/opcua-types/src/service_types/enum_definition.rs
+++ b/opcua-types/src/service_types/enum_definition.rs
@@ -15,7 +15,7 @@ mod opcua { pub use crate as types; }#[derive(Debug, Clone, PartialEq)]
 pub struct EnumDefinition {
     pub fields: Option<Vec<super::enum_field::EnumField>>,
 }
-impl opcua::types::BinaryEncoder for EnumDefinition {
+impl opcua::types::BinaryEncodable for EnumDefinition {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.fields.byte_len();
@@ -37,7 +37,7 @@ impl opcua::types::BinaryEncoder for EnumDefinition {
     ) -> opcua::types::EncodingResult<Self> {
         let fields = <Option<
             Vec<super::enum_field::EnumField>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { fields })
     }
 }

--- a/opcua-types/src/service_types/enum_description.rs
+++ b/opcua-types/src/service_types/enum_description.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for EnumDescription {
         opcua::types::ObjectId::EnumDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EnumDescription {
+impl opcua::types::BinaryEncodable for EnumDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.data_type_id.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for EnumDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let data_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let data_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let enum_definition = <super::enum_definition::EnumDefinition as opcua::types::BinaryEncoder>::decode(
+        let enum_definition = <super::enum_definition::EnumDefinition as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let built_in_type = <u8 as opcua::types::BinaryEncoder>::decode(
+        let built_in_type = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/enum_field.rs
+++ b/opcua-types/src/service_types/enum_field.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for EnumField {
         opcua::types::ObjectId::EnumField_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EnumField {
+impl opcua::types::BinaryEncodable for EnumField {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.value.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for EnumField {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let value = <i64 as opcua::types::BinaryEncoder>::decode(
+        let value = <i64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/enum_value_type.rs
+++ b/opcua-types/src/service_types/enum_value_type.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for EnumValueType {
         opcua::types::ObjectId::EnumValueType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EnumValueType {
+impl opcua::types::BinaryEncodable for EnumValueType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.value.byte_len();
@@ -52,15 +52,15 @@ impl opcua::types::BinaryEncoder for EnumValueType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let value = <i64 as opcua::types::BinaryEncoder>::decode(
+        let value = <i64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/enums.rs
+++ b/opcua-types/src/service_types/enums.rs
@@ -17,7 +17,7 @@ bitflags::bitflags! {
     NonatomicWrite = 512i32; const WriteFullArrayOnly = 1024i32; const NoSubDataTypes =
     2048i32; }
 }
-impl opcua::types::BinaryEncoder for AccessLevelExType {
+impl opcua::types::BinaryEncodable for AccessLevelExType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -95,7 +95,7 @@ bitflags::bitflags! {
     const HistoryWrite = 8u8; const SemanticChange = 16u8; const StatusWrite = 32u8;
     const TimestampWrite = 64u8; }
 }
-impl opcua::types::BinaryEncoder for AccessLevelType {
+impl opcua::types::BinaryEncodable for AccessLevelType {
     fn byte_len(&self) -> usize {
         1usize
     }
@@ -172,7 +172,7 @@ bitflags::bitflags! {
     const None = 0i16; const SigningRequired = 1i16; const EncryptionRequired = 2i16;
     const SessionRequired = 4i16; const ApplyRestrictionsToBrowse = 8i16; }
 }
-impl opcua::types::BinaryEncoder for AccessRestrictionType {
+impl opcua::types::BinaryEncodable for AccessRestrictionType {
     fn byte_len(&self) -> usize {
         2usize
     }
@@ -324,7 +324,7 @@ impl serde::ser::Serialize for ApplicationType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for ApplicationType {
+impl opcua::types::BinaryEncodable for ApplicationType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -352,7 +352,7 @@ bitflags::bitflags! {
     const DataTypeDefinition = 4194304i32; const RolePermissions = 8388608i32; const
     AccessRestrictions = 16777216i32; const AccessLevelEx = 33554432i32; }
 }
-impl opcua::types::BinaryEncoder for AttributeWriteMask {
+impl opcua::types::BinaryEncodable for AttributeWriteMask {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -502,7 +502,7 @@ impl serde::ser::Serialize for AxisScaleEnumeration {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for AxisScaleEnumeration {
+impl opcua::types::BinaryEncodable for AxisScaleEnumeration {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -606,7 +606,7 @@ impl serde::ser::Serialize for BrokerTransportQualityOfService {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for BrokerTransportQualityOfService {
+impl opcua::types::BinaryEncodable for BrokerTransportQualityOfService {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -704,7 +704,7 @@ impl serde::ser::Serialize for BrowseDirection {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for BrowseDirection {
+impl opcua::types::BinaryEncodable for BrowseDirection {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -811,7 +811,7 @@ impl serde::ser::Serialize for BrowseResultMask {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for BrowseResultMask {
+impl opcua::types::BinaryEncodable for BrowseResultMask {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -904,7 +904,7 @@ impl serde::ser::Serialize for DataChangeTrigger {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for DataChangeTrigger {
+impl opcua::types::BinaryEncodable for DataChangeTrigger {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -925,7 +925,7 @@ bitflags::bitflags! {
     ServerTimestamp = 4i32; const SourcePicoSeconds = 8i32; const ServerPicoSeconds =
     16i32; const RawData = 32i32; }
 }
-impl opcua::types::BinaryEncoder for DataSetFieldContentMask {
+impl opcua::types::BinaryEncodable for DataSetFieldContentMask {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -1001,7 +1001,7 @@ bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)] pub struct DataSetFieldFlags : i16 { const
     None = 0i16; const PromotedField = 1i16; }
 }
-impl opcua::types::BinaryEncoder for DataSetFieldFlags {
+impl opcua::types::BinaryEncodable for DataSetFieldFlags {
     fn byte_len(&self) -> usize {
         2usize
     }
@@ -1151,7 +1151,7 @@ impl serde::ser::Serialize for DataSetOrderingType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for DataSetOrderingType {
+impl opcua::types::BinaryEncodable for DataSetOrderingType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -1244,7 +1244,7 @@ impl serde::ser::Serialize for DeadbandType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for DeadbandType {
+impl opcua::types::BinaryEncodable for DeadbandType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -1341,7 +1341,7 @@ impl serde::ser::Serialize for DiagnosticsLevel {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for DiagnosticsLevel {
+impl opcua::types::BinaryEncodable for DiagnosticsLevel {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -1361,7 +1361,7 @@ bitflags::bitflags! {
     None = 0u8; const SubscribeToEvents = 1u8; const HistoryRead = 4u8; const
     HistoryWrite = 8u8; }
 }
-impl opcua::types::BinaryEncoder for EventNotifierType {
+impl opcua::types::BinaryEncodable for EventNotifierType {
     fn byte_len(&self) -> usize {
         1usize
     }
@@ -1522,7 +1522,7 @@ impl serde::ser::Serialize for ExceptionDeviationFormat {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for ExceptionDeviationFormat {
+impl opcua::types::BinaryEncodable for ExceptionDeviationFormat {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -1645,7 +1645,7 @@ impl serde::ser::Serialize for FilterOperator {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for FilterOperator {
+impl opcua::types::BinaryEncodable for FilterOperator {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -1740,7 +1740,7 @@ impl serde::ser::Serialize for HistoryUpdateType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for HistoryUpdateType {
+impl opcua::types::BinaryEncodable for HistoryUpdateType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -1839,7 +1839,7 @@ impl serde::ser::Serialize for IdentityCriteriaType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for IdentityCriteriaType {
+impl opcua::types::BinaryEncodable for IdentityCriteriaType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -1934,7 +1934,7 @@ impl serde::ser::Serialize for IdType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for IdType {
+impl opcua::types::BinaryEncodable for IdType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -1954,7 +1954,7 @@ bitflags::bitflags! {
     i32 { const None = 0i32; const DataSetWriterId = 1i32; const MetaDataVersion = 2i32;
     const SequenceNumber = 4i32; const Timestamp = 8i32; const Status = 16i32; }
 }
-impl opcua::types::BinaryEncoder for JsonDataSetMessageContentMask {
+impl opcua::types::BinaryEncodable for JsonDataSetMessageContentMask {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -2032,7 +2032,7 @@ bitflags::bitflags! {
     DataSetMessageHeader = 2i32; const SingleDataSetMessage = 4i32; const PublisherId =
     8i32; const DataSetClassId = 16i32; const ReplyTo = 32i32; }
 }
-impl opcua::types::BinaryEncoder for JsonNetworkMessageContentMask {
+impl opcua::types::BinaryEncodable for JsonNetworkMessageContentMask {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -2187,7 +2187,7 @@ impl serde::ser::Serialize for MessageSecurityMode {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for MessageSecurityMode {
+impl opcua::types::BinaryEncodable for MessageSecurityMode {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -2291,7 +2291,7 @@ impl serde::ser::Serialize for ModelChangeStructureVerbMask {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for ModelChangeStructureVerbMask {
+impl opcua::types::BinaryEncodable for ModelChangeStructureVerbMask {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -2384,7 +2384,7 @@ impl serde::ser::Serialize for MonitoringMode {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for MonitoringMode {
+impl opcua::types::BinaryEncodable for MonitoringMode {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -2477,7 +2477,7 @@ impl serde::ser::Serialize for NamingRuleType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for NamingRuleType {
+impl opcua::types::BinaryEncodable for NamingRuleType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -2634,7 +2634,7 @@ impl serde::ser::Serialize for NodeAttributesMask {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for NodeAttributesMask {
+impl opcua::types::BinaryEncodable for NodeAttributesMask {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -2739,7 +2739,7 @@ impl serde::ser::Serialize for NodeClass {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for NodeClass {
+impl opcua::types::BinaryEncodable for NodeClass {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -2839,7 +2839,7 @@ impl serde::ser::Serialize for NodeIdType {
         serializer.serialize_u8(*self as u8)
     }
 }
-impl opcua::types::BinaryEncoder for NodeIdType {
+impl opcua::types::BinaryEncodable for NodeIdType {
     fn byte_len(&self) -> usize {
         1usize
     }
@@ -2934,7 +2934,7 @@ impl serde::ser::Serialize for OpenFileMode {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for OpenFileMode {
+impl opcua::types::BinaryEncodable for OpenFileMode {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3027,7 +3027,7 @@ impl serde::ser::Serialize for OverrideValueHandling {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for OverrideValueHandling {
+impl opcua::types::BinaryEncodable for OverrideValueHandling {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3122,7 +3122,7 @@ impl serde::ser::Serialize for PerformUpdateType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for PerformUpdateType {
+impl opcua::types::BinaryEncodable for PerformUpdateType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3146,7 +3146,7 @@ bitflags::bitflags! {
     2048i32; const Call = 4096i32; const AddReference = 8192i32; const RemoveReference =
     16384i32; const DeleteNode = 32768i32; const AddNode = 65536i32; }
 }
-impl opcua::types::BinaryEncoder for PermissionType {
+impl opcua::types::BinaryEncodable for PermissionType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3301,7 +3301,7 @@ impl serde::ser::Serialize for PubSubDiagnosticsCounterClassification {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for PubSubDiagnosticsCounterClassification {
+impl opcua::types::BinaryEncodable for PubSubDiagnosticsCounterClassification {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3396,7 +3396,7 @@ impl serde::ser::Serialize for PubSubState {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for PubSubState {
+impl opcua::types::BinaryEncodable for PubSubState {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3495,7 +3495,7 @@ impl serde::ser::Serialize for RedundancySupport {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for RedundancySupport {
+impl opcua::types::BinaryEncodable for RedundancySupport {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3593,7 +3593,7 @@ impl serde::ser::Serialize for SecurityTokenRequestType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for SecurityTokenRequestType {
+impl opcua::types::BinaryEncodable for SecurityTokenRequestType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3696,7 +3696,7 @@ impl serde::ser::Serialize for ServerState {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for ServerState {
+impl opcua::types::BinaryEncodable for ServerState {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3789,7 +3789,7 @@ impl serde::ser::Serialize for StructureType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for StructureType {
+impl opcua::types::BinaryEncodable for StructureType {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3889,7 +3889,7 @@ impl serde::ser::Serialize for TimestampsToReturn {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for TimestampsToReturn {
+impl opcua::types::BinaryEncodable for TimestampsToReturn {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -3988,7 +3988,7 @@ impl serde::ser::Serialize for TrustListMasks {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for TrustListMasks {
+impl opcua::types::BinaryEncodable for TrustListMasks {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -4009,7 +4009,7 @@ bitflags::bitflags! {
     Status = 4i32; const MajorVersion = 8i32; const MinorVersion = 16i32; const
     SequenceNumber = 32i32; }
 }
-impl opcua::types::BinaryEncoder for UadpDataSetMessageContentMask {
+impl opcua::types::BinaryEncodable for UadpDataSetMessageContentMask {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -4089,7 +4089,7 @@ bitflags::bitflags! {
     const PicoSeconds = 256i32; const DataSetClassId = 512i32; const PromotedFields =
     1024i32; }
 }
-impl opcua::types::BinaryEncoder for UadpNetworkMessageContentMask {
+impl opcua::types::BinaryEncodable for UadpNetworkMessageContentMask {
     fn byte_len(&self) -> usize {
         4usize
     }
@@ -4241,7 +4241,7 @@ impl serde::ser::Serialize for UserTokenType {
         serializer.serialize_i32(*self as i32)
     }
 }
-impl opcua::types::BinaryEncoder for UserTokenType {
+impl opcua::types::BinaryEncodable for UserTokenType {
     fn byte_len(&self) -> usize {
         4usize
     }

--- a/opcua-types/src/service_types/ephemeral_key_type.rs
+++ b/opcua-types/src/service_types/ephemeral_key_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for EphemeralKeyType {
         opcua::types::ObjectId::EphemeralKeyType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EphemeralKeyType {
+impl opcua::types::BinaryEncodable for EphemeralKeyType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.public_key.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for EphemeralKeyType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let public_key = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let public_key = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let signature = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let signature = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/eu_information.rs
+++ b/opcua-types/src/service_types/eu_information.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for EUInformation {
         opcua::types::ObjectId::EUInformation_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EUInformation {
+impl opcua::types::BinaryEncodable for EUInformation {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.namespace_uri.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for EUInformation {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let namespace_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let namespace_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let unit_id = <i32 as opcua::types::BinaryEncoder>::decode(
+        let unit_id = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/event_field_list.rs
+++ b/opcua-types/src/service_types/event_field_list.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for EventFieldList {
         opcua::types::ObjectId::EventFieldList_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EventFieldList {
+impl opcua::types::BinaryEncodable for EventFieldList {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.client_handle.byte_len();
@@ -49,13 +49,13 @@ impl opcua::types::BinaryEncoder for EventFieldList {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let client_handle = <u32 as opcua::types::BinaryEncoder>::decode(
+        let client_handle = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let event_fields = <Option<
             Vec<opcua::types::variant::Variant>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             client_handle,
             event_fields,

--- a/opcua-types/src/service_types/event_filter.rs
+++ b/opcua-types/src/service_types/event_filter.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for EventFilter {
         opcua::types::ObjectId::EventFilter_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EventFilter {
+impl opcua::types::BinaryEncodable for EventFilter {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.select_clauses.byte_len();
@@ -53,8 +53,8 @@ impl opcua::types::BinaryEncoder for EventFilter {
     ) -> opcua::types::EncodingResult<Self> {
         let select_clauses = <Option<
             Vec<super::simple_attribute_operand::SimpleAttributeOperand>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let where_clause = <super::content_filter::ContentFilter as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let where_clause = <super::content_filter::ContentFilter as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/event_filter_result.rs
+++ b/opcua-types/src/service_types/event_filter_result.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for EventFilterResult {
         opcua::types::ObjectId::EventFilterResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EventFilterResult {
+impl opcua::types::BinaryEncodable for EventFilterResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.select_clause_results.byte_len();
@@ -56,11 +56,11 @@ impl opcua::types::BinaryEncoder for EventFilterResult {
     ) -> opcua::types::EncodingResult<Self> {
         let select_clause_results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let select_clause_diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let where_clause_result = <super::content_filter_result::ContentFilterResult as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let where_clause_result = <super::content_filter_result::ContentFilterResult as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/event_notification_list.rs
+++ b/opcua-types/src/service_types/event_notification_list.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for EventNotificationList {
         opcua::types::ObjectId::EventNotificationList_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for EventNotificationList {
+impl opcua::types::BinaryEncodable for EventNotificationList {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.events.byte_len();
@@ -48,7 +48,7 @@ impl opcua::types::BinaryEncoder for EventNotificationList {
     ) -> opcua::types::EncodingResult<Self> {
         let events = <Option<
             Vec<super::event_field_list::EventFieldList>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { events })
     }
 }

--- a/opcua-types/src/service_types/field_meta_data.rs
+++ b/opcua-types/src/service_types/field_meta_data.rs
@@ -35,7 +35,7 @@ impl opcua::types::MessageInfo for FieldMetaData {
         opcua::types::ObjectId::FieldMetaData_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for FieldMetaData {
+impl opcua::types::BinaryEncodable for FieldMetaData {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.name.byte_len();
@@ -73,44 +73,44 @@ impl opcua::types::BinaryEncoder for FieldMetaData {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let field_flags = <super::enums::DataSetFieldFlags as opcua::types::BinaryEncoder>::decode(
+        let field_flags = <super::enums::DataSetFieldFlags as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let built_in_type = <u8 as opcua::types::BinaryEncoder>::decode(
+        let built_in_type = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value_rank = <i32 as opcua::types::BinaryEncoder>::decode(
+        let value_rank = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let array_dimensions = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let max_string_length = <u32 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let max_string_length = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_field_id = <opcua::types::guid::Guid as opcua::types::BinaryEncoder>::decode(
+        let data_set_field_id = <opcua::types::guid::Guid as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let properties = <Option<
             Vec<super::key_value_pair::KeyValuePair>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             name,
             description,

--- a/opcua-types/src/service_types/field_target_data_type.rs
+++ b/opcua-types/src/service_types/field_target_data_type.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for FieldTargetDataType {
         opcua::types::ObjectId::FieldTargetDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for FieldTargetDataType {
+impl opcua::types::BinaryEncodable for FieldTargetDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.data_set_field_id.byte_len();
@@ -63,31 +63,31 @@ impl opcua::types::BinaryEncoder for FieldTargetDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let data_set_field_id = <opcua::types::guid::Guid as opcua::types::BinaryEncoder>::decode(
+        let data_set_field_id = <opcua::types::guid::Guid as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let receiver_index_range = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let receiver_index_range = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let target_node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let target_node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let attribute_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let attribute_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_index_range = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let write_index_range = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let override_value_handling = <super::enums::OverrideValueHandling as opcua::types::BinaryEncoder>::decode(
+        let override_value_handling = <super::enums::OverrideValueHandling as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let override_value = <opcua::types::variant::Variant as opcua::types::BinaryEncoder>::decode(
+        let override_value = <opcua::types::variant::Variant as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/filter_operand.rs
+++ b/opcua-types/src/service_types/filter_operand.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for FilterOperand {
         opcua::types::ObjectId::FilterOperand_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for FilterOperand {
+impl opcua::types::BinaryEncodable for FilterOperand {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/find_servers_on_network_request.rs
+++ b/opcua-types/src/service_types/find_servers_on_network_request.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for FindServersOnNetworkRequest {
         opcua::types::ObjectId::FindServersOnNetworkRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for FindServersOnNetworkRequest {
+impl opcua::types::BinaryEncodable for FindServersOnNetworkRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -55,24 +55,24 @@ impl opcua::types::BinaryEncoder for FindServersOnNetworkRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let starting_record_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let starting_record_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let max_records_to_return = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_records_to_return = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let server_capability_filter = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/find_servers_on_network_response.rs
+++ b/opcua-types/src/service_types/find_servers_on_network_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for FindServersOnNetworkResponse {
         opcua::types::ObjectId::FindServersOnNetworkResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for FindServersOnNetworkResponse {
+impl opcua::types::BinaryEncodable for FindServersOnNetworkResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,19 +52,19 @@ impl opcua::types::BinaryEncoder for FindServersOnNetworkResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
-        let last_counter_reset_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let last_counter_reset_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let servers = <Option<
             Vec<super::server_on_network::ServerOnNetwork>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/find_servers_request.rs
+++ b/opcua-types/src/service_types/find_servers_request.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for FindServersRequest {
         opcua::types::ObjectId::FindServersRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for FindServersRequest {
+impl opcua::types::BinaryEncodable for FindServersRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -55,23 +55,23 @@ impl opcua::types::BinaryEncoder for FindServersRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let locale_ids = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let server_uris = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/find_servers_response.rs
+++ b/opcua-types/src/service_types/find_servers_response.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for FindServersResponse {
         opcua::types::ObjectId::FindServersResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for FindServersResponse {
+impl opcua::types::BinaryEncodable for FindServersResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for FindServersResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let servers = <Option<
             Vec<super::application_description::ApplicationDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self { response_header, servers })
     }

--- a/opcua-types/src/service_types/frame.rs
+++ b/opcua-types/src/service_types/frame.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for Frame {
         opcua::types::ObjectId::Frame_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for Frame {
+impl opcua::types::BinaryEncodable for Frame {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/generic_attribute_value.rs
+++ b/opcua-types/src/service_types/generic_attribute_value.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for GenericAttributeValue {
         opcua::types::ObjectId::GenericAttributeValue_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for GenericAttributeValue {
+impl opcua::types::BinaryEncodable for GenericAttributeValue {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.attribute_id.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for GenericAttributeValue {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let attribute_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let attribute_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value = <opcua::types::variant::Variant as opcua::types::BinaryEncoder>::decode(
+        let value = <opcua::types::variant::Variant as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/generic_attributes.rs
+++ b/opcua-types/src/service_types/generic_attributes.rs
@@ -33,7 +33,7 @@ impl opcua::types::MessageInfo for GenericAttributes {
         opcua::types::ObjectId::GenericAttributes_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for GenericAttributes {
+impl opcua::types::BinaryEncodable for GenericAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_attributes.byte_len();
@@ -63,29 +63,29 @@ impl opcua::types::BinaryEncoder for GenericAttributes {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_attributes = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_attributes = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let user_write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let attribute_values = <Option<
             Vec<super::generic_attribute_value::GenericAttributeValue>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             specified_attributes,
             display_name,

--- a/opcua-types/src/service_types/get_endpoints_request.rs
+++ b/opcua-types/src/service_types/get_endpoints_request.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for GetEndpointsRequest {
         opcua::types::ObjectId::GetEndpointsRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for GetEndpointsRequest {
+impl opcua::types::BinaryEncodable for GetEndpointsRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -55,23 +55,23 @@ impl opcua::types::BinaryEncoder for GetEndpointsRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let locale_ids = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let profile_uris = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/get_endpoints_response.rs
+++ b/opcua-types/src/service_types/get_endpoints_response.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for GetEndpointsResponse {
         opcua::types::ObjectId::GetEndpointsResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for GetEndpointsResponse {
+impl opcua::types::BinaryEncodable for GetEndpointsResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for GetEndpointsResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let endpoints = <Option<
             Vec<super::endpoint_description::EndpointDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self { response_header, endpoints })
     }

--- a/opcua-types/src/service_types/history_data.rs
+++ b/opcua-types/src/service_types/history_data.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for HistoryData {
         opcua::types::ObjectId::HistoryData_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryData {
+impl opcua::types::BinaryEncodable for HistoryData {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.data_values.byte_len();
@@ -48,7 +48,7 @@ impl opcua::types::BinaryEncoder for HistoryData {
     ) -> opcua::types::EncodingResult<Self> {
         let data_values = <Option<
             Vec<opcua::types::data_value::DataValue>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { data_values })
     }
 }

--- a/opcua-types/src/service_types/history_event.rs
+++ b/opcua-types/src/service_types/history_event.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for HistoryEvent {
         opcua::types::ObjectId::HistoryEvent_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryEvent {
+impl opcua::types::BinaryEncodable for HistoryEvent {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.events.byte_len();
@@ -48,7 +48,7 @@ impl opcua::types::BinaryEncoder for HistoryEvent {
     ) -> opcua::types::EncodingResult<Self> {
         let events = <Option<
             Vec<super::history_event_field_list::HistoryEventFieldList>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { events })
     }
 }

--- a/opcua-types/src/service_types/history_event_field_list.rs
+++ b/opcua-types/src/service_types/history_event_field_list.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for HistoryEventFieldList {
         opcua::types::ObjectId::HistoryEventFieldList_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryEventFieldList {
+impl opcua::types::BinaryEncodable for HistoryEventFieldList {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.event_fields.byte_len();
@@ -48,7 +48,7 @@ impl opcua::types::BinaryEncoder for HistoryEventFieldList {
     ) -> opcua::types::EncodingResult<Self> {
         let event_fields = <Option<
             Vec<opcua::types::variant::Variant>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { event_fields })
     }
 }

--- a/opcua-types/src/service_types/history_modified_data.rs
+++ b/opcua-types/src/service_types/history_modified_data.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for HistoryModifiedData {
         opcua::types::ObjectId::HistoryModifiedData_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryModifiedData {
+impl opcua::types::BinaryEncodable for HistoryModifiedData {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.data_values.byte_len();
@@ -51,10 +51,10 @@ impl opcua::types::BinaryEncoder for HistoryModifiedData {
     ) -> opcua::types::EncodingResult<Self> {
         let data_values = <Option<
             Vec<opcua::types::data_value::DataValue>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let modification_infos = <Option<
             Vec<super::modification_info::ModificationInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             data_values,
             modification_infos,

--- a/opcua-types/src/service_types/history_read_details.rs
+++ b/opcua-types/src/service_types/history_read_details.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for HistoryReadDetails {
         opcua::types::ObjectId::HistoryReadDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryReadDetails {
+impl opcua::types::BinaryEncodable for HistoryReadDetails {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/history_read_request.rs
+++ b/opcua-types/src/service_types/history_read_request.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for HistoryReadRequest {
         opcua::types::ObjectId::HistoryReadRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryReadRequest {
+impl opcua::types::BinaryEncodable for HistoryReadRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -57,29 +57,29 @@ impl opcua::types::BinaryEncoder for HistoryReadRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let history_read_details = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let history_read_details = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let timestamps_to_return = <super::enums::TimestampsToReturn as opcua::types::BinaryEncoder>::decode(
+        let timestamps_to_return = <super::enums::TimestampsToReturn as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let release_continuation_points = <bool as opcua::types::BinaryEncoder>::decode(
+        let release_continuation_points = <bool as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let nodes_to_read = <Option<
             Vec<super::history_read_value_id::HistoryReadValueId>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/history_read_response.rs
+++ b/opcua-types/src/service_types/history_read_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for HistoryReadResponse {
         opcua::types::ObjectId::HistoryReadResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryReadResponse {
+impl opcua::types::BinaryEncodable for HistoryReadResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for HistoryReadResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<super::history_read_result::HistoryReadResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/history_read_result.rs
+++ b/opcua-types/src/service_types/history_read_result.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for HistoryReadResult {
         opcua::types::ObjectId::HistoryReadResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryReadResult {
+impl opcua::types::BinaryEncodable for HistoryReadResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -52,15 +52,15 @@ impl opcua::types::BinaryEncoder for HistoryReadResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let history_data = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let history_data = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/history_read_value_id.rs
+++ b/opcua-types/src/service_types/history_read_value_id.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for HistoryReadValueId {
         opcua::types::ObjectId::HistoryReadValueId_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryReadValueId {
+impl opcua::types::BinaryEncodable for HistoryReadValueId {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for HistoryReadValueId {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_encoding = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let data_encoding = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/history_update_details.rs
+++ b/opcua-types/src/service_types/history_update_details.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for HistoryUpdateDetails {
         opcua::types::ObjectId::HistoryUpdateDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryUpdateDetails {
+impl opcua::types::BinaryEncodable for HistoryUpdateDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for HistoryUpdateDetails {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/history_update_request.rs
+++ b/opcua-types/src/service_types/history_update_request.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for HistoryUpdateRequest {
         opcua::types::ObjectId::HistoryUpdateRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryUpdateRequest {
+impl opcua::types::BinaryEncodable for HistoryUpdateRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -51,14 +51,14 @@ impl opcua::types::BinaryEncoder for HistoryUpdateRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let history_update_details = <Option<
             Vec<opcua::types::extension_object::ExtensionObject>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/history_update_response.rs
+++ b/opcua-types/src/service_types/history_update_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for HistoryUpdateResponse {
         opcua::types::ObjectId::HistoryUpdateResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryUpdateResponse {
+impl opcua::types::BinaryEncodable for HistoryUpdateResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for HistoryUpdateResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<super::history_update_result::HistoryUpdateResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/history_update_result.rs
+++ b/opcua-types/src/service_types/history_update_result.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for HistoryUpdateResult {
         opcua::types::ObjectId::HistoryUpdateResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for HistoryUpdateResult {
+impl opcua::types::BinaryEncodable for HistoryUpdateResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -52,16 +52,16 @@ impl opcua::types::BinaryEncoder for HistoryUpdateResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let operation_results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             status_code,
             operation_results,

--- a/opcua-types/src/service_types/identity_mapping_rule_type.rs
+++ b/opcua-types/src/service_types/identity_mapping_rule_type.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for IdentityMappingRuleType {
         opcua::types::ObjectId::IdentityMappingRuleType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for IdentityMappingRuleType {
+impl opcua::types::BinaryEncodable for IdentityMappingRuleType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.criteria_type.byte_len();
@@ -48,11 +48,11 @@ impl opcua::types::BinaryEncoder for IdentityMappingRuleType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let criteria_type = <super::enums::IdentityCriteriaType as opcua::types::BinaryEncoder>::decode(
+        let criteria_type = <super::enums::IdentityCriteriaType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let criteria = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let criteria = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/issued_identity_token.rs
+++ b/opcua-types/src/service_types/issued_identity_token.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for IssuedIdentityToken {
         opcua::types::ObjectId::IssuedIdentityToken_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for IssuedIdentityToken {
+impl opcua::types::BinaryEncodable for IssuedIdentityToken {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.policy_id.byte_len();
@@ -52,15 +52,15 @@ impl opcua::types::BinaryEncoder for IssuedIdentityToken {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let token_data = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let token_data = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let encryption_algorithm = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let encryption_algorithm = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/json_data_set_reader_message_data_type.rs
+++ b/opcua-types/src/service_types/json_data_set_reader_message_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for JsonDataSetReaderMessageDataType {
         opcua::types::ObjectId::JsonDataSetReaderMessageDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for JsonDataSetReaderMessageDataType {
+impl opcua::types::BinaryEncodable for JsonDataSetReaderMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.network_message_content_mask.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for JsonDataSetReaderMessageDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let network_message_content_mask = <super::enums::JsonNetworkMessageContentMask as opcua::types::BinaryEncoder>::decode(
+        let network_message_content_mask = <super::enums::JsonNetworkMessageContentMask as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_message_content_mask = <super::enums::JsonDataSetMessageContentMask as opcua::types::BinaryEncoder>::decode(
+        let data_set_message_content_mask = <super::enums::JsonDataSetMessageContentMask as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/json_data_set_writer_message_data_type.rs
+++ b/opcua-types/src/service_types/json_data_set_writer_message_data_type.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for JsonDataSetWriterMessageDataType {
         opcua::types::ObjectId::JsonDataSetWriterMessageDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for JsonDataSetWriterMessageDataType {
+impl opcua::types::BinaryEncodable for JsonDataSetWriterMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.data_set_message_content_mask.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for JsonDataSetWriterMessageDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let data_set_message_content_mask = <super::enums::JsonDataSetMessageContentMask as opcua::types::BinaryEncoder>::decode(
+        let data_set_message_content_mask = <super::enums::JsonDataSetMessageContentMask as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/json_writer_group_message_data_type.rs
+++ b/opcua-types/src/service_types/json_writer_group_message_data_type.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for JsonWriterGroupMessageDataType {
         opcua::types::ObjectId::JsonWriterGroupMessageDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for JsonWriterGroupMessageDataType {
+impl opcua::types::BinaryEncodable for JsonWriterGroupMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.network_message_content_mask.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for JsonWriterGroupMessageDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let network_message_content_mask = <super::enums::JsonNetworkMessageContentMask as opcua::types::BinaryEncoder>::decode(
+        let network_message_content_mask = <super::enums::JsonNetworkMessageContentMask as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/key_value_pair.rs
+++ b/opcua-types/src/service_types/key_value_pair.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for KeyValuePair {
         opcua::types::ObjectId::KeyValuePair_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for KeyValuePair {
+impl opcua::types::BinaryEncodable for KeyValuePair {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.key.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for KeyValuePair {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let key = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let key = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value = <opcua::types::variant::Variant as opcua::types::BinaryEncoder>::decode(
+        let value = <opcua::types::variant::Variant as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/literal_operand.rs
+++ b/opcua-types/src/service_types/literal_operand.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for LiteralOperand {
         opcua::types::ObjectId::LiteralOperand_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for LiteralOperand {
+impl opcua::types::BinaryEncodable for LiteralOperand {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.value.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for LiteralOperand {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let value = <opcua::types::variant::Variant as opcua::types::BinaryEncoder>::decode(
+        let value = <opcua::types::variant::Variant as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/mdns_discovery_configuration.rs
+++ b/opcua-types/src/service_types/mdns_discovery_configuration.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for MdnsDiscoveryConfiguration {
         opcua::types::ObjectId::MdnsDiscoveryConfiguration_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for MdnsDiscoveryConfiguration {
+impl opcua::types::BinaryEncodable for MdnsDiscoveryConfiguration {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.mdns_server_name.byte_len();
@@ -49,13 +49,13 @@ impl opcua::types::BinaryEncoder for MdnsDiscoveryConfiguration {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let mdns_server_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let mdns_server_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let server_capabilities = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             mdns_server_name,
             server_capabilities,

--- a/opcua-types/src/service_types/method_attributes.rs
+++ b/opcua-types/src/service_types/method_attributes.rs
@@ -32,7 +32,7 @@ impl opcua::types::MessageInfo for MethodAttributes {
         opcua::types::ObjectId::MethodAttributes_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for MethodAttributes {
+impl opcua::types::BinaryEncodable for MethodAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_attributes.byte_len();
@@ -64,31 +64,31 @@ impl opcua::types::BinaryEncoder for MethodAttributes {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_attributes = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_attributes = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let user_write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let executable = <bool as opcua::types::BinaryEncoder>::decode(
+        let executable = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_executable = <bool as opcua::types::BinaryEncoder>::decode(
+        let user_executable = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/model_change_structure_data_type.rs
+++ b/opcua-types/src/service_types/model_change_structure_data_type.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for ModelChangeStructureDataType {
         opcua::types::ObjectId::ModelChangeStructureDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ModelChangeStructureDataType {
+impl opcua::types::BinaryEncodable for ModelChangeStructureDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.affected.byte_len();
@@ -52,15 +52,15 @@ impl opcua::types::BinaryEncoder for ModelChangeStructureDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let affected = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let affected = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let affected_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let affected_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let verb = <u8 as opcua::types::BinaryEncoder>::decode(
+        let verb = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/modification_info.rs
+++ b/opcua-types/src/service_types/modification_info.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for ModificationInfo {
         opcua::types::ObjectId::ModificationInfo_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ModificationInfo {
+impl opcua::types::BinaryEncodable for ModificationInfo {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.modification_time.byte_len();
@@ -51,15 +51,15 @@ impl opcua::types::BinaryEncoder for ModificationInfo {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let modification_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let modification_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let update_type = <super::enums::HistoryUpdateType as opcua::types::BinaryEncoder>::decode(
+        let update_type = <super::enums::HistoryUpdateType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let user_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/modify_monitored_items_request.rs
+++ b/opcua-types/src/service_types/modify_monitored_items_request.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for ModifyMonitoredItemsRequest {
         opcua::types::ObjectId::ModifyMonitoredItemsRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ModifyMonitoredItemsRequest {
+impl opcua::types::BinaryEncodable for ModifyMonitoredItemsRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -56,24 +56,24 @@ impl opcua::types::BinaryEncoder for ModifyMonitoredItemsRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let timestamps_to_return = <super::enums::TimestampsToReturn as opcua::types::BinaryEncoder>::decode(
+        let timestamps_to_return = <super::enums::TimestampsToReturn as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let items_to_modify = <Option<
             Vec<super::monitored_item_modify_request::MonitoredItemModifyRequest>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/modify_monitored_items_response.rs
+++ b/opcua-types/src/service_types/modify_monitored_items_response.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for ModifyMonitoredItemsResponse {
         opcua::types::ObjectId::ModifyMonitoredItemsResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ModifyMonitoredItemsResponse {
+impl opcua::types::BinaryEncodable for ModifyMonitoredItemsResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -54,18 +54,18 @@ impl opcua::types::BinaryEncoder for ModifyMonitoredItemsResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<super::monitored_item_modify_result::MonitoredItemModifyResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/modify_subscription_request.rs
+++ b/opcua-types/src/service_types/modify_subscription_request.rs
@@ -32,7 +32,7 @@ impl opcua::types::MessageInfo for ModifySubscriptionRequest {
         opcua::types::ObjectId::ModifySubscriptionRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ModifySubscriptionRequest {
+impl opcua::types::BinaryEncodable for ModifySubscriptionRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -64,37 +64,37 @@ impl opcua::types::BinaryEncoder for ModifySubscriptionRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let requested_publishing_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let requested_publishing_interval = <f64 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let requested_lifetime_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let requested_lifetime_count = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let requested_max_keep_alive_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let requested_max_keep_alive_count = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let max_notifications_per_publish = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_notifications_per_publish = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let priority = <u8 as opcua::types::BinaryEncoder>::decode(
+        let priority = <u8 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/modify_subscription_response.rs
+++ b/opcua-types/src/service_types/modify_subscription_response.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for ModifySubscriptionResponse {
         opcua::types::ObjectId::ModifySubscriptionResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ModifySubscriptionResponse {
+impl opcua::types::BinaryEncodable for ModifySubscriptionResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -55,22 +55,22 @@ impl opcua::types::BinaryEncoder for ModifySubscriptionResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
-        let revised_publishing_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let revised_publishing_interval = <f64 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let revised_lifetime_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let revised_lifetime_count = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let revised_max_keep_alive_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let revised_max_keep_alive_count = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/monitored_item_create_request.rs
+++ b/opcua-types/src/service_types/monitored_item_create_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for MonitoredItemCreateRequest {
         opcua::types::ObjectId::MonitoredItemCreateRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for MonitoredItemCreateRequest {
+impl opcua::types::BinaryEncodable for MonitoredItemCreateRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.item_to_monitor.byte_len();
@@ -51,15 +51,15 @@ impl opcua::types::BinaryEncoder for MonitoredItemCreateRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let item_to_monitor = <super::read_value_id::ReadValueId as opcua::types::BinaryEncoder>::decode(
+        let item_to_monitor = <super::read_value_id::ReadValueId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let monitoring_mode = <super::enums::MonitoringMode as opcua::types::BinaryEncoder>::decode(
+        let monitoring_mode = <super::enums::MonitoringMode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let requested_parameters = <super::monitoring_parameters::MonitoringParameters as opcua::types::BinaryEncoder>::decode(
+        let requested_parameters = <super::monitoring_parameters::MonitoringParameters as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/monitored_item_create_result.rs
+++ b/opcua-types/src/service_types/monitored_item_create_result.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for MonitoredItemCreateResult {
         opcua::types::ObjectId::MonitoredItemCreateResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for MonitoredItemCreateResult {
+impl opcua::types::BinaryEncodable for MonitoredItemCreateResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -58,23 +58,23 @@ impl opcua::types::BinaryEncoder for MonitoredItemCreateResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let monitored_item_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let monitored_item_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let revised_sampling_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let revised_sampling_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let revised_queue_size = <u32 as opcua::types::BinaryEncoder>::decode(
+        let revised_queue_size = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let filter_result = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let filter_result = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/monitored_item_modify_request.rs
+++ b/opcua-types/src/service_types/monitored_item_modify_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for MonitoredItemModifyRequest {
         opcua::types::ObjectId::MonitoredItemModifyRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for MonitoredItemModifyRequest {
+impl opcua::types::BinaryEncodable for MonitoredItemModifyRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.monitored_item_id.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for MonitoredItemModifyRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let monitored_item_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let monitored_item_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let requested_parameters = <super::monitoring_parameters::MonitoringParameters as opcua::types::BinaryEncoder>::decode(
+        let requested_parameters = <super::monitoring_parameters::MonitoringParameters as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/monitored_item_modify_result.rs
+++ b/opcua-types/src/service_types/monitored_item_modify_result.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for MonitoredItemModifyResult {
         opcua::types::ObjectId::MonitoredItemModifyResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for MonitoredItemModifyResult {
+impl opcua::types::BinaryEncodable for MonitoredItemModifyResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for MonitoredItemModifyResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let revised_sampling_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let revised_sampling_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let revised_queue_size = <u32 as opcua::types::BinaryEncoder>::decode(
+        let revised_queue_size = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let filter_result = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let filter_result = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/monitored_item_notification.rs
+++ b/opcua-types/src/service_types/monitored_item_notification.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for MonitoredItemNotification {
         opcua::types::ObjectId::MonitoredItemNotification_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for MonitoredItemNotification {
+impl opcua::types::BinaryEncodable for MonitoredItemNotification {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.client_handle.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for MonitoredItemNotification {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let client_handle = <u32 as opcua::types::BinaryEncoder>::decode(
+        let client_handle = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value = <opcua::types::data_value::DataValue as opcua::types::BinaryEncoder>::decode(
+        let value = <opcua::types::data_value::DataValue as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/monitoring_filter.rs
+++ b/opcua-types/src/service_types/monitoring_filter.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for MonitoringFilter {
         opcua::types::ObjectId::MonitoringFilter_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for MonitoringFilter {
+impl opcua::types::BinaryEncodable for MonitoringFilter {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/monitoring_filter_result.rs
+++ b/opcua-types/src/service_types/monitoring_filter_result.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for MonitoringFilterResult {
         opcua::types::ObjectId::MonitoringFilterResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for MonitoringFilterResult {
+impl opcua::types::BinaryEncodable for MonitoringFilterResult {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/monitoring_parameters.rs
+++ b/opcua-types/src/service_types/monitoring_parameters.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for MonitoringParameters {
         opcua::types::ObjectId::MonitoringParameters_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for MonitoringParameters {
+impl opcua::types::BinaryEncodable for MonitoringParameters {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.client_handle.byte_len();
@@ -58,23 +58,23 @@ impl opcua::types::BinaryEncoder for MonitoringParameters {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let client_handle = <u32 as opcua::types::BinaryEncoder>::decode(
+        let client_handle = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let sampling_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let sampling_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let filter = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let filter = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let queue_size = <u32 as opcua::types::BinaryEncoder>::decode(
+        let queue_size = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let discard_oldest = <bool as opcua::types::BinaryEncoder>::decode(
+        let discard_oldest = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/network_address_data_type.rs
+++ b/opcua-types/src/service_types/network_address_data_type.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for NetworkAddressDataType {
         opcua::types::ObjectId::NetworkAddressDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for NetworkAddressDataType {
+impl opcua::types::BinaryEncodable for NetworkAddressDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.network_interface.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for NetworkAddressDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let network_interface = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let network_interface = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/network_address_url_data_type.rs
+++ b/opcua-types/src/service_types/network_address_url_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for NetworkAddressUrlDataType {
         opcua::types::ObjectId::NetworkAddressUrlDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for NetworkAddressUrlDataType {
+impl opcua::types::BinaryEncodable for NetworkAddressUrlDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.network_interface.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for NetworkAddressUrlDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let network_interface = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let network_interface = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let url = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let url = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/network_group_data_type.rs
+++ b/opcua-types/src/service_types/network_group_data_type.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for NetworkGroupDataType {
         opcua::types::ObjectId::NetworkGroupDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for NetworkGroupDataType {
+impl opcua::types::BinaryEncodable for NetworkGroupDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.server_uri.byte_len();
@@ -51,13 +51,13 @@ impl opcua::types::BinaryEncoder for NetworkGroupDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let network_paths = <Option<
             Vec<super::endpoint_url_list_data_type::EndpointUrlListDataType>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { server_uri, network_paths })
     }
 }

--- a/opcua-types/src/service_types/node_attributes.rs
+++ b/opcua-types/src/service_types/node_attributes.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for NodeAttributes {
         opcua::types::ObjectId::NodeAttributes_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for NodeAttributes {
+impl opcua::types::BinaryEncodable for NodeAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_attributes.byte_len();
@@ -58,23 +58,23 @@ impl opcua::types::BinaryEncoder for NodeAttributes {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_attributes = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_attributes = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let user_write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/node_reference.rs
+++ b/opcua-types/src/service_types/node_reference.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for NodeReference {
         opcua::types::ObjectId::NodeReference_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for NodeReference {
+impl opcua::types::BinaryEncodable for NodeReference {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -55,21 +55,21 @@ impl opcua::types::BinaryEncoder for NodeReference {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_forward = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_forward = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let referenced_node_ids = <Option<
             Vec<opcua::types::node_id::NodeId>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             node_id,
             reference_type_id,

--- a/opcua-types/src/service_types/node_type_description.rs
+++ b/opcua-types/src/service_types/node_type_description.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for NodeTypeDescription {
         opcua::types::ObjectId::NodeTypeDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for NodeTypeDescription {
+impl opcua::types::BinaryEncodable for NodeTypeDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.type_definition_node.byte_len();
@@ -52,17 +52,17 @@ impl opcua::types::BinaryEncoder for NodeTypeDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let type_definition_node = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let type_definition_node = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let include_sub_types = <bool as opcua::types::BinaryEncoder>::decode(
+        let include_sub_types = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let data_to_return = <Option<
             Vec<super::query_data_description::QueryDataDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             type_definition_node,
             include_sub_types,

--- a/opcua-types/src/service_types/notification_data.rs
+++ b/opcua-types/src/service_types/notification_data.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for NotificationData {
         opcua::types::ObjectId::NotificationData_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for NotificationData {
+impl opcua::types::BinaryEncodable for NotificationData {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/notification_message.rs
+++ b/opcua-types/src/service_types/notification_message.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for NotificationMessage {
         opcua::types::ObjectId::NotificationMessage_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for NotificationMessage {
+impl opcua::types::BinaryEncodable for NotificationMessage {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.sequence_number.byte_len();
@@ -52,17 +52,17 @@ impl opcua::types::BinaryEncoder for NotificationMessage {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let sequence_number = <u32 as opcua::types::BinaryEncoder>::decode(
+        let sequence_number = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let publish_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let publish_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let notification_data = <Option<
             Vec<opcua::types::extension_object::ExtensionObject>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             sequence_number,
             publish_time,

--- a/opcua-types/src/service_types/object_attributes.rs
+++ b/opcua-types/src/service_types/object_attributes.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for ObjectAttributes {
         opcua::types::ObjectId::ObjectAttributes_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ObjectAttributes {
+impl opcua::types::BinaryEncodable for ObjectAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_attributes.byte_len();
@@ -61,27 +61,27 @@ impl opcua::types::BinaryEncoder for ObjectAttributes {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_attributes = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_attributes = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let user_write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let event_notifier = <u8 as opcua::types::BinaryEncoder>::decode(
+        let event_notifier = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/object_type_attributes.rs
+++ b/opcua-types/src/service_types/object_type_attributes.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for ObjectTypeAttributes {
         opcua::types::ObjectId::ObjectTypeAttributes_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ObjectTypeAttributes {
+impl opcua::types::BinaryEncodable for ObjectTypeAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_attributes.byte_len();
@@ -61,27 +61,27 @@ impl opcua::types::BinaryEncoder for ObjectTypeAttributes {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_attributes = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_attributes = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let user_write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_abstract = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_abstract = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/open_secure_channel_request.rs
+++ b/opcua-types/src/service_types/open_secure_channel_request.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for OpenSecureChannelRequest {
         opcua::types::ObjectId::OpenSecureChannelRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for OpenSecureChannelRequest {
+impl opcua::types::BinaryEncodable for OpenSecureChannelRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -60,32 +60,32 @@ impl opcua::types::BinaryEncoder for OpenSecureChannelRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let client_protocol_version = <u32 as opcua::types::BinaryEncoder>::decode(
+        let client_protocol_version = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let request_type = <super::enums::SecurityTokenRequestType as opcua::types::BinaryEncoder>::decode(
+        let request_type = <super::enums::SecurityTokenRequestType as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncoder>::decode(
+        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let client_nonce = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let client_nonce = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let requested_lifetime = <u32 as opcua::types::BinaryEncoder>::decode(
+        let requested_lifetime = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/open_secure_channel_response.rs
+++ b/opcua-types/src/service_types/open_secure_channel_response.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for OpenSecureChannelResponse {
         opcua::types::ObjectId::OpenSecureChannelResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for OpenSecureChannelResponse {
+impl opcua::types::BinaryEncodable for OpenSecureChannelResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -55,22 +55,22 @@ impl opcua::types::BinaryEncoder for OpenSecureChannelResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
-        let server_protocol_version = <u32 as opcua::types::BinaryEncoder>::decode(
+        let server_protocol_version = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let security_token = <super::channel_security_token::ChannelSecurityToken as opcua::types::BinaryEncoder>::decode(
+        let security_token = <super::channel_security_token::ChannelSecurityToken as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let server_nonce = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let server_nonce = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/option_set.rs
+++ b/opcua-types/src/service_types/option_set.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for OptionSet {
         opcua::types::ObjectId::OptionSet_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for OptionSet {
+impl opcua::types::BinaryEncodable for OptionSet {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.value.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for OptionSet {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let value = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let value = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let valid_bits = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let valid_bits = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/orientation.rs
+++ b/opcua-types/src/service_types/orientation.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for Orientation {
         opcua::types::ObjectId::Orientation_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for Orientation {
+impl opcua::types::BinaryEncodable for Orientation {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/parsing_result.rs
+++ b/opcua-types/src/service_types/parsing_result.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for ParsingResult {
         opcua::types::ObjectId::ParsingResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ParsingResult {
+impl opcua::types::BinaryEncodable for ParsingResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -54,16 +54,16 @@ impl opcua::types::BinaryEncoder for ParsingResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let data_status_codes = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let data_diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             status_code,
             data_status_codes,

--- a/opcua-types/src/service_types/program_diagnostic_2_data_type.rs
+++ b/opcua-types/src/service_types/program_diagnostic_2_data_type.rs
@@ -37,7 +37,7 @@ impl opcua::types::MessageInfo for ProgramDiagnostic2DataType {
         opcua::types::ObjectId::ProgramDiagnostic2DataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ProgramDiagnostic2DataType {
+impl opcua::types::BinaryEncodable for ProgramDiagnostic2DataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.create_session_id.byte_len();
@@ -79,47 +79,47 @@ impl opcua::types::BinaryEncoder for ProgramDiagnostic2DataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let create_session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let create_session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let create_client_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let create_client_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let invocation_creation_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let invocation_creation_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let last_transition_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let last_transition_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let last_method_call = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let last_method_call = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let last_method_session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let last_method_session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let last_method_input_arguments = <Option<
             Vec<super::argument::Argument>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let last_method_output_arguments = <Option<
             Vec<super::argument::Argument>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let last_method_input_values = <Option<
             Vec<opcua::types::variant::Variant>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let last_method_output_values = <Option<
             Vec<opcua::types::variant::Variant>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let last_method_call_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let last_method_call_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let last_method_return_status = <super::status_result::StatusResult as opcua::types::BinaryEncoder>::decode(
+        let last_method_return_status = <super::status_result::StatusResult as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/program_diagnostic_data_type.rs
+++ b/opcua-types/src/service_types/program_diagnostic_data_type.rs
@@ -35,7 +35,7 @@ impl opcua::types::MessageInfo for ProgramDiagnosticDataType {
         opcua::types::ObjectId::ProgramDiagnosticDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ProgramDiagnosticDataType {
+impl opcua::types::BinaryEncodable for ProgramDiagnosticDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.create_session_id.byte_len();
@@ -73,41 +73,41 @@ impl opcua::types::BinaryEncoder for ProgramDiagnosticDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let create_session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let create_session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let create_client_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let create_client_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let invocation_creation_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let invocation_creation_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let last_transition_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let last_transition_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let last_method_call = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let last_method_call = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let last_method_session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let last_method_session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let last_method_input_arguments = <Option<
             Vec<super::argument::Argument>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let last_method_output_arguments = <Option<
             Vec<super::argument::Argument>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let last_method_call_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let last_method_call_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let last_method_return_status = <super::status_result::StatusResult as opcua::types::BinaryEncoder>::decode(
+        let last_method_return_status = <super::status_result::StatusResult as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/pub_sub_configuration_data_type.rs
+++ b/opcua-types/src/service_types/pub_sub_configuration_data_type.rs
@@ -32,7 +32,7 @@ impl opcua::types::MessageInfo for PubSubConfigurationDataType {
         opcua::types::ObjectId::PubSubConfigurationDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for PubSubConfigurationDataType {
+impl opcua::types::BinaryEncodable for PubSubConfigurationDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.published_data_sets.byte_len();
@@ -58,11 +58,11 @@ impl opcua::types::BinaryEncoder for PubSubConfigurationDataType {
     ) -> opcua::types::EncodingResult<Self> {
         let published_data_sets = <Option<
             Vec<super::published_data_set_data_type::PublishedDataSetDataType>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let connections = <Option<
             Vec<super::pub_sub_connection_data_type::PubSubConnectionDataType>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let enabled = <bool as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let enabled = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/pub_sub_connection_data_type.rs
+++ b/opcua-types/src/service_types/pub_sub_connection_data_type.rs
@@ -34,7 +34,7 @@ impl opcua::types::MessageInfo for PubSubConnectionDataType {
         opcua::types::ObjectId::PubSubConnectionDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for PubSubConnectionDataType {
+impl opcua::types::BinaryEncodable for PubSubConnectionDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.name.byte_len();
@@ -70,39 +70,39 @@ impl opcua::types::BinaryEncoder for PubSubConnectionDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let enabled = <bool as opcua::types::BinaryEncoder>::decode(
+        let enabled = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let publisher_id = <opcua::types::variant::Variant as opcua::types::BinaryEncoder>::decode(
+        let publisher_id = <opcua::types::variant::Variant as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let transport_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let transport_profile_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let address = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let address = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let connection_properties = <Option<
             Vec<super::key_value_pair::KeyValuePair>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let transport_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let transport_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let writer_groups = <Option<
             Vec<super::writer_group_data_type::WriterGroupDataType>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let reader_groups = <Option<
             Vec<super::reader_group_data_type::ReaderGroupDataType>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             name,
             enabled,

--- a/opcua-types/src/service_types/pub_sub_group_data_type.rs
+++ b/opcua-types/src/service_types/pub_sub_group_data_type.rs
@@ -33,7 +33,7 @@ impl opcua::types::MessageInfo for PubSubGroupDataType {
         opcua::types::ObjectId::PubSubGroupDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for PubSubGroupDataType {
+impl opcua::types::BinaryEncodable for PubSubGroupDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.name.byte_len();
@@ -65,32 +65,32 @@ impl opcua::types::BinaryEncoder for PubSubGroupDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let enabled = <bool as opcua::types::BinaryEncoder>::decode(
+        let enabled = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncoder>::decode(
+        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_group_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let security_group_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let security_key_services = <Option<
             Vec<super::endpoint_description::EndpointDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let max_network_message_size = <u32 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let max_network_message_size = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let group_properties = <Option<
             Vec<super::key_value_pair::KeyValuePair>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             name,
             enabled,

--- a/opcua-types/src/service_types/publish_request.rs
+++ b/opcua-types/src/service_types/publish_request.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for PublishRequest {
         opcua::types::ObjectId::PublishRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for PublishRequest {
+impl opcua::types::BinaryEncodable for PublishRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -51,14 +51,14 @@ impl opcua::types::BinaryEncoder for PublishRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let subscription_acknowledgements = <Option<
             Vec<super::subscription_acknowledgement::SubscriptionAcknowledgement>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/publish_response.rs
+++ b/opcua-types/src/service_types/publish_response.rs
@@ -32,7 +32,7 @@ impl opcua::types::MessageInfo for PublishResponse {
         opcua::types::ObjectId::PublishResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for PublishResponse {
+impl opcua::types::BinaryEncodable for PublishResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -64,37 +64,37 @@ impl opcua::types::BinaryEncoder for PublishResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let available_sequence_numbers = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let more_notifications = <bool as opcua::types::BinaryEncoder>::decode(
+        let more_notifications = <bool as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let notification_message = <super::notification_message::NotificationMessage as opcua::types::BinaryEncoder>::decode(
+        let notification_message = <super::notification_message::NotificationMessage as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/published_data_items_data_type.rs
+++ b/opcua-types/src/service_types/published_data_items_data_type.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for PublishedDataItemsDataType {
         opcua::types::ObjectId::PublishedDataItemsDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for PublishedDataItemsDataType {
+impl opcua::types::BinaryEncodable for PublishedDataItemsDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.published_data.byte_len();
@@ -50,7 +50,7 @@ impl opcua::types::BinaryEncoder for PublishedDataItemsDataType {
     ) -> opcua::types::EncodingResult<Self> {
         let published_data = <Option<
             Vec<super::published_variable_data_type::PublishedVariableDataType>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { published_data })
     }
 }

--- a/opcua-types/src/service_types/published_data_set_data_type.rs
+++ b/opcua-types/src/service_types/published_data_set_data_type.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for PublishedDataSetDataType {
         opcua::types::ObjectId::PublishedDataSetDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for PublishedDataSetDataType {
+impl opcua::types::BinaryEncodable for PublishedDataSetDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.name.byte_len();
@@ -58,21 +58,21 @@ impl opcua::types::BinaryEncoder for PublishedDataSetDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let data_set_folder = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let data_set_meta_data = <super::data_set_meta_data_type::DataSetMetaDataType as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let data_set_meta_data = <super::data_set_meta_data_type::DataSetMetaDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let extension_fields = <Option<
             Vec<super::key_value_pair::KeyValuePair>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let data_set_source = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let data_set_source = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/published_data_set_source_data_type.rs
+++ b/opcua-types/src/service_types/published_data_set_source_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for PublishedDataSetSourceDataType {
         opcua::types::ObjectId::PublishedDataSetSourceDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for PublishedDataSetSourceDataType {
+impl opcua::types::BinaryEncodable for PublishedDataSetSourceDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/published_events_data_type.rs
+++ b/opcua-types/src/service_types/published_events_data_type.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for PublishedEventsDataType {
         opcua::types::ObjectId::PublishedEventsDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for PublishedEventsDataType {
+impl opcua::types::BinaryEncodable for PublishedEventsDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.event_notifier.byte_len();
@@ -54,14 +54,14 @@ impl opcua::types::BinaryEncoder for PublishedEventsDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let event_notifier = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let event_notifier = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let selected_fields = <Option<
             Vec<super::simple_attribute_operand::SimpleAttributeOperand>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let filter = <super::content_filter::ContentFilter as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let filter = <super::content_filter::ContentFilter as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/published_variable_data_type.rs
+++ b/opcua-types/src/service_types/published_variable_data_type.rs
@@ -33,7 +33,7 @@ impl opcua::types::MessageInfo for PublishedVariableDataType {
         opcua::types::ObjectId::PublishedVariableDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for PublishedVariableDataType {
+impl opcua::types::BinaryEncodable for PublishedVariableDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.published_variable.byte_len();
@@ -67,37 +67,37 @@ impl opcua::types::BinaryEncoder for PublishedVariableDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let published_variable = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let published_variable = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let attribute_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let attribute_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let sampling_interval_hint = <f64 as opcua::types::BinaryEncoder>::decode(
+        let sampling_interval_hint = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let deadband_type = <u32 as opcua::types::BinaryEncoder>::decode(
+        let deadband_type = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let deadband_value = <f64 as opcua::types::BinaryEncoder>::decode(
+        let deadband_value = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let substitute_value = <opcua::types::variant::Variant as opcua::types::BinaryEncoder>::decode(
+        let substitute_value = <opcua::types::variant::Variant as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let meta_data_properties = <Option<
             Vec<opcua::types::qualified_name::QualifiedName>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             published_variable,
             attribute_id,

--- a/opcua-types/src/service_types/query_data_description.rs
+++ b/opcua-types/src/service_types/query_data_description.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for QueryDataDescription {
         opcua::types::ObjectId::QueryDataDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for QueryDataDescription {
+impl opcua::types::BinaryEncodable for QueryDataDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.relative_path.byte_len();
@@ -52,15 +52,15 @@ impl opcua::types::BinaryEncoder for QueryDataDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let relative_path = <super::relative_path::RelativePath as opcua::types::BinaryEncoder>::decode(
+        let relative_path = <super::relative_path::RelativePath as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let attribute_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let attribute_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/query_data_set.rs
+++ b/opcua-types/src/service_types/query_data_set.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for QueryDataSet {
         opcua::types::ObjectId::QueryDataSet_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for QueryDataSet {
+impl opcua::types::BinaryEncodable for QueryDataSet {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -52,17 +52,17 @@ impl opcua::types::BinaryEncoder for QueryDataSet {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let type_definition_node = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let type_definition_node = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let values = <Option<
             Vec<opcua::types::variant::Variant>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             node_id,
             type_definition_node,

--- a/opcua-types/src/service_types/query_first_request.rs
+++ b/opcua-types/src/service_types/query_first_request.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for QueryFirstRequest {
         opcua::types::ObjectId::QueryFirstRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for QueryFirstRequest {
+impl opcua::types::BinaryEncodable for QueryFirstRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -61,31 +61,31 @@ impl opcua::types::BinaryEncoder for QueryFirstRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let view = <super::view_description::ViewDescription as opcua::types::BinaryEncoder>::decode(
+        let view = <super::view_description::ViewDescription as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let node_types = <Option<
             Vec<super::node_type_description::NodeTypeDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let filter = <super::content_filter::ContentFilter as opcua::types::BinaryEncoder>::decode(
+        let filter = <super::content_filter::ContentFilter as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let max_data_sets_to_return = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_data_sets_to_return = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let max_references_to_return = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_references_to_return = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/query_first_response.rs
+++ b/opcua-types/src/service_types/query_first_response.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for QueryFirstResponse {
         opcua::types::ObjectId::QueryFirstResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for QueryFirstResponse {
+impl opcua::types::BinaryEncodable for QueryFirstResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -61,29 +61,29 @@ impl opcua::types::BinaryEncoder for QueryFirstResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let query_data_sets = <Option<
             Vec<super::query_data_set::QueryDataSet>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let parsing_results = <Option<
             Vec<super::parsing_result::ParsingResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let filter_result = <super::content_filter_result::ContentFilterResult as opcua::types::BinaryEncoder>::decode(
+        let filter_result = <super::content_filter_result::ContentFilterResult as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/query_next_request.rs
+++ b/opcua-types/src/service_types/query_next_request.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for QueryNextRequest {
         opcua::types::ObjectId::QueryNextRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for QueryNextRequest {
+impl opcua::types::BinaryEncodable for QueryNextRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -52,17 +52,17 @@ impl opcua::types::BinaryEncoder for QueryNextRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let release_continuation_point = <bool as opcua::types::BinaryEncoder>::decode(
+        let release_continuation_point = <bool as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/query_next_response.rs
+++ b/opcua-types/src/service_types/query_next_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for QueryNextResponse {
         opcua::types::ObjectId::QueryNextResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for QueryNextResponse {
+impl opcua::types::BinaryEncodable for QueryNextResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,16 +52,16 @@ impl opcua::types::BinaryEncoder for QueryNextResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let query_data_sets = <Option<
             Vec<super::query_data_set::QueryDataSet>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let revised_continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let revised_continuation_point = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/range.rs
+++ b/opcua-types/src/service_types/range.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for Range {
         opcua::types::ObjectId::Range_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for Range {
+impl opcua::types::BinaryEncodable for Range {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.low.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for Range {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let low = <f64 as opcua::types::BinaryEncoder>::decode(
+        let low = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let high = <f64 as opcua::types::BinaryEncoder>::decode(
+        let high = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/rational_number.rs
+++ b/opcua-types/src/service_types/rational_number.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for RationalNumber {
         opcua::types::ObjectId::RationalNumber_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RationalNumber {
+impl opcua::types::BinaryEncodable for RationalNumber {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.numerator.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for RationalNumber {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let numerator = <i32 as opcua::types::BinaryEncoder>::decode(
+        let numerator = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let denominator = <u32 as opcua::types::BinaryEncoder>::decode(
+        let denominator = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/read_annotation_data_details.rs
+++ b/opcua-types/src/service_types/read_annotation_data_details.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for ReadAnnotationDataDetails {
         opcua::types::ObjectId::ReadAnnotationDataDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReadAnnotationDataDetails {
+impl opcua::types::BinaryEncodable for ReadAnnotationDataDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.req_times.byte_len();
@@ -48,7 +48,7 @@ impl opcua::types::BinaryEncoder for ReadAnnotationDataDetails {
     ) -> opcua::types::EncodingResult<Self> {
         let req_times = <Option<
             Vec<opcua::types::date_time::DateTime>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { req_times })
     }
 }

--- a/opcua-types/src/service_types/read_at_time_details.rs
+++ b/opcua-types/src/service_types/read_at_time_details.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for ReadAtTimeDetails {
         opcua::types::ObjectId::ReadAtTimeDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReadAtTimeDetails {
+impl opcua::types::BinaryEncodable for ReadAtTimeDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.req_times.byte_len();
@@ -51,8 +51,8 @@ impl opcua::types::BinaryEncoder for ReadAtTimeDetails {
     ) -> opcua::types::EncodingResult<Self> {
         let req_times = <Option<
             Vec<opcua::types::date_time::DateTime>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let use_simple_bounds = <bool as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let use_simple_bounds = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/read_event_details.rs
+++ b/opcua-types/src/service_types/read_event_details.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for ReadEventDetails {
         opcua::types::ObjectId::ReadEventDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReadEventDetails {
+impl opcua::types::BinaryEncodable for ReadEventDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.num_values_per_node.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for ReadEventDetails {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let num_values_per_node = <u32 as opcua::types::BinaryEncoder>::decode(
+        let num_values_per_node = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let end_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let end_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let filter = <super::event_filter::EventFilter as opcua::types::BinaryEncoder>::decode(
+        let filter = <super::event_filter::EventFilter as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/read_processed_details.rs
+++ b/opcua-types/src/service_types/read_processed_details.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for ReadProcessedDetails {
         opcua::types::ObjectId::ReadProcessedDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReadProcessedDetails {
+impl opcua::types::BinaryEncodable for ReadProcessedDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.start_time.byte_len();
@@ -58,22 +58,22 @@ impl opcua::types::BinaryEncoder for ReadProcessedDetails {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let end_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let end_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let processing_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let processing_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let aggregate_type = <Option<
             Vec<opcua::types::node_id::NodeId>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let aggregate_configuration = <super::aggregate_configuration::AggregateConfiguration as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let aggregate_configuration = <super::aggregate_configuration::AggregateConfiguration as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/read_raw_modified_details.rs
+++ b/opcua-types/src/service_types/read_raw_modified_details.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for ReadRawModifiedDetails {
         opcua::types::ObjectId::ReadRawModifiedDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReadRawModifiedDetails {
+impl opcua::types::BinaryEncodable for ReadRawModifiedDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.is_read_modified.byte_len();
@@ -58,23 +58,23 @@ impl opcua::types::BinaryEncoder for ReadRawModifiedDetails {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let is_read_modified = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_read_modified = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let end_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let end_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let num_values_per_node = <u32 as opcua::types::BinaryEncoder>::decode(
+        let num_values_per_node = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let return_bounds = <bool as opcua::types::BinaryEncoder>::decode(
+        let return_bounds = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/read_request.rs
+++ b/opcua-types/src/service_types/read_request.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for ReadRequest {
         opcua::types::ObjectId::ReadRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReadRequest {
+impl opcua::types::BinaryEncodable for ReadRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -54,24 +54,24 @@ impl opcua::types::BinaryEncoder for ReadRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let max_age = <f64 as opcua::types::BinaryEncoder>::decode(
+        let max_age = <f64 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let timestamps_to_return = <super::enums::TimestampsToReturn as opcua::types::BinaryEncoder>::decode(
+        let timestamps_to_return = <super::enums::TimestampsToReturn as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let nodes_to_read = <Option<
             Vec<super::read_value_id::ReadValueId>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/read_response.rs
+++ b/opcua-types/src/service_types/read_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for ReadResponse {
         opcua::types::ObjectId::ReadResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReadResponse {
+impl opcua::types::BinaryEncodable for ReadResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for ReadResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<opcua::types::data_value::DataValue>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/read_value_id.rs
+++ b/opcua-types/src/service_types/read_value_id.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for ReadValueId {
         opcua::types::ObjectId::ReadValueId_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReadValueId {
+impl opcua::types::BinaryEncodable for ReadValueId {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for ReadValueId {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let attribute_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let attribute_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_encoding = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let data_encoding = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/reader_group_data_type.rs
+++ b/opcua-types/src/service_types/reader_group_data_type.rs
@@ -38,7 +38,7 @@ impl opcua::types::MessageInfo for ReaderGroupDataType {
         opcua::types::ObjectId::ReaderGroupDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReaderGroupDataType {
+impl opcua::types::BinaryEncodable for ReaderGroupDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.name.byte_len();
@@ -76,43 +76,43 @@ impl opcua::types::BinaryEncoder for ReaderGroupDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let enabled = <bool as opcua::types::BinaryEncoder>::decode(
+        let enabled = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncoder>::decode(
+        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_group_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let security_group_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let security_key_services = <Option<
             Vec<super::endpoint_description::EndpointDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let max_network_message_size = <u32 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let max_network_message_size = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let group_properties = <Option<
             Vec<super::key_value_pair::KeyValuePair>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let transport_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let transport_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let message_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let message_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let data_set_readers = <Option<
             Vec<super::data_set_reader_data_type::DataSetReaderDataType>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             name,
             enabled,

--- a/opcua-types/src/service_types/reader_group_message_data_type.rs
+++ b/opcua-types/src/service_types/reader_group_message_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for ReaderGroupMessageDataType {
         opcua::types::ObjectId::ReaderGroupMessageDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReaderGroupMessageDataType {
+impl opcua::types::BinaryEncodable for ReaderGroupMessageDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/reader_group_transport_data_type.rs
+++ b/opcua-types/src/service_types/reader_group_transport_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for ReaderGroupTransportDataType {
         opcua::types::ObjectId::ReaderGroupTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReaderGroupTransportDataType {
+impl opcua::types::BinaryEncodable for ReaderGroupTransportDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/redundant_server_data_type.rs
+++ b/opcua-types/src/service_types/redundant_server_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for RedundantServerDataType {
         opcua::types::ObjectId::RedundantServerDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RedundantServerDataType {
+impl opcua::types::BinaryEncodable for RedundantServerDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.server_id.byte_len();
@@ -51,15 +51,15 @@ impl opcua::types::BinaryEncoder for RedundantServerDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let server_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let server_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let service_level = <u8 as opcua::types::BinaryEncoder>::decode(
+        let service_level = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let server_state = <super::enums::ServerState as opcua::types::BinaryEncoder>::decode(
+        let server_state = <super::enums::ServerState as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/reference_description.rs
+++ b/opcua-types/src/service_types/reference_description.rs
@@ -31,7 +31,7 @@ impl opcua::types::MessageInfo for ReferenceDescription {
         opcua::types::ObjectId::ReferenceDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReferenceDescription {
+impl opcua::types::BinaryEncodable for ReferenceDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.reference_type_id.byte_len();
@@ -63,31 +63,31 @@ impl opcua::types::BinaryEncoder for ReferenceDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_forward = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_forward = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let browse_name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let browse_name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let node_class = <super::enums::NodeClass as opcua::types::BinaryEncoder>::decode(
+        let node_class = <super::enums::NodeClass as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let type_definition = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncoder>::decode(
+        let type_definition = <opcua::types::expanded_node_id::ExpandedNodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/reference_type_attributes.rs
+++ b/opcua-types/src/service_types/reference_type_attributes.rs
@@ -33,7 +33,7 @@ impl opcua::types::MessageInfo for ReferenceTypeAttributes {
         opcua::types::ObjectId::ReferenceTypeAttributes_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ReferenceTypeAttributes {
+impl opcua::types::BinaryEncodable for ReferenceTypeAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_attributes.byte_len();
@@ -67,35 +67,35 @@ impl opcua::types::BinaryEncoder for ReferenceTypeAttributes {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_attributes = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_attributes = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let user_write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_abstract = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_abstract = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let symmetric = <bool as opcua::types::BinaryEncoder>::decode(
+        let symmetric = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let inverse_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let inverse_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/register_nodes_request.rs
+++ b/opcua-types/src/service_types/register_nodes_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for RegisterNodesRequest {
         opcua::types::ObjectId::RegisterNodesRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RegisterNodesRequest {
+impl opcua::types::BinaryEncodable for RegisterNodesRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for RegisterNodesRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let nodes_to_register = <Option<
             Vec<opcua::types::node_id::NodeId>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/register_nodes_response.rs
+++ b/opcua-types/src/service_types/register_nodes_response.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for RegisterNodesResponse {
         opcua::types::ObjectId::RegisterNodesResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RegisterNodesResponse {
+impl opcua::types::BinaryEncodable for RegisterNodesResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for RegisterNodesResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let registered_node_ids = <Option<
             Vec<opcua::types::node_id::NodeId>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/register_server_2_request.rs
+++ b/opcua-types/src/service_types/register_server_2_request.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for RegisterServer2Request {
         opcua::types::ObjectId::RegisterServer2Request_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RegisterServer2Request {
+impl opcua::types::BinaryEncodable for RegisterServer2Request {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -53,19 +53,19 @@ impl opcua::types::BinaryEncoder for RegisterServer2Request {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let server = <super::registered_server::RegisteredServer as opcua::types::BinaryEncoder>::decode(
+        let server = <super::registered_server::RegisteredServer as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let discovery_configuration = <Option<
             Vec<opcua::types::extension_object::ExtensionObject>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/register_server_2_response.rs
+++ b/opcua-types/src/service_types/register_server_2_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for RegisterServer2Response {
         opcua::types::ObjectId::RegisterServer2Response_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RegisterServer2Response {
+impl opcua::types::BinaryEncodable for RegisterServer2Response {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for RegisterServer2Response {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let configuration_results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/register_server_request.rs
+++ b/opcua-types/src/service_types/register_server_request.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for RegisterServerRequest {
         opcua::types::ObjectId::RegisterServerRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RegisterServerRequest {
+impl opcua::types::BinaryEncodable for RegisterServerRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -48,12 +48,12 @@ impl opcua::types::BinaryEncoder for RegisterServerRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let server = <super::registered_server::RegisteredServer as opcua::types::BinaryEncoder>::decode(
+        let server = <super::registered_server::RegisteredServer as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/register_server_response.rs
+++ b/opcua-types/src/service_types/register_server_response.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for RegisterServerResponse {
         opcua::types::ObjectId::RegisterServerResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RegisterServerResponse {
+impl opcua::types::BinaryEncodable for RegisterServerResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for RegisterServerResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/registered_server.rs
+++ b/opcua-types/src/service_types/registered_server.rs
@@ -32,7 +32,7 @@ impl opcua::types::MessageInfo for RegisteredServer {
         opcua::types::ObjectId::RegisteredServer_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RegisteredServer {
+impl opcua::types::BinaryEncodable for RegisteredServer {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.server_uri.byte_len();
@@ -66,33 +66,33 @@ impl opcua::types::BinaryEncoder for RegisteredServer {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let product_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let product_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let server_names = <Option<
             Vec<opcua::types::localized_text::LocalizedText>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let server_type = <super::enums::ApplicationType as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let server_type = <super::enums::ApplicationType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let gateway_server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let gateway_server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let discovery_urls = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let semaphore_file_path = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let semaphore_file_path = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_online = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_online = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/relative_path.rs
+++ b/opcua-types/src/service_types/relative_path.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for RelativePath {
         opcua::types::ObjectId::RelativePath_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RelativePath {
+impl opcua::types::BinaryEncodable for RelativePath {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.elements.byte_len();
@@ -48,7 +48,7 @@ impl opcua::types::BinaryEncoder for RelativePath {
     ) -> opcua::types::EncodingResult<Self> {
         let elements = <Option<
             Vec<super::relative_path_element::RelativePathElement>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { elements })
     }
 }

--- a/opcua-types/src/service_types/relative_path_element.rs
+++ b/opcua-types/src/service_types/relative_path_element.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for RelativePathElement {
         opcua::types::ObjectId::RelativePathElement_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RelativePathElement {
+impl opcua::types::BinaryEncodable for RelativePathElement {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.reference_type_id.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for RelativePathElement {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let reference_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_inverse = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_inverse = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let include_subtypes = <bool as opcua::types::BinaryEncoder>::decode(
+        let include_subtypes = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let target_name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let target_name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/republish_request.rs
+++ b/opcua-types/src/service_types/republish_request.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for RepublishRequest {
         opcua::types::ObjectId::RepublishRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RepublishRequest {
+impl opcua::types::BinaryEncodable for RepublishRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -52,17 +52,17 @@ impl opcua::types::BinaryEncoder for RepublishRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let retransmit_sequence_number = <u32 as opcua::types::BinaryEncoder>::decode(
+        let retransmit_sequence_number = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/republish_response.rs
+++ b/opcua-types/src/service_types/republish_response.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for RepublishResponse {
         opcua::types::ObjectId::RepublishResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RepublishResponse {
+impl opcua::types::BinaryEncodable for RepublishResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -49,12 +49,12 @@ impl opcua::types::BinaryEncoder for RepublishResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
-        let notification_message = <super::notification_message::NotificationMessage as opcua::types::BinaryEncoder>::decode(
+        let notification_message = <super::notification_message::NotificationMessage as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/role_permission_type.rs
+++ b/opcua-types/src/service_types/role_permission_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for RolePermissionType {
         opcua::types::ObjectId::RolePermissionType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for RolePermissionType {
+impl opcua::types::BinaryEncodable for RolePermissionType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.role_id.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for RolePermissionType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let role_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let role_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let permissions = <super::enums::PermissionType as opcua::types::BinaryEncoder>::decode(
+        let permissions = <super::enums::PermissionType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/sampling_interval_diagnostics_data_type.rs
+++ b/opcua-types/src/service_types/sampling_interval_diagnostics_data_type.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for SamplingIntervalDiagnosticsDataType {
         opcua::types::ObjectId::SamplingIntervalDiagnosticsDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SamplingIntervalDiagnosticsDataType {
+impl opcua::types::BinaryEncodable for SamplingIntervalDiagnosticsDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.sampling_interval.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for SamplingIntervalDiagnosticsDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let sampling_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let sampling_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let monitored_item_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let monitored_item_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let max_monitored_item_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_monitored_item_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let disabled_monitored_item_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let disabled_monitored_item_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/semantic_change_structure_data_type.rs
+++ b/opcua-types/src/service_types/semantic_change_structure_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for SemanticChangeStructureDataType {
         opcua::types::ObjectId::SemanticChangeStructureDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SemanticChangeStructureDataType {
+impl opcua::types::BinaryEncodable for SemanticChangeStructureDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.affected.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for SemanticChangeStructureDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let affected = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let affected = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let affected_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let affected_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/server_diagnostics_summary_data_type.rs
+++ b/opcua-types/src/service_types/server_diagnostics_summary_data_type.rs
@@ -37,7 +37,7 @@ impl opcua::types::MessageInfo for ServerDiagnosticsSummaryDataType {
         opcua::types::ObjectId::ServerDiagnosticsSummaryDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ServerDiagnosticsSummaryDataType {
+impl opcua::types::BinaryEncodable for ServerDiagnosticsSummaryDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.server_view_count.byte_len();
@@ -79,51 +79,51 @@ impl opcua::types::BinaryEncoder for ServerDiagnosticsSummaryDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let server_view_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let server_view_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let current_session_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let current_session_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let cumulated_session_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let cumulated_session_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_rejected_session_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let security_rejected_session_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let rejected_session_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let rejected_session_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let session_timeout_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let session_timeout_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let session_abort_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let session_abort_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let current_subscription_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let current_subscription_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let cumulated_subscription_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let cumulated_subscription_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let publishing_interval_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let publishing_interval_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_rejected_requests_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let security_rejected_requests_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let rejected_requests_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let rejected_requests_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/server_on_network.rs
+++ b/opcua-types/src/service_types/server_on_network.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for ServerOnNetwork {
         opcua::types::ObjectId::ServerOnNetwork_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ServerOnNetwork {
+impl opcua::types::BinaryEncodable for ServerOnNetwork {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.record_id.byte_len();
@@ -55,21 +55,21 @@ impl opcua::types::BinaryEncoder for ServerOnNetwork {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let record_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let record_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let server_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let server_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let discovery_url = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let discovery_url = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let server_capabilities = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             record_id,
             server_name,

--- a/opcua-types/src/service_types/server_status_data_type.rs
+++ b/opcua-types/src/service_types/server_status_data_type.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for ServerStatusDataType {
         opcua::types::ObjectId::ServerStatusDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ServerStatusDataType {
+impl opcua::types::BinaryEncodable for ServerStatusDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.start_time.byte_len();
@@ -60,27 +60,27 @@ impl opcua::types::BinaryEncoder for ServerStatusDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let start_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let current_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let current_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let state = <super::enums::ServerState as opcua::types::BinaryEncoder>::decode(
+        let state = <super::enums::ServerState as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let build_info = <super::build_info::BuildInfo as opcua::types::BinaryEncoder>::decode(
+        let build_info = <super::build_info::BuildInfo as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let seconds_till_shutdown = <u32 as opcua::types::BinaryEncoder>::decode(
+        let seconds_till_shutdown = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let shutdown_reason = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let shutdown_reason = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/service_counter_data_type.rs
+++ b/opcua-types/src/service_types/service_counter_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for ServiceCounterDataType {
         opcua::types::ObjectId::ServiceCounterDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ServiceCounterDataType {
+impl opcua::types::BinaryEncodable for ServiceCounterDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.total_count.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for ServiceCounterDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let total_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let total_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let error_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let error_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/service_fault.rs
+++ b/opcua-types/src/service_types/service_fault.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for ServiceFault {
         opcua::types::ObjectId::ServiceFault_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ServiceFault {
+impl opcua::types::BinaryEncodable for ServiceFault {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for ServiceFault {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/session_diagnostics_data_type.rs
+++ b/opcua-types/src/service_types/session_diagnostics_data_type.rs
@@ -67,7 +67,7 @@ impl opcua::types::MessageInfo for SessionDiagnosticsDataType {
         opcua::types::ObjectId::SessionDiagnosticsDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SessionDiagnosticsDataType {
+impl opcua::types::BinaryEncodable for SessionDiagnosticsDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.session_id.byte_len();
@@ -171,174 +171,174 @@ impl opcua::types::BinaryEncoder for SessionDiagnosticsDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let session_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let session_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let client_description = <super::application_description::ApplicationDescription as opcua::types::BinaryEncoder>::decode(
+        let client_description = <super::application_description::ApplicationDescription as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let server_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let locale_ids = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let actual_session_timeout = <f64 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let actual_session_timeout = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let max_response_message_size = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_response_message_size = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let client_connection_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let client_connection_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let client_last_contact_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let client_last_contact_time = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let current_subscriptions_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let current_subscriptions_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let current_monitored_items_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let current_monitored_items_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let current_publish_requests_in_queue = <u32 as opcua::types::BinaryEncoder>::decode(
+        let current_publish_requests_in_queue = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let total_request_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let total_request_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let unauthorized_request_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let unauthorized_request_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let read_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let read_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let history_read_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let history_read_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let write_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let history_update_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let history_update_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let call_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let call_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let create_monitored_items_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let create_monitored_items_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let modify_monitored_items_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let modify_monitored_items_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let set_monitoring_mode_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let set_monitoring_mode_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let set_triggering_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let set_triggering_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let delete_monitored_items_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let delete_monitored_items_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let create_subscription_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let create_subscription_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let modify_subscription_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let modify_subscription_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let set_publishing_mode_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let set_publishing_mode_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let publish_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let publish_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let republish_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let republish_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let transfer_subscriptions_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let transfer_subscriptions_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let delete_subscriptions_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let delete_subscriptions_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let add_nodes_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let add_nodes_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let add_references_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let add_references_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let delete_nodes_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let delete_nodes_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let delete_references_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let delete_references_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let browse_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let browse_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let browse_next_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let browse_next_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let translate_browse_paths_to_node_ids_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let translate_browse_paths_to_node_ids_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let query_first_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let query_first_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let query_next_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let query_next_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let register_nodes_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let register_nodes_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let unregister_nodes_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncoder>::decode(
+        let unregister_nodes_count = <super::service_counter_data_type::ServiceCounterDataType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/session_security_diagnostics_data_type.rs
+++ b/opcua-types/src/service_types/session_security_diagnostics_data_type.rs
@@ -33,7 +33,7 @@ impl opcua::types::MessageInfo for SessionSecurityDiagnosticsDataType {
         opcua::types::ObjectId::SessionSecurityDiagnosticsDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SessionSecurityDiagnosticsDataType {
+impl opcua::types::BinaryEncodable for SessionSecurityDiagnosticsDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.session_id.byte_len();
@@ -69,38 +69,38 @@ impl opcua::types::BinaryEncoder for SessionSecurityDiagnosticsDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let client_user_id_of_session = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let client_user_id_of_session = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let client_user_id_history = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let authentication_mechanism = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let authentication_mechanism = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let encoding = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let encoding = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let transport_protocol = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let transport_protocol = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncoder>::decode(
+        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_policy_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let security_policy_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let client_certificate = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let client_certificate = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/sessionless_invoke_request_type.rs
+++ b/opcua-types/src/service_types/sessionless_invoke_request_type.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for SessionlessInvokeRequestType {
         opcua::types::ObjectId::SessionlessInvokeRequestType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SessionlessInvokeRequestType {
+impl opcua::types::BinaryEncodable for SessionlessInvokeRequestType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.uris_version.byte_len();
@@ -58,20 +58,20 @@ impl opcua::types::BinaryEncoder for SessionlessInvokeRequestType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let uris_version = <u32 as opcua::types::BinaryEncoder>::decode(
+        let uris_version = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let namespace_uris = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let server_uris = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let locale_ids = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let service_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let service_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/sessionless_invoke_response_type.rs
+++ b/opcua-types/src/service_types/sessionless_invoke_response_type.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for SessionlessInvokeResponseType {
         opcua::types::ObjectId::SessionlessInvokeResponseType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SessionlessInvokeResponseType {
+impl opcua::types::BinaryEncodable for SessionlessInvokeResponseType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.namespace_uris.byte_len();
@@ -54,11 +54,11 @@ impl opcua::types::BinaryEncoder for SessionlessInvokeResponseType {
     ) -> opcua::types::EncodingResult<Self> {
         let namespace_uris = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let server_uris = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let service_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let service_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/set_monitoring_mode_request.rs
+++ b/opcua-types/src/service_types/set_monitoring_mode_request.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for SetMonitoringModeRequest {
         opcua::types::ObjectId::SetMonitoringModeRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SetMonitoringModeRequest {
+impl opcua::types::BinaryEncodable for SetMonitoringModeRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -54,24 +54,24 @@ impl opcua::types::BinaryEncoder for SetMonitoringModeRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let monitoring_mode = <super::enums::MonitoringMode as opcua::types::BinaryEncoder>::decode(
+        let monitoring_mode = <super::enums::MonitoringMode as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let monitored_item_ids = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/set_monitoring_mode_response.rs
+++ b/opcua-types/src/service_types/set_monitoring_mode_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for SetMonitoringModeResponse {
         opcua::types::ObjectId::SetMonitoringModeResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SetMonitoringModeResponse {
+impl opcua::types::BinaryEncodable for SetMonitoringModeResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for SetMonitoringModeResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/set_publishing_mode_request.rs
+++ b/opcua-types/src/service_types/set_publishing_mode_request.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for SetPublishingModeRequest {
         opcua::types::ObjectId::SetPublishingModeRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SetPublishingModeRequest {
+impl opcua::types::BinaryEncodable for SetPublishingModeRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -52,19 +52,19 @@ impl opcua::types::BinaryEncoder for SetPublishingModeRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let publishing_enabled = <bool as opcua::types::BinaryEncoder>::decode(
+        let publishing_enabled = <bool as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let subscription_ids = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/set_publishing_mode_response.rs
+++ b/opcua-types/src/service_types/set_publishing_mode_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for SetPublishingModeResponse {
         opcua::types::ObjectId::SetPublishingModeResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SetPublishingModeResponse {
+impl opcua::types::BinaryEncodable for SetPublishingModeResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for SetPublishingModeResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/set_triggering_request.rs
+++ b/opcua-types/src/service_types/set_triggering_request.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for SetTriggeringRequest {
         opcua::types::ObjectId::SetTriggeringRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SetTriggeringRequest {
+impl opcua::types::BinaryEncodable for SetTriggeringRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -58,28 +58,28 @@ impl opcua::types::BinaryEncoder for SetTriggeringRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let triggering_item_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let triggering_item_id = <u32 as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let links_to_add = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let links_to_remove = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/set_triggering_response.rs
+++ b/opcua-types/src/service_types/set_triggering_response.rs
@@ -32,7 +32,7 @@ impl opcua::types::MessageInfo for SetTriggeringResponse {
         opcua::types::ObjectId::SetTriggeringResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SetTriggeringResponse {
+impl opcua::types::BinaryEncodable for SetTriggeringResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -60,26 +60,26 @@ impl opcua::types::BinaryEncoder for SetTriggeringResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let add_results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let add_diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let remove_results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let remove_diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/signature_data.rs
+++ b/opcua-types/src/service_types/signature_data.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for SignatureData {
         opcua::types::ObjectId::SignatureData_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SignatureData {
+impl opcua::types::BinaryEncodable for SignatureData {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.algorithm.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for SignatureData {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let algorithm = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let algorithm = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let signature = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let signature = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/signed_software_certificate.rs
+++ b/opcua-types/src/service_types/signed_software_certificate.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for SignedSoftwareCertificate {
         opcua::types::ObjectId::SignedSoftwareCertificate_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SignedSoftwareCertificate {
+impl opcua::types::BinaryEncodable for SignedSoftwareCertificate {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.certificate_data.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for SignedSoftwareCertificate {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let certificate_data = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let certificate_data = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let signature = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let signature = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/simple_attribute_operand.rs
+++ b/opcua-types/src/service_types/simple_attribute_operand.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for SimpleAttributeOperand {
         opcua::types::ObjectId::SimpleAttributeOperand_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SimpleAttributeOperand {
+impl opcua::types::BinaryEncodable for SimpleAttributeOperand {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.type_definition_id.byte_len();
@@ -55,18 +55,18 @@ impl opcua::types::BinaryEncoder for SimpleAttributeOperand {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let type_definition_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let type_definition_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let browse_path = <Option<
             Vec<opcua::types::qualified_name::QualifiedName>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let attribute_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let attribute_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/simple_type_description.rs
+++ b/opcua-types/src/service_types/simple_type_description.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for SimpleTypeDescription {
         opcua::types::ObjectId::SimpleTypeDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SimpleTypeDescription {
+impl opcua::types::BinaryEncodable for SimpleTypeDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.data_type_id.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for SimpleTypeDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let data_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let data_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let base_data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let base_data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let built_in_type = <u8 as opcua::types::BinaryEncoder>::decode(
+        let built_in_type = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/status_change_notification.rs
+++ b/opcua-types/src/service_types/status_change_notification.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for StatusChangeNotification {
         opcua::types::ObjectId::StatusChangeNotification_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for StatusChangeNotification {
+impl opcua::types::BinaryEncodable for StatusChangeNotification {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for StatusChangeNotification {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let diagnostic_info = <opcua::types::diagnostic_info::DiagnosticInfo as opcua::types::BinaryEncoder>::decode(
+        let diagnostic_info = <opcua::types::diagnostic_info::DiagnosticInfo as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/status_result.rs
+++ b/opcua-types/src/service_types/status_result.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for StatusResult {
         opcua::types::ObjectId::StatusResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for StatusResult {
+impl opcua::types::BinaryEncodable for StatusResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for StatusResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let diagnostic_info = <opcua::types::diagnostic_info::DiagnosticInfo as opcua::types::BinaryEncoder>::decode(
+        let diagnostic_info = <opcua::types::diagnostic_info::DiagnosticInfo as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/structure_definition.rs
+++ b/opcua-types/src/service_types/structure_definition.rs
@@ -17,7 +17,7 @@ pub struct StructureDefinition {
     pub structure_type: super::enums::StructureType,
     pub fields: Option<Vec<super::structure_field::StructureField>>,
 }
-impl opcua::types::BinaryEncoder for StructureDefinition {
+impl opcua::types::BinaryEncodable for StructureDefinition {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.default_encoding_id.byte_len();
@@ -43,21 +43,21 @@ impl opcua::types::BinaryEncoder for StructureDefinition {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let default_encoding_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let default_encoding_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let base_data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let base_data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let structure_type = <super::enums::StructureType as opcua::types::BinaryEncoder>::decode(
+        let structure_type = <super::enums::StructureType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let fields = <Option<
             Vec<super::structure_field::StructureField>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             default_encoding_id,
             base_data_type,

--- a/opcua-types/src/service_types/structure_description.rs
+++ b/opcua-types/src/service_types/structure_description.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for StructureDescription {
         opcua::types::ObjectId::StructureDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for StructureDescription {
+impl opcua::types::BinaryEncodable for StructureDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.data_type_id.byte_len();
@@ -51,15 +51,15 @@ impl opcua::types::BinaryEncoder for StructureDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let data_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let data_type_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::qualified_name::QualifiedName as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let structure_definition = <super::structure_definition::StructureDefinition as opcua::types::BinaryEncoder>::decode(
+        let structure_definition = <super::structure_definition::StructureDefinition as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/structure_field.rs
+++ b/opcua-types/src/service_types/structure_field.rs
@@ -32,7 +32,7 @@ impl opcua::types::MessageInfo for StructureField {
         opcua::types::ObjectId::StructureField_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for StructureField {
+impl opcua::types::BinaryEncodable for StructureField {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.name.byte_len();
@@ -64,30 +64,30 @@ impl opcua::types::BinaryEncoder for StructureField {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value_rank = <i32 as opcua::types::BinaryEncoder>::decode(
+        let value_rank = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let array_dimensions = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let max_string_length = <u32 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let max_string_length = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let is_optional = <bool as opcua::types::BinaryEncoder>::decode(
+        let is_optional = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/subscribed_data_set_data_type.rs
+++ b/opcua-types/src/service_types/subscribed_data_set_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for SubscribedDataSetDataType {
         opcua::types::ObjectId::SubscribedDataSetDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SubscribedDataSetDataType {
+impl opcua::types::BinaryEncodable for SubscribedDataSetDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/subscribed_data_set_mirror_data_type.rs
+++ b/opcua-types/src/service_types/subscribed_data_set_mirror_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for SubscribedDataSetMirrorDataType {
         opcua::types::ObjectId::SubscribedDataSetMirrorDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SubscribedDataSetMirrorDataType {
+impl opcua::types::BinaryEncodable for SubscribedDataSetMirrorDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.parent_node_name.byte_len();
@@ -49,13 +49,13 @@ impl opcua::types::BinaryEncoder for SubscribedDataSetMirrorDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let parent_node_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let parent_node_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let role_permissions = <Option<
             Vec<super::role_permission_type::RolePermissionType>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             parent_node_name,
             role_permissions,

--- a/opcua-types/src/service_types/subscription_acknowledgement.rs
+++ b/opcua-types/src/service_types/subscription_acknowledgement.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for SubscriptionAcknowledgement {
         opcua::types::ObjectId::SubscriptionAcknowledgement_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SubscriptionAcknowledgement {
+impl opcua::types::BinaryEncodable for SubscriptionAcknowledgement {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.subscription_id.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for SubscriptionAcknowledgement {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let sequence_number = <u32 as opcua::types::BinaryEncoder>::decode(
+        let sequence_number = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/subscription_diagnostics_data_type.rs
+++ b/opcua-types/src/service_types/subscription_diagnostics_data_type.rs
@@ -56,7 +56,7 @@ impl opcua::types::MessageInfo for SubscriptionDiagnosticsDataType {
         opcua::types::ObjectId::SubscriptionDiagnosticsDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for SubscriptionDiagnosticsDataType {
+impl opcua::types::BinaryEncodable for SubscriptionDiagnosticsDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.session_id.byte_len();
@@ -136,127 +136,127 @@ impl opcua::types::BinaryEncoder for SubscriptionDiagnosticsDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let session_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let subscription_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let subscription_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let priority = <u8 as opcua::types::BinaryEncoder>::decode(
+        let priority = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let publishing_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let publishing_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let max_keep_alive_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_keep_alive_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let max_lifetime_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_lifetime_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let max_notifications_per_publish = <u32 as opcua::types::BinaryEncoder>::decode(
+        let max_notifications_per_publish = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let publishing_enabled = <bool as opcua::types::BinaryEncoder>::decode(
+        let publishing_enabled = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let modify_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let modify_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let enable_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let enable_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let disable_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let disable_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let republish_request_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let republish_request_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let republish_message_request_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let republish_message_request_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let republish_message_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let republish_message_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let transfer_request_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let transfer_request_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let transferred_to_alt_client_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let transferred_to_alt_client_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let transferred_to_same_client_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let transferred_to_same_client_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let publish_request_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let publish_request_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_change_notifications_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let data_change_notifications_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let event_notifications_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let event_notifications_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let notifications_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let notifications_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let late_publish_request_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let late_publish_request_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let current_keep_alive_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let current_keep_alive_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let current_lifetime_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let current_lifetime_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let unacknowledged_message_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let unacknowledged_message_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let discarded_message_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let discarded_message_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let monitored_item_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let monitored_item_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let disabled_monitored_item_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let disabled_monitored_item_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let monitoring_queue_overflow_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let monitoring_queue_overflow_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let next_sequence_number = <u32 as opcua::types::BinaryEncoder>::decode(
+        let next_sequence_number = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let event_queue_over_flow_count = <u32 as opcua::types::BinaryEncoder>::decode(
+        let event_queue_over_flow_count = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/target_variables_data_type.rs
+++ b/opcua-types/src/service_types/target_variables_data_type.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for TargetVariablesDataType {
         opcua::types::ObjectId::TargetVariablesDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for TargetVariablesDataType {
+impl opcua::types::BinaryEncodable for TargetVariablesDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.target_variables.byte_len();
@@ -50,7 +50,7 @@ impl opcua::types::BinaryEncoder for TargetVariablesDataType {
     ) -> opcua::types::EncodingResult<Self> {
         let target_variables = <Option<
             Vec<super::field_target_data_type::FieldTargetDataType>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { target_variables })
     }
 }

--- a/opcua-types/src/service_types/three_d_cartesian_coordinates.rs
+++ b/opcua-types/src/service_types/three_d_cartesian_coordinates.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for ThreeDCartesianCoordinates {
         opcua::types::ObjectId::ThreeDCartesianCoordinates_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ThreeDCartesianCoordinates {
+impl opcua::types::BinaryEncodable for ThreeDCartesianCoordinates {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.x.byte_len();
@@ -52,9 +52,9 @@ impl opcua::types::BinaryEncoder for ThreeDCartesianCoordinates {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let x = <f64 as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let y = <f64 as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let z = <f64 as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        let x = <f64 as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let y = <f64 as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let z = <f64 as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { x, y, z })
     }
 }

--- a/opcua-types/src/service_types/three_d_frame.rs
+++ b/opcua-types/src/service_types/three_d_frame.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for ThreeDFrame {
         opcua::types::ObjectId::ThreeDFrame_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ThreeDFrame {
+impl opcua::types::BinaryEncodable for ThreeDFrame {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.cartesian_coordinates.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for ThreeDFrame {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let cartesian_coordinates = <super::three_d_cartesian_coordinates::ThreeDCartesianCoordinates as opcua::types::BinaryEncoder>::decode(
+        let cartesian_coordinates = <super::three_d_cartesian_coordinates::ThreeDCartesianCoordinates as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let orientation = <super::three_d_orientation::ThreeDOrientation as opcua::types::BinaryEncoder>::decode(
+        let orientation = <super::three_d_orientation::ThreeDOrientation as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/three_d_orientation.rs
+++ b/opcua-types/src/service_types/three_d_orientation.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for ThreeDOrientation {
         opcua::types::ObjectId::ThreeDOrientation_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ThreeDOrientation {
+impl opcua::types::BinaryEncodable for ThreeDOrientation {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.a.byte_len();
@@ -52,9 +52,9 @@ impl opcua::types::BinaryEncoder for ThreeDOrientation {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let a = <f64 as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let b = <f64 as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let c = <f64 as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        let a = <f64 as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let b = <f64 as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let c = <f64 as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { a, b, c })
     }
 }

--- a/opcua-types/src/service_types/three_d_vector.rs
+++ b/opcua-types/src/service_types/three_d_vector.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for ThreeDVector {
         opcua::types::ObjectId::ThreeDVector_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ThreeDVector {
+impl opcua::types::BinaryEncodable for ThreeDVector {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.x.byte_len();
@@ -52,9 +52,9 @@ impl opcua::types::BinaryEncoder for ThreeDVector {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let x = <f64 as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let y = <f64 as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let z = <f64 as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        let x = <f64 as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let y = <f64 as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let z = <f64 as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self { x, y, z })
     }
 }

--- a/opcua-types/src/service_types/time_zone_data_type.rs
+++ b/opcua-types/src/service_types/time_zone_data_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for TimeZoneDataType {
         opcua::types::ObjectId::TimeZoneDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for TimeZoneDataType {
+impl opcua::types::BinaryEncodable for TimeZoneDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.offset.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for TimeZoneDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let offset = <i16 as opcua::types::BinaryEncoder>::decode(
+        let offset = <i16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let daylight_saving_in_offset = <bool as opcua::types::BinaryEncoder>::decode(
+        let daylight_saving_in_offset = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/transfer_result.rs
+++ b/opcua-types/src/service_types/transfer_result.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for TransferResult {
         opcua::types::ObjectId::TransferResult_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for TransferResult {
+impl opcua::types::BinaryEncodable for TransferResult {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.status_code.byte_len();
@@ -49,13 +49,13 @@ impl opcua::types::BinaryEncoder for TransferResult {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncoder>::decode(
+        let status_code = <opcua::types::status_code::StatusCode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let available_sequence_numbers = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             status_code,
             available_sequence_numbers,

--- a/opcua-types/src/service_types/transfer_subscriptions_request.rs
+++ b/opcua-types/src/service_types/transfer_subscriptions_request.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for TransferSubscriptionsRequest {
         opcua::types::ObjectId::TransferSubscriptionsRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for TransferSubscriptionsRequest {
+impl opcua::types::BinaryEncodable for TransferSubscriptionsRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -52,16 +52,16 @@ impl opcua::types::BinaryEncoder for TransferSubscriptionsRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let subscription_ids = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
-        let send_initial_values = <bool as opcua::types::BinaryEncoder>::decode(
+        let send_initial_values = <bool as opcua::types::BinaryEncodable>::decode(
                 stream,
                 decoding_options,
             )

--- a/opcua-types/src/service_types/transfer_subscriptions_response.rs
+++ b/opcua-types/src/service_types/transfer_subscriptions_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for TransferSubscriptionsResponse {
         opcua::types::ObjectId::TransferSubscriptionsResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for TransferSubscriptionsResponse {
+impl opcua::types::BinaryEncodable for TransferSubscriptionsResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for TransferSubscriptionsResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<super::transfer_result::TransferResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/translate_browse_paths_to_node_ids_request.rs
+++ b/opcua-types/src/service_types/translate_browse_paths_to_node_ids_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for TranslateBrowsePathsToNodeIdsRequest {
         opcua::types::ObjectId::TranslateBrowsePathsToNodeIdsRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for TranslateBrowsePathsToNodeIdsRequest {
+impl opcua::types::BinaryEncodable for TranslateBrowsePathsToNodeIdsRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for TranslateBrowsePathsToNodeIdsRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let browse_paths = <Option<
             Vec<super::browse_path::BrowsePath>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/translate_browse_paths_to_node_ids_response.rs
+++ b/opcua-types/src/service_types/translate_browse_paths_to_node_ids_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for TranslateBrowsePathsToNodeIdsResponse {
         opcua::types::ObjectId::TranslateBrowsePathsToNodeIdsResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for TranslateBrowsePathsToNodeIdsResponse {
+impl opcua::types::BinaryEncodable for TranslateBrowsePathsToNodeIdsResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for TranslateBrowsePathsToNodeIdsResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<super::browse_path_result::BrowsePathResult>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/trust_list_data_type.rs
+++ b/opcua-types/src/service_types/trust_list_data_type.rs
@@ -30,7 +30,7 @@ impl opcua::types::MessageInfo for TrustListDataType {
         opcua::types::ObjectId::TrustListDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for TrustListDataType {
+impl opcua::types::BinaryEncodable for TrustListDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_lists.byte_len();
@@ -58,22 +58,22 @@ impl opcua::types::BinaryEncoder for TrustListDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_lists = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_lists = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let trusted_certificates = <Option<
             Vec<opcua::types::byte_string::ByteString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let trusted_crls = <Option<
             Vec<opcua::types::byte_string::ByteString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let issuer_certificates = <Option<
             Vec<opcua::types::byte_string::ByteString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let issuer_crls = <Option<
             Vec<opcua::types::byte_string::ByteString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             specified_lists,
             trusted_certificates,

--- a/opcua-types/src/service_types/ua_binary_file_data_type.rs
+++ b/opcua-types/src/service_types/ua_binary_file_data_type.rs
@@ -36,7 +36,7 @@ impl opcua::types::MessageInfo for UABinaryFileDataType {
         opcua::types::ObjectId::UABinaryFileDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UABinaryFileDataType {
+impl opcua::types::BinaryEncodable for UABinaryFileDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.namespaces.byte_len();
@@ -70,24 +70,24 @@ impl opcua::types::BinaryEncoder for UABinaryFileDataType {
     ) -> opcua::types::EncodingResult<Self> {
         let namespaces = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let structure_data_types = <Option<
             Vec<super::structure_description::StructureDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let enum_data_types = <Option<
             Vec<super::enum_description::EnumDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         let simple_data_types = <Option<
             Vec<super::simple_type_description::SimpleTypeDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let schema_location = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let schema_location = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let file_header = <Option<
             Vec<super::key_value_pair::KeyValuePair>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let body = <opcua::types::variant::Variant as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let body = <opcua::types::variant::Variant as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/uadp_data_set_reader_message_data_type.rs
+++ b/opcua-types/src/service_types/uadp_data_set_reader_message_data_type.rs
@@ -34,7 +34,7 @@ impl opcua::types::MessageInfo for UadpDataSetReaderMessageDataType {
         opcua::types::ObjectId::UadpDataSetReaderMessageDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UadpDataSetReaderMessageDataType {
+impl opcua::types::BinaryEncodable for UadpDataSetReaderMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.group_version.byte_len();
@@ -70,39 +70,39 @@ impl opcua::types::BinaryEncoder for UadpDataSetReaderMessageDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let group_version = <u32 as opcua::types::BinaryEncoder>::decode(
+        let group_version = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let network_message_number = <u16 as opcua::types::BinaryEncoder>::decode(
+        let network_message_number = <u16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_offset = <u16 as opcua::types::BinaryEncoder>::decode(
+        let data_set_offset = <u16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_class_id = <opcua::types::guid::Guid as opcua::types::BinaryEncoder>::decode(
+        let data_set_class_id = <opcua::types::guid::Guid as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let network_message_content_mask = <super::enums::UadpNetworkMessageContentMask as opcua::types::BinaryEncoder>::decode(
+        let network_message_content_mask = <super::enums::UadpNetworkMessageContentMask as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_message_content_mask = <super::enums::UadpDataSetMessageContentMask as opcua::types::BinaryEncoder>::decode(
+        let data_set_message_content_mask = <super::enums::UadpDataSetMessageContentMask as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let publishing_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let publishing_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let receive_offset = <f64 as opcua::types::BinaryEncoder>::decode(
+        let receive_offset = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let processing_offset = <f64 as opcua::types::BinaryEncoder>::decode(
+        let processing_offset = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/uadp_data_set_writer_message_data_type.rs
+++ b/opcua-types/src/service_types/uadp_data_set_writer_message_data_type.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for UadpDataSetWriterMessageDataType {
         opcua::types::ObjectId::UadpDataSetWriterMessageDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UadpDataSetWriterMessageDataType {
+impl opcua::types::BinaryEncodable for UadpDataSetWriterMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.data_set_message_content_mask.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for UadpDataSetWriterMessageDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let data_set_message_content_mask = <super::enums::UadpDataSetMessageContentMask as opcua::types::BinaryEncoder>::decode(
+        let data_set_message_content_mask = <super::enums::UadpDataSetMessageContentMask as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let configured_size = <u16 as opcua::types::BinaryEncoder>::decode(
+        let configured_size = <u16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let network_message_number = <u16 as opcua::types::BinaryEncoder>::decode(
+        let network_message_number = <u16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_offset = <u16 as opcua::types::BinaryEncoder>::decode(
+        let data_set_offset = <u16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/uadp_writer_group_message_data_type.rs
+++ b/opcua-types/src/service_types/uadp_writer_group_message_data_type.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for UadpWriterGroupMessageDataType {
         opcua::types::ObjectId::UadpWriterGroupMessageDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UadpWriterGroupMessageDataType {
+impl opcua::types::BinaryEncodable for UadpWriterGroupMessageDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.group_version.byte_len();
@@ -57,25 +57,25 @@ impl opcua::types::BinaryEncoder for UadpWriterGroupMessageDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let group_version = <u32 as opcua::types::BinaryEncoder>::decode(
+        let group_version = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_set_ordering = <super::enums::DataSetOrderingType as opcua::types::BinaryEncoder>::decode(
+        let data_set_ordering = <super::enums::DataSetOrderingType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let network_message_content_mask = <super::enums::UadpNetworkMessageContentMask as opcua::types::BinaryEncoder>::decode(
+        let network_message_content_mask = <super::enums::UadpNetworkMessageContentMask as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let sampling_offset = <f64 as opcua::types::BinaryEncoder>::decode(
+        let sampling_offset = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let publishing_offset = <Option<
             Vec<f64>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             group_version,
             data_set_ordering,

--- a/opcua-types/src/service_types/unregister_nodes_request.rs
+++ b/opcua-types/src/service_types/unregister_nodes_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for UnregisterNodesRequest {
         opcua::types::ObjectId::UnregisterNodesRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UnregisterNodesRequest {
+impl opcua::types::BinaryEncodable for UnregisterNodesRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for UnregisterNodesRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let nodes_to_unregister = <Option<
             Vec<opcua::types::node_id::NodeId>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/unregister_nodes_response.rs
+++ b/opcua-types/src/service_types/unregister_nodes_response.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for UnregisterNodesResponse {
         opcua::types::ObjectId::UnregisterNodesResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UnregisterNodesResponse {
+impl opcua::types::BinaryEncodable for UnregisterNodesResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for UnregisterNodesResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/update_data_details.rs
+++ b/opcua-types/src/service_types/update_data_details.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for UpdateDataDetails {
         opcua::types::ObjectId::UpdateDataDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UpdateDataDetails {
+impl opcua::types::BinaryEncodable for UpdateDataDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -51,17 +51,17 @@ impl opcua::types::BinaryEncoder for UpdateDataDetails {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let perform_insert_replace = <super::enums::PerformUpdateType as opcua::types::BinaryEncoder>::decode(
+        let perform_insert_replace = <super::enums::PerformUpdateType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let update_values = <Option<
             Vec<opcua::types::data_value::DataValue>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             node_id,
             perform_insert_replace,

--- a/opcua-types/src/service_types/update_event_details.rs
+++ b/opcua-types/src/service_types/update_event_details.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for UpdateEventDetails {
         opcua::types::ObjectId::UpdateEventDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UpdateEventDetails {
+impl opcua::types::BinaryEncodable for UpdateEventDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -54,21 +54,21 @@ impl opcua::types::BinaryEncoder for UpdateEventDetails {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let perform_insert_replace = <super::enums::PerformUpdateType as opcua::types::BinaryEncoder>::decode(
+        let perform_insert_replace = <super::enums::PerformUpdateType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let filter = <super::event_filter::EventFilter as opcua::types::BinaryEncoder>::decode(
+        let filter = <super::event_filter::EventFilter as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let event_data = <Option<
             Vec<super::history_event_field_list::HistoryEventFieldList>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             node_id,
             perform_insert_replace,

--- a/opcua-types/src/service_types/update_structure_data_details.rs
+++ b/opcua-types/src/service_types/update_structure_data_details.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for UpdateStructureDataDetails {
         opcua::types::ObjectId::UpdateStructureDataDetails_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UpdateStructureDataDetails {
+impl opcua::types::BinaryEncodable for UpdateStructureDataDetails {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -51,17 +51,17 @@ impl opcua::types::BinaryEncoder for UpdateStructureDataDetails {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let perform_insert_replace = <super::enums::PerformUpdateType as opcua::types::BinaryEncoder>::decode(
+        let perform_insert_replace = <super::enums::PerformUpdateType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let update_values = <Option<
             Vec<opcua::types::data_value::DataValue>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             node_id,
             perform_insert_replace,

--- a/opcua-types/src/service_types/user_identity_token.rs
+++ b/opcua-types/src/service_types/user_identity_token.rs
@@ -26,7 +26,7 @@ impl opcua::types::MessageInfo for UserIdentityToken {
         opcua::types::ObjectId::UserIdentityToken_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UserIdentityToken {
+impl opcua::types::BinaryEncodable for UserIdentityToken {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.policy_id.byte_len();
@@ -46,7 +46,7 @@ impl opcua::types::BinaryEncoder for UserIdentityToken {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/user_name_identity_token.rs
+++ b/opcua-types/src/service_types/user_name_identity_token.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for UserNameIdentityToken {
         opcua::types::ObjectId::UserNameIdentityToken_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UserNameIdentityToken {
+impl opcua::types::BinaryEncodable for UserNameIdentityToken {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.policy_id.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for UserNameIdentityToken {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let user_name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let password = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let password = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let encryption_algorithm = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let encryption_algorithm = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/user_token_policy.rs
+++ b/opcua-types/src/service_types/user_token_policy.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for UserTokenPolicy {
         opcua::types::ObjectId::UserTokenPolicy_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for UserTokenPolicy {
+impl opcua::types::BinaryEncodable for UserTokenPolicy {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.policy_id.byte_len();
@@ -57,23 +57,23 @@ impl opcua::types::BinaryEncoder for UserTokenPolicy {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let token_type = <super::enums::UserTokenType as opcua::types::BinaryEncoder>::decode(
+        let token_type = <super::enums::UserTokenType as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let issued_token_type = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let issued_token_type = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let issuer_endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let issuer_endpoint_url = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_policy_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let security_policy_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/variable_attributes.rs
+++ b/opcua-types/src/service_types/variable_attributes.rs
@@ -38,7 +38,7 @@ impl opcua::types::MessageInfo for VariableAttributes {
         opcua::types::ObjectId::VariableAttributes_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for VariableAttributes {
+impl opcua::types::BinaryEncodable for VariableAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_attributes.byte_len();
@@ -82,54 +82,54 @@ impl opcua::types::BinaryEncoder for VariableAttributes {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_attributes = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_attributes = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let user_write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value = <opcua::types::variant::Variant as opcua::types::BinaryEncoder>::decode(
+        let value = <opcua::types::variant::Variant as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value_rank = <i32 as opcua::types::BinaryEncoder>::decode(
+        let value_rank = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let array_dimensions = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let access_level = <u8 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let access_level = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_access_level = <u8 as opcua::types::BinaryEncoder>::decode(
+        let user_access_level = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let minimum_sampling_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let minimum_sampling_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let historizing = <bool as opcua::types::BinaryEncoder>::decode(
+        let historizing = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/variable_type_attributes.rs
+++ b/opcua-types/src/service_types/variable_type_attributes.rs
@@ -35,7 +35,7 @@ impl opcua::types::MessageInfo for VariableTypeAttributes {
         opcua::types::ObjectId::VariableTypeAttributes_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for VariableTypeAttributes {
+impl opcua::types::BinaryEncodable for VariableTypeAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_attributes.byte_len();
@@ -73,42 +73,42 @@ impl opcua::types::BinaryEncoder for VariableTypeAttributes {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_attributes = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_attributes = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let user_write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value = <opcua::types::variant::Variant as opcua::types::BinaryEncoder>::decode(
+        let value = <opcua::types::variant::Variant as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let data_type = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value_rank = <i32 as opcua::types::BinaryEncoder>::decode(
+        let value_rank = <i32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let array_dimensions = <Option<
             Vec<u32>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let is_abstract = <bool as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let is_abstract = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/vector.rs
+++ b/opcua-types/src/service_types/vector.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for Vector {
         opcua::types::ObjectId::Vector_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for Vector {
+impl opcua::types::BinaryEncodable for Vector {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/view_attributes.rs
+++ b/opcua-types/src/service_types/view_attributes.rs
@@ -32,7 +32,7 @@ impl opcua::types::MessageInfo for ViewAttributes {
         opcua::types::ObjectId::ViewAttributes_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ViewAttributes {
+impl opcua::types::BinaryEncodable for ViewAttributes {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.specified_attributes.byte_len();
@@ -64,31 +64,31 @@ impl opcua::types::BinaryEncoder for ViewAttributes {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let specified_attributes = <u32 as opcua::types::BinaryEncoder>::decode(
+        let specified_attributes = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let display_name = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncoder>::decode(
+        let description = <opcua::types::localized_text::LocalizedText as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let user_write_mask = <u32 as opcua::types::BinaryEncoder>::decode(
+        let user_write_mask = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let contains_no_loops = <bool as opcua::types::BinaryEncoder>::decode(
+        let contains_no_loops = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let event_notifier = <u8 as opcua::types::BinaryEncoder>::decode(
+        let event_notifier = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/view_description.rs
+++ b/opcua-types/src/service_types/view_description.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for ViewDescription {
         opcua::types::ObjectId::ViewDescription_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for ViewDescription {
+impl opcua::types::BinaryEncodable for ViewDescription {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.view_id.byte_len();
@@ -52,15 +52,15 @@ impl opcua::types::BinaryEncoder for ViewDescription {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let view_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let view_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let timestamp = <opcua::types::date_time::DateTime as opcua::types::BinaryEncoder>::decode(
+        let timestamp = <opcua::types::date_time::DateTime as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let view_version = <u32 as opcua::types::BinaryEncoder>::decode(
+        let view_version = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/write_request.rs
+++ b/opcua-types/src/service_types/write_request.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for WriteRequest {
         opcua::types::ObjectId::WriteRequest_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for WriteRequest {
+impl opcua::types::BinaryEncodable for WriteRequest {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.request_header.byte_len();
@@ -49,14 +49,14 @@ impl opcua::types::BinaryEncoder for WriteRequest {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncoder>::decode(
+        let request_header = <opcua::types::request_header::RequestHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = request_header.request_handle;
         let nodes_to_write = <Option<
             Vec<super::write_value::WriteValue>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             request_header,

--- a/opcua-types/src/service_types/write_response.rs
+++ b/opcua-types/src/service_types/write_response.rs
@@ -28,7 +28,7 @@ impl opcua::types::MessageInfo for WriteResponse {
         opcua::types::ObjectId::WriteResponse_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for WriteResponse {
+impl opcua::types::BinaryEncodable for WriteResponse {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.response_header.byte_len();
@@ -52,18 +52,18 @@ impl opcua::types::BinaryEncoder for WriteResponse {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncoder>::decode(
+        let response_header = <opcua::types::response_header::ResponseHeader as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let __request_handle = response_header.request_handle;
         let results = <Option<
             Vec<opcua::types::status_code::StatusCode>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         let diagnostic_infos = <Option<
             Vec<opcua::types::diagnostic_info::DiagnosticInfo>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)
             .map_err(|e| e.with_request_handle(__request_handle))?;
         Ok(Self {
             response_header,

--- a/opcua-types/src/service_types/write_value.rs
+++ b/opcua-types/src/service_types/write_value.rs
@@ -29,7 +29,7 @@ impl opcua::types::MessageInfo for WriteValue {
         opcua::types::ObjectId::WriteValue_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for WriteValue {
+impl opcua::types::BinaryEncodable for WriteValue {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.node_id.byte_len();
@@ -55,19 +55,19 @@ impl opcua::types::BinaryEncoder for WriteValue {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncoder>::decode(
+        let node_id = <opcua::types::node_id::NodeId as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let attribute_id = <u32 as opcua::types::BinaryEncoder>::decode(
+        let attribute_id = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let index_range = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let value = <opcua::types::data_value::DataValue as opcua::types::BinaryEncoder>::decode(
+        let value = <opcua::types::data_value::DataValue as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/writer_group_data_type.rs
+++ b/opcua-types/src/service_types/writer_group_data_type.rs
@@ -44,7 +44,7 @@ impl opcua::types::MessageInfo for WriterGroupDataType {
         opcua::types::ObjectId::WriterGroupDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for WriterGroupDataType {
+impl opcua::types::BinaryEncodable for WriterGroupDataType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.name.byte_len();
@@ -94,66 +94,66 @@ impl opcua::types::BinaryEncoder for WriterGroupDataType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let name = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let name = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let enabled = <bool as opcua::types::BinaryEncoder>::decode(
+        let enabled = <bool as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncoder>::decode(
+        let security_mode = <super::enums::MessageSecurityMode as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let security_group_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let security_group_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let security_key_services = <Option<
             Vec<super::endpoint_description::EndpointDescription>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let max_network_message_size = <u32 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let max_network_message_size = <u32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let group_properties = <Option<
             Vec<super::key_value_pair::KeyValuePair>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let writer_group_id = <u16 as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let writer_group_id = <u16 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let publishing_interval = <f64 as opcua::types::BinaryEncoder>::decode(
+        let publishing_interval = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let keep_alive_time = <f64 as opcua::types::BinaryEncoder>::decode(
+        let keep_alive_time = <f64 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let priority = <u8 as opcua::types::BinaryEncoder>::decode(
+        let priority = <u8 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let locale_ids = <Option<
             Vec<opcua::types::string::UAString>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let header_layout_uri = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let header_layout_uri = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let transport_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let transport_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let message_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncoder>::decode(
+        let message_settings = <opcua::types::extension_object::ExtensionObject as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
         let data_set_writers = <Option<
             Vec<super::data_set_writer_data_type::DataSetWriterDataType>,
-        > as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
+        > as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
         Ok(Self {
             name,
             enabled,

--- a/opcua-types/src/service_types/writer_group_message_data_type.rs
+++ b/opcua-types/src/service_types/writer_group_message_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for WriterGroupMessageDataType {
         opcua::types::ObjectId::WriterGroupMessageDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for WriterGroupMessageDataType {
+impl opcua::types::BinaryEncodable for WriterGroupMessageDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/writer_group_transport_data_type.rs
+++ b/opcua-types/src/service_types/writer_group_transport_data_type.rs
@@ -24,7 +24,7 @@ impl opcua::types::MessageInfo for WriterGroupTransportDataType {
         opcua::types::ObjectId::WriterGroupTransportDataType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for WriterGroupTransportDataType {
+impl opcua::types::BinaryEncodable for WriterGroupTransportDataType {
     fn byte_len(&self) -> usize {
         0usize
     }

--- a/opcua-types/src/service_types/x_509_identity_token.rs
+++ b/opcua-types/src/service_types/x_509_identity_token.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for X509IdentityToken {
         opcua::types::ObjectId::X509IdentityToken_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for X509IdentityToken {
+impl opcua::types::BinaryEncodable for X509IdentityToken {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.policy_id.byte_len();
@@ -49,11 +49,11 @@ impl opcua::types::BinaryEncoder for X509IdentityToken {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncoder>::decode(
+        let policy_id = <opcua::types::string::UAString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;
-        let certificate_data = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncoder>::decode(
+        let certificate_data = <opcua::types::byte_string::ByteString as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/service_types/xv_type.rs
+++ b/opcua-types/src/service_types/xv_type.rs
@@ -27,7 +27,7 @@ impl opcua::types::MessageInfo for XVType {
         opcua::types::ObjectId::XVType_Encoding_DefaultXml
     }
 }
-impl opcua::types::BinaryEncoder for XVType {
+impl opcua::types::BinaryEncodable for XVType {
     fn byte_len(&self) -> usize {
         let mut size = 0usize;
         size += self.x.byte_len();
@@ -49,8 +49,8 @@ impl opcua::types::BinaryEncoder for XVType {
         stream: &mut S,
         decoding_options: &opcua::types::DecodingOptions,
     ) -> opcua::types::EncodingResult<Self> {
-        let x = <f64 as opcua::types::BinaryEncoder>::decode(stream, decoding_options)?;
-        let value = <f32 as opcua::types::BinaryEncoder>::decode(
+        let x = <f64 as opcua::types::BinaryEncodable>::decode(stream, decoding_options)?;
+        let value = <f32 as opcua::types::BinaryEncodable>::decode(
             stream,
             decoding_options,
         )?;

--- a/opcua-types/src/status_code.rs
+++ b/opcua-types/src/status_code.rs
@@ -4,7 +4,7 @@ use std::{
     io::{Read, Write},
 };
 
-use super::encoding::{read_u32, write_u32, BinaryEncoder, DecodingOptions, EncodingResult};
+use super::encoding::{read_u32, write_u32, BinaryEncodable, DecodingOptions, EncodingResult};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Default)]
 /// Wrapper around an OPC-UA status code, with utilities for displaying,
@@ -251,7 +251,7 @@ impl std::fmt::Debug for StatusCode {
     }
 }
 
-impl BinaryEncoder for StatusCode {
+impl BinaryEncodable for StatusCode {
     fn byte_len(&self) -> usize {
         4
     }

--- a/opcua-types/src/string.rs
+++ b/opcua-types/src/string.rs
@@ -13,7 +13,7 @@ use log::{error, trace};
 
 use crate::{
     encoding::{
-        process_decode_io_result, process_encode_io_result, write_i32, BinaryEncoder,
+        process_decode_io_result, process_encode_io_result, write_i32, BinaryEncodable,
         DecodingOptions, EncodingResult,
     },
     status_code::StatusCode,
@@ -100,7 +100,7 @@ mod json {
     }
 }
 
-impl BinaryEncoder for UAString {
+impl BinaryEncodable for UAString {
     fn byte_len(&self) -> usize {
         // Length plus the actual string length in bytes for a non-null string.
         4 + if self.value.is_none() {

--- a/opcua-types/src/tests/mod.rs
+++ b/opcua-types/src/tests/mod.rs
@@ -15,14 +15,14 @@ use crate::{argument::Argument, status_code::StatusCode, *};
 
 pub fn serialize_test_and_return<T>(value: T) -> T
 where
-    T: BinaryEncoder + Debug + PartialEq + Clone,
+    T: BinaryEncodable + Debug + PartialEq + Clone,
 {
     serialize_test_and_return_expected(value.clone(), value)
 }
 
 pub fn serialize_as_stream<T>(value: T) -> Cursor<Vec<u8>>
 where
-    T: BinaryEncoder + Debug,
+    T: BinaryEncodable + Debug,
 {
     // Ask the struct for its byte length
     let byte_len = value.byte_len();
@@ -48,7 +48,7 @@ where
 
 pub fn serialize_test_and_return_expected<T>(value: T, expected_value: T) -> T
 where
-    T: BinaryEncoder + Debug + PartialEq,
+    T: BinaryEncodable + Debug + PartialEq,
 {
     let mut stream = serialize_as_stream(value);
 
@@ -61,21 +61,21 @@ where
 
 pub fn serialize_test<T>(value: T)
 where
-    T: BinaryEncoder + Debug + PartialEq + Clone,
+    T: BinaryEncodable + Debug + PartialEq + Clone,
 {
     let _ = serialize_test_and_return(value);
 }
 
 pub fn serialize_test_expected<T>(value: T, expected_value: T)
 where
-    T: BinaryEncoder + Debug + PartialEq,
+    T: BinaryEncodable + Debug + PartialEq,
 {
     let _ = serialize_test_and_return_expected(value, expected_value);
 }
 
 pub fn serialize_and_compare<T>(value: T, expected: &[u8])
 where
-    T: BinaryEncoder + Debug + PartialEq,
+    T: BinaryEncodable + Debug + PartialEq,
 {
     // Ask the struct for its byte length
     let byte_len = value.byte_len();

--- a/opcua-types/src/variant.rs
+++ b/opcua-types/src/variant.rs
@@ -127,7 +127,7 @@ pub trait AsVariantRef {
 
 impl<T> AsVariantRef for T
 where
-    T: BinaryEncoder + ExpandedMessageInfo,
+    T: BinaryEncodable + ExpandedMessageInfo,
 {
     fn as_variant(&self, ctx: &EncodingContext) -> Variant {
         ExtensionObject::from_message_full(self, ctx)
@@ -523,7 +523,7 @@ where
 
 impl<T> From<&T> for Variant
 where
-    T: BinaryEncoder + MessageInfo,
+    T: BinaryEncodable + MessageInfo,
 {
     fn from(value: &T) -> Self {
         ExtensionObject::from_message(value).into()
@@ -579,7 +579,7 @@ try_from_variant_to_array_impl!(u64, UInt64);
 try_from_variant_to_array_impl!(f32, Float);
 try_from_variant_to_array_impl!(f64, Double);
 
-impl BinaryEncoder for Variant {
+impl BinaryEncodable for Variant {
     fn byte_len(&self) -> usize {
         let mut size: usize = 0;
 


### PR DESCRIPTION
Makes more sense, it's not a trait for _encoders_ but for types that can be _encoded_.