### PR TITLE
External server tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,29 +20,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Provision toolchain
-        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
       - name: Build
-        run: cargo build
+        run: cargo check
       - name: Run tests
         run: cargo test --verbose
 
-  # build-windows:
-  #   strategy:
-  #     matrix:
-  #       toolchain:
-  #         - stable
-  #         - beta
-  #   runs-on: windows-latest
-  #   env:
-  #     VCPKGRS_DYNAMIC: 1
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Provision toolchain
-  #       run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-  #     - name: Build
-  #       run: cargo build
-  #     - name: Run tests
-  #       run: cargo test --verbose
+  test-external-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Build .NET
+        run: dotnet build
+      - name: Run tests against external server
+        run: cargo run --bin external-tests
 
   code-coverage:
     uses: ./.github/workflows/ci_code_coverage.yml

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ lib/certs
 
 **/bin
 **/obj
+**/pki-ext-client

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ log/
 3rd-party/open62541/build/
 lib/pki*
 lib/certs
+
+**/bin
+**/obj

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,8 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 name = "external-tests"
 version = "0.1.0"
 dependencies = [
+ "futures",
+ "log",
  "opcua",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "external-tests"
+version = "0.1.0"
+dependencies = [
+ "opcua",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "flagset"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
     "opcua-macros",
     "opcua-xml",
     "opcua-types"
-, "opcua-crypto", "opcua-core", "opcua-client", "opcua-server", "opcua-nodes", "opcua-core-namespace", "samples/custom-codegen"]
+, "opcua-crypto", "opcua-core", "opcua-client", "opcua-server", "opcua-nodes", "opcua-core-namespace", "samples/custom-codegen", "dotnet-tests/external-tests"]
 
 [workspace.dependencies]
 async-trait = "0.1.79"

--- a/TODO.md
+++ b/TODO.md
@@ -1,33 +1,18 @@
 # TODO
 
-This is a pending rewrite of the OPC-UA stack, following up on the rewrite of the client to be async all the way through.
+This is a list of things that are known to be missing, or ideas that could be implemented. Feel free to pick up any of these if you wish to contribute.
 
-The following is a list of tasks, with progress indicated where relevant.
-
- - Rewrite the server to be async, and a great deal more flexible, making it possible to create _really_ advanced servers using this SDK.
-   - **~100%** done with the initial scope, barring any bugs or details that need fixing.
-     - Some features are left out:
-     - Diagnostics, both as diagnosticsInfo from services, and general session diagnostics. There's a skeleton for this in the DiagnosticsNodeManager.
-     - Events are _implemented_ but incredibly cumbersome to write, so there is nothing fancy implemented for them. See below.
-     - Audit events are taken out due to the above.
-     - The web server is removed. Likely forever, a better solution is to use the `metrics` library to hook into the rust metrics ecosystem.
-     - A smattering of TODO's, most are somehow blocked by other tasks.
- - **100%** (The big stuff is merged) Merge most recent PRs on the main repo, especially the one migrating away from OpenSSL.
- - **100%** Split the library into parts again.
-   - Initially into types, client, core, and server.
-   - This is needed for other features.
- - **70%** Write a codegen/macro library. Initially this should just replace all the JS codegen, later on it will do _more_.
-   - It would be best if this could be written in such a way that it can either be used as a core for a macro library, or as a standalone build.rs codegen module.
- - **70%** Implement sophisticated event support, using a macro to create event types.
- - **100%?** Investigate decoding. There are several things that would be interesting to do here.
-   - Capture request-id/request-handle for error reporting during decoding. This will allow us to fatally fail much less often, but will require major changes to codegen.
-   - **100%** See if there is a way to avoid needing to pass the ID when decoding ExtensionObjects. This info should be available, either in the object itself or as part of the type being decoded.
  - Flesh out the server and client SDK with tooling for ease if use.
-   - **100%** I had an idea of a "request builder" framework for the client SDK, which might be really useful.
-   - The server should be possible to set up in such a way that it is no harder to use than before. A specialized node manager would be ideal for this.
-   - There are probably lots of neat logic we can add as utility methods that make it easier to implement node managers.
- - Go through the standard and implement _more_ of the core stuff. Diagnostics (**done-ish**), server management methods, etc.
- - Implement a better framework for security checks. (?)
+   - Make it even easier to implement custom node managers.
+   - Write a generic `Browser` for the client, to make it easier to recursively browse node hierarchies. This should be made super flexible, perhaps a trait based approach where the browser is generic over something that handles the response from a browse request and returns what nodes to browse next...
+   - Automate fetching data type definitions from the server for custom structs.
+ - Support for StructureWithOptionalFields and Union in the encoding macros.
+ - Implement Part 4 7.41.2.3, encrypted secrets. We currently only support legacy secrets. We should also support more encryption algorithms for secrets.
+ - Write some form of support for IssuedToken based authentication on the client.
+ - Implement a better framework for security checks on the server.
  - Write a sophisticated server example with a persistent store. This would be a great way to verify the flexibility of the server.
  - Write some "bad ideas" servers, it would be nice to showcase how flexible this is.
- - **N/A, clippy warns about this** Look into using non-send locks, to eliminate a source of deadlocks.
+ - Re-implement XML. The current approach using roxmltree is easy to write, but not actually what we need if we really wanted to implement OPC-UA XML encoding. A stream-based low level XML parser like `quick-xml` would probably be a better option. An implementation could probably borrow a lot from the JSON implementation.
+ - Write a framework for method calls. The foundation for this has been laid with `TryFromVariant`, if we really wanted to we could use clever trait magic to let users simply define a rust method that takes in values that each implement a trait `MethodArg`, with a blanket impl for `TryFromVariant`, and return a tuple of results. Could be really powerful, but methods are a little niche.
+ - Implement `Query`. I never got around to this, because the service is just so complex. Currently there is no way to actually implement it, since it won't work unless _all_ node managers implement it, and the core node managers don't.
+ - Look into running certain services concurrently. Currently they are sequential because that makes everything much simpler, but the services that don't have any cross node-manager interaction could run on all node managers concurrently.

--- a/dotnet-tests/Common/Common.csproj
+++ b/dotnet-tests/Common/Common.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+</Project>

--- a/dotnet-tests/Common/Comms.cs
+++ b/dotnet-tests/Common/Comms.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Common;
 
@@ -12,6 +13,9 @@ public static class Comms
         {
             PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
         };
+        res.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower, false));
+        res.Converters.Add(new OutMessageConverter());
+        res.Converters.Add(new InMessageConverter());
         return res;
     }
 

--- a/dotnet-tests/Common/Comms.cs
+++ b/dotnet-tests/Common/Comms.cs
@@ -1,0 +1,58 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+
+namespace Common;
+
+public static class Comms
+{
+    private static JsonSerializerOptions MakeOptions()
+    {
+        var res = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+        };
+        return res;
+    }
+
+    private static readonly JsonSerializerOptions options = MakeOptions();
+
+    public static void Send(IOutMessage message)
+    {
+        using var stdout = Console.OpenStandardOutput();
+        stdout.Write(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(message, options)));
+        stdout.WriteByte(0);
+        stdout.Flush();
+    }
+
+    public static async IAsyncEnumerable<IInMessage> ListenToInput([EnumeratorCancellation] CancellationToken token)
+    {
+        using var stream = Console.OpenStandardInput();
+
+        var batch = new List<byte>();
+        var buffer = new byte[1024];
+        while (!token.IsCancellationRequested)
+        {
+            var len = await stream.ReadAsync(buffer, token);
+            foreach (var b in buffer.Take(len))
+            {
+                if (b == 0)
+                {
+                    var str = Encoding.UTF8.GetString([.. batch]);
+                    var msg = JsonSerializer.Deserialize<IInMessage>(str, options) ?? throw new Exception("Got null message");
+                    yield return msg;
+                    batch.Clear();
+                }
+                else
+                {
+                    batch.Add(b);
+                }
+            }
+        }
+    }
+
+    public static void LogToRust(string message)
+    {
+        Send(new LogMessage { Message = message });
+    }
+}

--- a/dotnet-tests/Common/In.cs
+++ b/dotnet-tests/Common/In.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+
+namespace Common;
+
+public interface IInMessage;
+
+public class ShutdownMessage : IInMessage
+{
+}
+
+public enum InMessageType
+{
+    Shutdown,
+}
+
+class InMessageConverter : TaggedUnionConverter<IInMessage, InMessageType>
+{
+    protected override string TagName => "type";
+
+    protected override IInMessage? FromEnum(JsonDocument document, JsonSerializerOptions options, InMessageType type)
+    {
+        return type switch
+        {
+            InMessageType.Shutdown => document.Deserialize<ShutdownMessage>(options),
+            _ => throw new JsonException("Unknown type variant")
+        };
+    }
+
+    protected override InMessageType? ParseEnum(string value)
+    {
+        return value switch
+        {
+            "shutdown" => InMessageType.Shutdown,
+            _ => null
+        };
+    }
+}

--- a/dotnet-tests/Common/In.cs
+++ b/dotnet-tests/Common/In.cs
@@ -2,10 +2,14 @@ using System.Text.Json;
 
 namespace Common;
 
-public interface IInMessage;
+public interface IInMessage
+{
+    InMessageType Type { get; }
+}
 
 public class ShutdownMessage : IInMessage
 {
+    public InMessageType Type { get; set; } = InMessageType.Shutdown;
 }
 
 public enum InMessageType
@@ -23,15 +27,6 @@ class InMessageConverter : TaggedUnionConverter<IInMessage, InMessageType>
         {
             InMessageType.Shutdown => document.Deserialize<ShutdownMessage>(options),
             _ => throw new JsonException("Unknown type variant")
-        };
-    }
-
-    protected override InMessageType? ParseEnum(string value)
-    {
-        return value switch
-        {
-            "shutdown" => InMessageType.Shutdown,
-            _ => null
         };
     }
 }

--- a/dotnet-tests/Common/Out.cs
+++ b/dotnet-tests/Common/Out.cs
@@ -3,19 +3,27 @@ using System.Text.Json;
 namespace Common;
 
 
-public interface IOutMessage;
+public interface IOutMessage
+{
+    OutMessageType Type { get; }
+}
 
 public class LogMessage : IOutMessage
 {
+    public OutMessageType Type { get; set; } = OutMessageType.Log;
     public string? Message { get; set; }
 }
 
 public class ErrorMessage : IOutMessage
 {
+    public OutMessageType Type { get; set; } = OutMessageType.Error;
     public string? Message { get; set; }
 }
 
-public class ReadyMessage : IOutMessage { }
+public class ReadyMessage : IOutMessage
+{
+    public OutMessageType Type { get; set; } = OutMessageType.Ready;
+}
 
 public enum OutMessageType
 {
@@ -27,6 +35,7 @@ public enum OutMessageType
 
 public class GeneralMessage : IOutMessage
 {
+    public OutMessageType Type { get; set; } = OutMessageType.Payload;
     public JsonDocument? Payload { get; set; }
 }
 
@@ -43,18 +52,6 @@ class OutMessageConverter : TaggedUnionConverter<IOutMessage, OutMessageType>
             OutMessageType.Payload => document.Deserialize<GeneralMessage>(options),
             OutMessageType.Error => document.Deserialize<ErrorMessage>(options),
             _ => throw new JsonException("Unknown type variant")
-        };
-    }
-
-    protected override OutMessageType? ParseEnum(string value)
-    {
-        return value switch
-        {
-            "log" => OutMessageType.Log,
-            "ready" => OutMessageType.Ready,
-            "payload" => OutMessageType.Payload,
-            "error" => OutMessageType.Error,
-            _ => null
         };
     }
 }

--- a/dotnet-tests/Common/Out.cs
+++ b/dotnet-tests/Common/Out.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+
+namespace Common;
+
+
+public interface IOutMessage;
+
+public class LogMessage : IOutMessage
+{
+    public string? Message { get; set; }
+}
+
+public class ErrorMessage : IOutMessage
+{
+    public string? Message { get; set; }
+}
+
+public class ReadyMessage : IOutMessage { }
+
+public enum OutMessageType
+{
+    Log,
+    Ready,
+    Payload,
+    Error,
+}
+
+public class GeneralMessage : IOutMessage
+{
+    public JsonDocument? Payload { get; set; }
+}
+
+class OutMessageConverter : TaggedUnionConverter<IOutMessage, OutMessageType>
+{
+    protected override string TagName => "type";
+
+    protected override IOutMessage? FromEnum(JsonDocument document, JsonSerializerOptions options, OutMessageType type)
+    {
+        return type switch
+        {
+            OutMessageType.Log => document.Deserialize<LogMessage>(options),
+            OutMessageType.Ready => document.Deserialize<ReadyMessage>(options),
+            OutMessageType.Payload => document.Deserialize<GeneralMessage>(options),
+            OutMessageType.Error => document.Deserialize<ErrorMessage>(options),
+            _ => throw new JsonException("Unknown type variant")
+        };
+    }
+
+    protected override OutMessageType? ParseEnum(string value)
+    {
+        return value switch
+        {
+            "log" => OutMessageType.Log,
+            "ready" => OutMessageType.Ready,
+            "payload" => OutMessageType.Payload,
+            "error" => OutMessageType.Error,
+            _ => null
+        };
+    }
+}

--- a/dotnet-tests/Common/TaggedUnionConverter.cs
+++ b/dotnet-tests/Common/TaggedUnionConverter.cs
@@ -1,0 +1,39 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Common;
+
+/// <summary>
+/// Utility for working with rust style internally-tagged unions.
+/// 
+/// Requires specifying an enum, and an interface where each enum variant corresponds to
+/// an implementor of the interface.
+/// </summary>
+public abstract class TaggedUnionConverter<TInterface, TEnum> : JsonConverter<TInterface>
+    where TInterface : class
+    where TEnum : struct, Enum
+{
+    protected abstract string TagName { get; }
+
+    protected abstract TInterface? FromEnum(JsonDocument document, JsonSerializerOptions options, TEnum type);
+
+    protected abstract TEnum? ParseEnum(string value);
+
+    public override TInterface? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var doc = JsonDocument.ParseValue(ref reader);
+
+        var prop = doc.RootElement.GetProperty(TagName).GetString();
+        if (string.IsNullOrEmpty(prop))
+        {
+            throw new JsonException($"Missing tag \"{TagName}\"");
+        }
+        var type = ParseEnum(prop) ?? throw new JsonException($"Invalid tag value \"{prop}\"");
+        return FromEnum(doc, options, type);
+    }
+
+    public override void Write(Utf8JsonWriter writer, TInterface value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, value.GetType(), options);
+    }
+}

--- a/dotnet-tests/Common/TaggedUnionConverter.cs
+++ b/dotnet-tests/Common/TaggedUnionConverter.cs
@@ -17,8 +17,6 @@ public abstract class TaggedUnionConverter<TInterface, TEnum> : JsonConverter<TI
 
     protected abstract TInterface? FromEnum(JsonDocument document, JsonSerializerOptions options, TEnum type);
 
-    protected abstract TEnum? ParseEnum(string value);
-
     public override TInterface? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         using var doc = JsonDocument.ParseValue(ref reader);
@@ -28,7 +26,10 @@ public abstract class TaggedUnionConverter<TInterface, TEnum> : JsonConverter<TI
         {
             throw new JsonException($"Missing tag \"{TagName}\"");
         }
-        var type = ParseEnum(prop) ?? throw new JsonException($"Invalid tag value \"{prop}\"");
+        if (!Enum.TryParse<TEnum>(prop, true, out var type))
+        {
+            throw new JsonException($"Invalid tag \"{TagName}\"");
+        }
         return FromEnum(doc, options, type);
     }
 

--- a/dotnet-tests/TestServer.Config.xml
+++ b/dotnet-tests/TestServer.Config.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ApplicationConfiguration
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:ua="http://opcfoundation.org/UA/2008/02/Types.xsd"
+  xmlns="http://opcfoundation.org/UA/SDK/Configuration.xsd"
+>
+  <ApplicationName>Rust OPC-UA Test Server</ApplicationName>
+  <ApplicationUri>urn:localhost:RustOpcua:TestServer</ApplicationUri>
+  <ApplicationType>Server_0</ApplicationType>
+
+  <SecurityConfiguration>
+
+    <!-- Where the application instance certificate is stored (MachineDefault) -->
+    <ApplicationCertificate>
+      <StoreType>Directory</StoreType>
+      <StorePath>./servercertificates/pki/own</StorePath>
+      <SubjectName>CN=Rust-opcua-test-server</SubjectName>
+    </ApplicationCertificate>
+
+    <!-- Where the issuer certificate are stored (certificate authorities) -->
+    <TrustedIssuerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>./servercertificates/pki/issuer</StorePath>
+    </TrustedIssuerCertificates>
+
+    <!-- Where the trust list is stored -->
+    <TrustedPeerCertificates>
+      <StoreType>Directory</StoreType>
+      <StorePath>./servercertificates/pki/trusted</StorePath>
+    </TrustedPeerCertificates>
+
+    <!-- The directory used to store invalid certficates for later review by the administrator. -->
+    <RejectedCertificateStore>
+      <StoreType>Directory</StoreType>
+      <StorePath>./servercertificates/pki/rejected</StorePath>
+    </RejectedCertificateStore>
+
+    <AutoAcceptUntrustedCertificates>true</AutoAcceptUntrustedCertificates>
+  </SecurityConfiguration>
+
+  <TransportConfigurations></TransportConfigurations>
+
+  <TransportQuotas>
+    <OperationTimeout>600000</OperationTimeout>
+    <MaxStringLength>1048576</MaxStringLength>
+    <MaxByteStringLength>1048576</MaxByteStringLength>
+    <MaxArrayLength>65535</MaxArrayLength>
+    <MaxMessageSize>4194304</MaxMessageSize>
+    <MaxBufferSize>65535</MaxBufferSize>
+    <ChannelLifetime>300000</ChannelLifetime>
+    <SecurityTokenLifetime>3600000</SecurityTokenLifetime>
+  </TransportQuotas>
+  <ServerConfiguration>
+    <BaseAddresses>
+      <!--ua:String>https://localhost:62545</ua:String-->
+      <ua:String>opc.tcp://localhost:62546</ua:String>
+    </BaseAddresses>
+    <SecurityPolicies>
+      <ServerSecurityPolicy>
+        <SecurityMode>None_1</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#None</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>Sign_2</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>SignAndEncrypt_3</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>Sign_2</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>SignAndEncrypt_3</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>Sign_2</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>SignAndEncrypt_3</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>Sign_2</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>SignAndEncrypt_3</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>Sign_2</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+      <ServerSecurityPolicy>
+        <SecurityMode>SignAndEncrypt_3</SecurityMode>
+        <SecurityPolicyUri>http://opcfoundation.org/UA/SecurityPolicy#Basic256</SecurityPolicyUri>
+      </ServerSecurityPolicy>
+    </SecurityPolicies>
+    <UserTokenPolicies>
+      <ua:UserTokenPolicy>
+        <ua:TokenType>Anonymous_0</ua:TokenType>
+      </ua:UserTokenPolicy>
+      <ua:UserTokenPolicy>
+        <ua:TokenType>UserName_1</ua:TokenType>
+      </ua:UserTokenPolicy>
+    </UserTokenPolicies>
+    <DiagnosticsEnabled>false</DiagnosticsEnabled>
+    <MaxSessionCount>100</MaxSessionCount>
+    <MinSessionTimeout>10000</MinSessionTimeout>
+    <MaxSessionTimeout>3600000</MaxSessionTimeout>
+    <MaxBrowseContinuationPoints>1000</MaxBrowseContinuationPoints>
+    <MaxQueryContinuationPoints>10</MaxQueryContinuationPoints>
+    <MaxHistoryContinuationPoints>1000</MaxHistoryContinuationPoints>
+    <MaxRequestAge>600000</MaxRequestAge>
+    <MinPublishingInterval>100</MinPublishingInterval>
+    <MaxPublishingInterval>3600000</MaxPublishingInterval>
+    <PublishingResolution>50</PublishingResolution>
+    <MaxSubscriptionLifetime>3600000</MaxSubscriptionLifetime>
+    <MaxMessageQueueSize>10</MaxMessageQueueSize>
+    <MaxNotificationQueueSize>100</MaxNotificationQueueSize>
+    <MaxNotificationsPerPublish>1000</MaxNotificationsPerPublish>
+    <MinMetadataSamplingInterval>1000</MinMetadataSamplingInterval>
+    <AvailableSamplingRates>
+      <SamplingRateGroup>
+        <Start>5</Start>
+        <Increment>5</Increment>
+        <Count>20</Count>
+      </SamplingRateGroup>
+      <SamplingRateGroup>
+        <Start>100</Start>
+        <Increment>100</Increment>
+        <Count>4</Count>
+      </SamplingRateGroup>
+      <SamplingRateGroup>
+        <Start>500</Start>
+        <Increment>250</Increment>
+        <Count>2</Count>
+      </SamplingRateGroup>
+      <SamplingRateGroup>
+        <Start>1000</Start>
+        <Increment>500</Increment>
+        <Count>20</Count>
+      </SamplingRateGroup>
+    </AvailableSamplingRates>
+    <MaxRegistrationInterval>0</MaxRegistrationInterval>
+  </ServerConfiguration>
+</ApplicationConfiguration>

--- a/dotnet-tests/TestServer/Program.cs
+++ b/dotnet-tests/TestServer/Program.cs
@@ -1,0 +1,48 @@
+﻿using Common;
+using Opc.Ua.Configuration;
+
+namespace TestServer;
+
+internal sealed class Program
+{
+    private static async Task<int> Main()
+    {
+        var app = new ApplicationInstance
+        {
+            ConfigSectionName = "TestServer"
+        };
+        using var source = new CancellationTokenSource();
+        TestServer server;
+        try
+        {
+            var cfg = await app.LoadApplicationConfiguration(Path.Join("dotnet-tests", "TestServer.Config.xml"), true);
+            await app.CheckApplicationInstanceCertificate(false, 0);
+            server = new TestServer();
+            await app.Start(server);
+        }
+        catch (Exception e)
+        {
+            Comms.Send(new ErrorMessage
+            {
+                Message = $"Fatal error: {e}"
+            });
+            return 1;
+        }
+
+        Comms.Send(new ReadyMessage());
+
+        while (!source.Token.IsCancellationRequested)
+        {
+            await foreach (var message in Comms.ListenToInput(source.Token))
+            {
+                if (message is ShutdownMessage)
+                {
+                    source.Cancel();
+                }
+            }
+        }
+
+
+        return 0;
+    }
+}

--- a/dotnet-tests/TestServer/Program.cs
+++ b/dotnet-tests/TestServer/Program.cs
@@ -1,24 +1,35 @@
 ﻿using Common;
+using Opc.Ua;
 using Opc.Ua.Configuration;
 
 namespace TestServer;
 
 internal sealed class Program
 {
-    private static async Task<int> Main()
+    private static async Task<int> Main(string[] args)
     {
+        var configPath = args[0];
         var app = new ApplicationInstance
         {
             ConfigSectionName = "TestServer"
         };
         using var source = new CancellationTokenSource();
         TestServer server;
+        ApplicationConfiguration cfg;
         try
         {
-            var cfg = await app.LoadApplicationConfiguration(Path.Join("dotnet-tests", "TestServer.Config.xml"), true);
+            cfg = await app.LoadApplicationConfiguration(configPath, true);
             await app.CheckApplicationInstanceCertificate(false, 0);
             server = new TestServer();
             await app.Start(server);
+        }
+        catch (ServiceResultException e)
+        {
+            Comms.Send(new ErrorMessage
+            {
+                Message = $"Fatal error: {e}. {e.InnerResult?.AdditionalInfo}"
+            });
+            return 1;
         }
         catch (Exception e)
         {

--- a/dotnet-tests/TestServer/Server.cs
+++ b/dotnet-tests/TestServer/Server.cs
@@ -1,3 +1,4 @@
+using Common;
 using Opc.Ua;
 using Opc.Ua.Server;
 
@@ -37,8 +38,10 @@ public class TestServer : StandardServer
         if (args.NewIdentity is UserNameIdentityToken userNameToken)
         {
             if (userNameToken.UserName != "test" || userNameToken.DecryptedPassword != "pass")
+            {
                 throw ServiceResultException.Create(StatusCodes.BadIdentityTokenRejected,
                     "Incorrect username or password");
+            }
         }
         else if (args.NewIdentity is AnonymousIdentityToken)
         {

--- a/dotnet-tests/TestServer/Server.cs
+++ b/dotnet-tests/TestServer/Server.cs
@@ -1,0 +1,59 @@
+using Opc.Ua;
+using Opc.Ua.Server;
+
+namespace TestServer;
+
+public class TestServer : StandardServer
+{
+    TestNodeManager custom = null!;
+
+    protected override void OnServerStarting(ApplicationConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        base.OnServerStarting(configuration);
+    }
+
+    protected override void OnServerStarted(IServerInternal server)
+    {
+        ArgumentNullException.ThrowIfNull(server);
+
+        base.OnServerStarted(server);
+
+        // request notifications when the user identity is changed. all valid users are accepted by default.
+        server.SessionManager.ImpersonateUser += new ImpersonateEventHandler(ImpersonateUser);
+        // Auto accept untrusted, for testing
+        CertificateValidator.AutoAcceptUntrustedCertificates = true;
+    }
+
+    protected override MasterNodeManager CreateMasterNodeManager(IServerInternal server, ApplicationConfiguration configuration)
+    {
+        custom = new TestNodeManager(server);
+        return new MasterNodeManager(server, configuration, custom.NamespaceUris.First(), custom);
+    }
+
+    private void ImpersonateUser(Session _, ImpersonateEventArgs args)
+    {
+        if (args.NewIdentity is UserNameIdentityToken userNameToken)
+        {
+            if (userNameToken.UserName != "test" || userNameToken.DecryptedPassword != "pass")
+                throw ServiceResultException.Create(StatusCodes.BadIdentityTokenRejected,
+                    "Incorrect username or password");
+        }
+        else if (args.NewIdentity is AnonymousIdentityToken)
+        {
+            if (args.EndpointDescription.SecurityPolicyUri != SecurityPolicies.None)
+            {
+                throw ServiceResultException.Create(StatusCodes.BadIdentityTokenRejected,
+                    "Anonymous token not permitted");
+            }
+        }
+        else
+        {
+            throw ServiceResultException.Create(StatusCodes.BadIdentityTokenRejected,
+                "Unsupported identity token");
+        }
+
+        args.Identity = new UserIdentity();
+    }
+}

--- a/dotnet-tests/TestServer/TestNodeManager.cs
+++ b/dotnet-tests/TestServer/TestNodeManager.cs
@@ -1,0 +1,143 @@
+using Opc.Ua;
+using Opc.Ua.Server;
+
+public class TestNodeManager : CustomNodeManager2
+{
+    private uint nextId;
+
+    public TestNodeManager(IServerInternal server) : base(server, "opc.tcp://rust.test.localhost")
+    {
+        SystemContext.NodeIdFactory = this;
+    }
+
+    public override void CreateAddressSpace(IDictionary<NodeId, IList<IReference>> externalReferences)
+    {
+        lock (Lock)
+        {
+            PopulateCore(externalReferences);
+        }
+
+        base.CreateAddressSpace(externalReferences);
+    }
+
+    private void PopulateCore(IDictionary<NodeId, IList<IReference>> externalReferences)
+    {
+        var root = CreateObject("CoreBase");
+        AddExtRef(root, ObjectIds.ObjectsFolder, ReferenceTypeIds.Organizes, externalReferences);
+
+        var varDouble = CreateVariable("VarDouble", DataTypeIds.Double);
+        varDouble.Value = 0.0;
+        AddNodeRelation(varDouble, root, ReferenceTypeIds.HasComponent);
+
+        var varString = CreateVariable("VarString", DataTypeIds.String);
+        varString.Value = "test 0";
+        AddNodeRelation(varString, root, ReferenceTypeIds.HasComponent);
+
+        var varEuInfo = CreateVariable("VarEuInfo", DataTypeIds.EUInformation,
+            typeDefinitionId: VariableTypeIds.PropertyType);
+        varEuInfo.Value = new EUInformation
+        {
+            NamespaceUri = "opc.tcp://test.localhost",
+            DisplayName = "Degrees C",
+            Description = "Temperature degrees Celsius",
+        };
+        AddNodeRelation(varEuInfo, root, ReferenceTypeIds.HasComponent);
+
+        var mHello = new MethodState(null)
+        {
+            NodeId = new NodeId("EchoMethod", NamespaceIndex),
+            BrowseName = new QualifiedName("EchoMethod", NamespaceIndex)
+        };
+        mHello.DisplayName = mHello.BrowseName.Name;
+        mHello.InputArguments.Value = [
+            new Argument("Thing", DataTypeIds.String, ValueRanks.Scalar, "Thing to echo"),
+        ];
+        mHello.OutputArguments.Value = [
+            new Argument("Echo", DataTypeIds.String, ValueRanks.Scalar, "The echo"),
+        ];
+        mHello.OnCallMethod += (_, _, args, outArgs) =>
+        {
+            if (args.Count != 1)
+            {
+                return new ServiceResult(StatusCodes.BadInvalidArgument);
+            }
+            var m = args[0] as string;
+
+            outArgs[0] = $"Echo: {m}";
+
+            return ServiceResult.Good;
+        };
+        AddPredefinedNode(SystemContext, mHello);
+    }
+
+    public override NodeId New(ISystemContext context, NodeState node)
+    {
+        if (node is BaseInstanceState instance && instance.Parent != null)
+        {
+            return GenerateNodeId();
+        }
+
+        return node.NodeId;
+    }
+
+    private BaseObjectState CreateObject(string name, NodeId? nodeId = null)
+    {
+        var state = new BaseObjectState(null)
+        {
+            NodeId = nodeId ?? new NodeId(name, NamespaceIndex),
+            BrowseName = new QualifiedName(name, NamespaceIndex)
+        };
+        state.DisplayName = state.BrowseName.Name;
+        state.TypeDefinitionId = ObjectTypeIds.BaseObjectType;
+
+        AddPredefinedNode(SystemContext, state);
+
+        return state;
+    }
+
+    private BaseDataVariableState CreateVariable(string name, NodeId dataType,
+        NodeId? nodeId = null, int dim = -1, NodeId? typeDefinitionId = null)
+    {
+        var state = new BaseDataVariableState(null)
+        {
+            NodeId = nodeId ?? new NodeId(name, NamespaceIndex),
+            BrowseName = new QualifiedName(name, NamespaceIndex)
+        };
+        state.DisplayName = state.BrowseName.Name;
+        state.TypeDefinitionId = typeDefinitionId ?? VariableTypeIds.BaseDataVariableType;
+        state.DataType = dataType;
+        state.ValueRank = ValueRanks.Scalar;
+        if (dim > -1)
+        {
+            state.ValueRank = ValueRanks.OneDimension;
+            state.ArrayDimensions = new[] { (uint)dim };
+        }
+
+        AddPredefinedNode(SystemContext, state);
+
+        return state;
+    }
+
+    private void AddNodeRelation(NodeState state, NodeState parent, NodeId typeId)
+    {
+        state.AddReference(typeId, true, parent.NodeId);
+        parent.AddReference(typeId, false, state.NodeId);
+    }
+
+    private void AddExtRef(NodeState state, NodeId id, NodeId typeId,
+            IDictionary<NodeId, IList<IReference>> externalReferences)
+    {
+        if (!externalReferences.TryGetValue(id, out var references))
+        {
+            externalReferences[id] = references = new List<IReference>();
+        }
+
+        state.AddReference(typeId, true, id);
+        references.Add(new NodeStateReference(typeId, false, state.NodeId));
+    }
+
+    private NodeId GenerateNodeId()
+    {
+        return new NodeId(Interlocked.Increment(ref nextId), NamespaceIndex);
+    }
+}

--- a/dotnet-tests/TestServer/TestNodeManager.cs
+++ b/dotnet-tests/TestServer/TestNodeManager.cs
@@ -49,6 +49,10 @@ public class TestNodeManager : CustomNodeManager2
             BrowseName = new QualifiedName("EchoMethod", NamespaceIndex)
         };
         mHello.DisplayName = mHello.BrowseName.Name;
+        mHello.InputArguments = new PropertyState<Argument[]>(mHello);
+        mHello.InputArguments.NodeId = GenerateNodeId();
+        mHello.OutputArguments = new PropertyState<Argument[]>(mHello);
+        mHello.OutputArguments.NodeId = GenerateNodeId();
         mHello.InputArguments.Value = [
             new Argument("Thing", DataTypeIds.String, ValueRanks.Scalar, "Thing to echo"),
         ];

--- a/dotnet-tests/TestServer/TestServer.csproj
+++ b/dotnet-tests/TestServer/TestServer.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.374.158" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.5.374.158" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Common/Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/dotnet-tests/external-tests/Cargo.toml
+++ b/dotnet-tests/external-tests/Cargo.toml
@@ -6,14 +6,13 @@ description = "OPC UA tests using an external .NET server"
 authors = ["Einar Omang <einar@omang.com>"]
 license = "MPL-2.0"
 
-[lib]
-name = "external_tests"
-
-[dev-dependencies]
+[dependencies]
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+log = { workspace = true }
+futures = { workspace = true }
 
 opcua = { path = "../../lib" }
 

--- a/dotnet-tests/external-tests/Cargo.toml
+++ b/dotnet-tests/external-tests/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "external-tests"
+version = "0.1.0"
+edition = "2021"
+description = "OPC UA tests using an external .NET server"
+authors = ["Einar Omang <einar@omang.com>"]
+license = "MPL-2.0"
+
+[lib]
+name = "external_tests"
+
+[dev-dependencies]
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+opcua = { path = "../../lib" }
+

--- a/dotnet-tests/external-tests/src/client/mod.rs
+++ b/dotnet-tests/external-tests/src/client/mod.rs
@@ -1,0 +1,47 @@
+use std::{
+    sync::atomic::{AtomicU16, Ordering},
+    time::Duration,
+};
+
+use opcua::client::ClientBuilder;
+
+use crate::common::{spawn_proc, ProcessWrapper};
+
+pub struct ClientTestState {
+    pub server: ProcessWrapper,
+    pub handle: tokio::task::JoinHandle<()>,
+}
+
+impl ClientTestState {
+    pub async fn new() -> Self {
+        let (server, server_loop) = spawn_proc(
+            "dotnet-tests/TestServer/bin/Debug/net8.0/TestServer",
+            "dotnet-tests/TestServer.Config.xml",
+        );
+        let handle = tokio::task::spawn(server_loop.run());
+
+        Self { server, handle }
+    }
+}
+
+pub static TEST_COUNTER: AtomicU16 = AtomicU16::new(0);
+
+pub fn make_client(quick_timeout: bool) -> ClientBuilder {
+    let test_id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let client = ClientBuilder::new()
+        .application_name("external_test_client")
+        .application_uri("x")
+        .pki_dir(format!("./pki-ext-client/{test_id}"))
+        .create_sample_keypair(true)
+        .trust_server_certs(true)
+        .session_retry_initial(Duration::from_millis(200))
+        .max_array_length(1024 * 1024 * 64)
+        .max_chunk_count(64);
+
+    if quick_timeout {
+        client.session_retry_limit(1)
+    } else {
+        client
+    }
+}

--- a/dotnet-tests/external-tests/src/common/comms.rs
+++ b/dotnet-tests/external-tests/src/common/comms.rs
@@ -1,0 +1,144 @@
+use std::process::Stdio;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    process::{ChildStdin, ChildStdout},
+    select,
+    sync::mpsc::{channel, Receiver, Sender},
+};
+
+pub struct ProcessWrapper {
+    send: Sender<InMessage>,
+    recv: Receiver<OutMessage>,
+}
+
+pub struct ProcessLoop {
+    outgoing: Receiver<InMessage>,
+    incoming: Sender<OutMessage>,
+    proc: tokio::process::Child,
+    stdin: ChildStdin,
+    stdout: ChildStdout,
+}
+
+pub fn spawn_proc(path: &str) -> (ProcessWrapper, ProcessLoop) {
+    let mut child = tokio::process::Command::new(path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stdout = child.stdout.take().expect("Failed to open stdout");
+    let stdin = child.stdin.take().expect("Failed to open stdin");
+
+    let (outsend, outrecv) = channel(100);
+    let (insend, inrecv) = channel(100);
+
+    (
+        ProcessWrapper {
+            send: insend,
+            recv: outrecv,
+        },
+        ProcessLoop {
+            outgoing: inrecv,
+            incoming: outsend,
+            proc: child,
+            stdin,
+            stdout,
+        },
+    )
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum OutMessage {
+    Log(LogMessage),
+    Ready {},
+    Error(LogMessage),
+    Payload(GeneralMessage),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct LogMessage {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct GeneralMessage {
+    pub payload: Value,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum InMessage {
+    Shutdown {},
+}
+
+impl ProcessLoop {
+    pub async fn run(mut self) {
+        let mut batch = Vec::new();
+        let mut buf = [0u8; 1024];
+        let mut buf_mut = &mut buf[..];
+
+        loop {
+            select! {
+                len = self.stdout.read_buf(&mut buf_mut) => {
+                    let Ok(len) = len else {
+                        return;
+                    };
+                    batch.reserve(len);
+                    for it in &buf_mut[0..len] {
+                        if *it == 0 {
+                            let incoming: OutMessage = match serde_json::from_slice(&batch) {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    panic!("Failed to deserialize message from reader: {e}");
+                                }
+                            };
+                            match incoming {
+                                OutMessage::Log(msg) => {
+                                    println!("Message from .NET: {}", msg.message);
+                                }
+                                OutMessage::Error(msg) => {
+                                    eprintln!("Error message from .NET: {}", msg.message);
+                                    panic!("Received error from .NET");
+                                }
+                                r => self.incoming.send(r).await.unwrap()
+                            }
+
+                        }
+                    }
+                }
+                m = self.outgoing.recv() => {
+                    let Some(m) = m else {
+                        return;
+                    };
+                    self.stdin.write_all(&match serde_json::to_vec(&m) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            panic!("Failed to serialize message to send: {e}");
+                        }
+                    }).await.unwrap();
+                }
+                r = self.proc.wait() => {
+                    let r = r.unwrap();
+                    if !r.success() {
+                        panic!("Child excited with non-zero exit code");
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl ProcessWrapper {
+    pub async fn send_message(&self, msg: InMessage) {
+        let _ = self.send.send(msg).await;
+    }
+    pub async fn receive_message(&mut self) -> Option<OutMessage> {
+        self.recv.recv().await
+    }
+}

--- a/dotnet-tests/external-tests/src/common/comms.rs
+++ b/dotnet-tests/external-tests/src/common/comms.rs
@@ -130,12 +130,14 @@ impl ProcessLoop {
                             panic!("Failed to serialize message to send: {e}");
                         }
                     }).await.unwrap();
+                    self.stdin.write_u8(0).await.unwrap();
                 }
                 r = self.proc.wait() => {
                     let r = r.unwrap();
                     if !r.success() {
                         panic!("Child excited with non-zero exit code");
                     }
+                    return;
                 }
             }
         }

--- a/dotnet-tests/external-tests/src/common/mod.rs
+++ b/dotnet-tests/external-tests/src/common/mod.rs
@@ -1,0 +1,3 @@
+mod comms;
+
+pub use comms::*;

--- a/dotnet-tests/external-tests/src/common/mod.rs
+++ b/dotnet-tests/external-tests/src/common/mod.rs
@@ -1,3 +1,18 @@
 mod comms;
 
 pub use comms::*;
+use tokio::task::AbortHandle;
+
+pub struct JoinHandleAbortGuard(AbortHandle);
+
+impl JoinHandleAbortGuard {
+    pub fn new(handle: AbortHandle) -> Self {
+        Self(handle)
+    }
+}
+
+impl Drop for JoinHandleAbortGuard {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}

--- a/dotnet-tests/external-tests/src/lib.rs
+++ b/dotnet-tests/external-tests/src/lib.rs
@@ -1,0 +1,4 @@
+#![cfg(test)]
+
+pub mod client;
+pub mod common;

--- a/dotnet-tests/external-tests/src/lib.rs
+++ b/dotnet-tests/external-tests/src/lib.rs
@@ -1,4 +1,0 @@
-#![cfg(test)]
-
-pub mod client;
-pub mod common;

--- a/dotnet-tests/external-tests/src/main.rs
+++ b/dotnet-tests/external-tests/src/main.rs
@@ -1,0 +1,60 @@
+use std::{env, future::Future, panic::AssertUnwindSafe};
+
+use futures::FutureExt;
+
+use tests::run_client_tests;
+
+pub mod client;
+pub mod common;
+mod tests;
+
+#[tokio::main]
+pub async fn main() {
+    let runner = Runner::new();
+    run_client_tests(&runner).await
+}
+
+fn colored(r: i32, g: i32, b: i32, text: &str) -> String {
+    return format!("\x1B[38;2;{};{};{}m{}\x1B[0m", r, g, b, text);
+}
+
+pub struct Runner {
+    filter: Option<String>,
+}
+
+impl Runner {
+    pub fn new() -> Self {
+        Self {
+            filter: env::args().nth(1),
+        }
+    }
+
+    pub async fn run_test<Fut: Future<Output = ()>>(&self, name: &str, test: Fut) {
+        if self.filter.as_ref().is_some_and(|f| !name.contains(f)) {
+            return;
+        }
+
+        println!("Starting test {name}");
+        let r = AssertUnwindSafe(test).catch_unwind().await;
+        match r {
+            Ok(_) => println!(" {} {name}", colored(0, 255, 0, "🗸")),
+            Err(e) => {
+                if e.is::<&'static str>() {
+                    println!(
+                        " {} {name}: {}",
+                        colored(255, 0, 0, "X"),
+                        e.downcast_ref::<&'static str>().unwrap()
+                    );
+                } else if e.is::<String>() {
+                    println!(
+                        " {} {name}: {}",
+                        colored(255, 0, 0, "X"),
+                        e.downcast_ref::<String>().unwrap()
+                    );
+                } else {
+                    println!(" {} {name}", colored(255, 0, 0, "X"));
+                }
+            }
+        }
+    }
+}

--- a/dotnet-tests/external-tests/src/main.rs
+++ b/dotnet-tests/external-tests/src/main.rs
@@ -15,11 +15,17 @@ pub async fn main() {
 }
 
 fn colored(r: i32, g: i32, b: i32, text: &str) -> String {
-    return format!("\x1B[38;2;{};{};{}m{}\x1B[0m", r, g, b, text);
+    format!("\x1B[38;2;{};{};{}m{}\x1B[0m", r, g, b, text)
 }
 
 pub struct Runner {
     filter: Option<String>,
+}
+
+impl Default for Runner {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Runner {

--- a/dotnet-tests/external-tests/src/tests/client/mod.rs
+++ b/dotnet-tests/external-tests/src/tests/client/mod.rs
@@ -92,7 +92,10 @@ pub async fn run_connect_tests(runner: &Runner, _tester: &mut ClientTestState) {
         ),
     ] {
         runner
-            .run_test(&format!("{policy}:{mode}"), test_connect(policy, mode))
+            .run_test(
+                &format!("Connect {policy}:{mode}"),
+                test_connect(policy, mode),
+            )
             .await;
     }
 }

--- a/dotnet-tests/external-tests/src/tests/client/mod.rs
+++ b/dotnet-tests/external-tests/src/tests/client/mod.rs
@@ -1,0 +1,98 @@
+use opcua::{
+    client::IdentityToken,
+    crypto::{hostname, SecurityPolicy},
+    types::{
+        AttributeId, MessageSecurityMode, ReadValueId, ServerState, TimestampsToReturn, VariableId,
+    },
+};
+use tokio::select;
+
+use crate::{
+    client::{make_client, ClientTestState},
+    Runner,
+};
+
+async fn test_connect(policy: SecurityPolicy, mode: MessageSecurityMode) {
+    opcua::console_logging::init();
+    let mut client = make_client(true).client().unwrap();
+    let (session, event_loop) = client
+        .connect_to_matching_endpoint(
+            (
+                format!("opc.tcp://{}:62546", hostname().unwrap()).as_str(),
+                policy.to_str(),
+                mode,
+            ),
+            IdentityToken::UserName("test".to_owned(), "pass".to_owned()),
+        )
+        .await
+        .unwrap();
+    let h = event_loop.spawn();
+    select! {
+        r = h => {
+            panic!("Failed to connect, loop terminated: {r:?}");
+        }
+        c = session.wait_for_connection() => {
+            assert!(c, "Expected connection");
+        }
+    }
+
+    let read = session
+        .read(
+            &[ReadValueId {
+                node_id: VariableId::Server_ServerStatus_State.into(),
+                attribute_id: AttributeId::Value as u32,
+                ..Default::default()
+            }],
+            TimestampsToReturn::Both,
+            0.0,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        read[0].value.clone().unwrap().try_cast_to::<i32>().unwrap(),
+        ServerState::Running as i32
+    );
+}
+
+pub async fn run_connect_tests(runner: &Runner, _tester: &mut ClientTestState) {
+    for (policy, mode) in [
+        (SecurityPolicy::None, MessageSecurityMode::None),
+        (SecurityPolicy::Basic256Sha256, MessageSecurityMode::Sign),
+        (
+            SecurityPolicy::Basic256Sha256,
+            MessageSecurityMode::SignAndEncrypt,
+        ),
+        (
+            SecurityPolicy::Aes128Sha256RsaOaep,
+            MessageSecurityMode::Sign,
+        ),
+        (
+            SecurityPolicy::Aes128Sha256RsaOaep,
+            MessageSecurityMode::SignAndEncrypt,
+        ),
+        (
+            SecurityPolicy::Aes256Sha256RsaPss,
+            MessageSecurityMode::Sign,
+        ),
+        (
+            SecurityPolicy::Aes256Sha256RsaPss,
+            MessageSecurityMode::SignAndEncrypt,
+        ),
+        // The .NET SDK is hard to use with these, since its configuration around minimum
+        // required nonce length is really weird.
+        /*(SecurityPolicy::Basic128Rsa15, MessageSecurityMode::Sign),
+        (
+            SecurityPolicy::Basic128Rsa15,
+            MessageSecurityMode::SignAndEncrypt,
+        ), */
+        (SecurityPolicy::Basic256, MessageSecurityMode::Sign),
+        (
+            SecurityPolicy::Basic256,
+            MessageSecurityMode::SignAndEncrypt,
+        ),
+    ] {
+        runner
+            .run_test(&format!("{policy}:{mode}"), test_connect(policy, mode))
+            .await;
+    }
+}

--- a/dotnet-tests/external-tests/src/tests/mod.rs
+++ b/dotnet-tests/external-tests/src/tests/mod.rs
@@ -1,0 +1,15 @@
+use client::run_connect_tests;
+
+use crate::{client::ClientTestState, common::OutMessage, Runner};
+
+mod client;
+
+pub async fn run_client_tests(runner: &Runner) {
+    let mut state = ClientTestState::new().await;
+    let msg = state.server.receive_message().await;
+    let Some(OutMessage::Ready {}) = &msg else {
+        panic!("Expected ready message, got {msg:?}");
+    };
+    println!("Server is live, starting connection tests");
+    run_connect_tests(runner, &mut state).await;
+}

--- a/dotnet-tests/external-tests/src/tests/mod.rs
+++ b/dotnet-tests/external-tests/src/tests/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use client::run_connect_tests;
 
 use crate::{client::ClientTestState, common::OutMessage, Runner};
@@ -12,4 +14,15 @@ pub async fn run_client_tests(runner: &Runner) {
     };
     println!("Server is live, starting connection tests");
     run_connect_tests(runner, &mut state).await;
+    state
+        .server
+        .send_message(crate::common::InMessage::Shutdown {})
+        .await;
+
+    if tokio::time::timeout(Duration::from_secs(5), state.handle)
+        .await
+        .is_err()
+    {
+        println!("Server failed to shut down!");
+    }
 }

--- a/opcua-client/src/session/services/session.rs
+++ b/opcua-client/src/session/services/session.rs
@@ -179,6 +179,7 @@ impl<'b> UARequest for CreateSession<'b> {
         let response = channel.send(request, self.header.timeout).await?;
 
         if let ResponseMessage::CreateSession(response) = response {
+            log::debug!("create_session, success");
             process_service_result(&response.response_header)?;
 
             let security_policy = channel.security_policy();
@@ -211,6 +212,7 @@ impl<'b> UARequest for CreateSession<'b> {
 
             Ok(*response)
         } else {
+            log::error!("create_session failed");
             Err(process_unexpected_response(response))
         }
     }
@@ -483,10 +485,12 @@ impl UARequest for ActivateSession {
         let response = channel.send(request, timeout).await?;
 
         if let ResponseMessage::ActivateSession(response) = response {
+            log::debug!("activate_session success");
             // trace!("ActivateSessionResponse = {:#?}", response);
             process_service_result(&response.response_header)?;
             Ok(*response)
         } else {
+            log::error!("activate_session failed");
             Err(process_unexpected_response(response))
         }
     }

--- a/opcua-crypto/src/security_policy.rs
+++ b/opcua-crypto/src/security_policy.rs
@@ -45,7 +45,7 @@ mod aes_128_sha_256_rsa_oaep {
 
     pub const SYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_HMAC_SHA256;
     pub const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_RSA_SHA256;
-    pub const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = ENC_RSA_15;
+    pub const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = ENC_RSA_OAEP;
     pub const DERIVED_SIGNATURE_KEY_LENGTH: usize = 256;
     pub const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (2048, 4096);
 }
@@ -73,7 +73,7 @@ mod aes_256_sha_256_rsa_pss {
 
     pub const SYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_HMAC_SHA256;
     pub const ASYMMETRIC_SIGNATURE_ALGORITHM: &str = DSIG_RSA_PSS_SHA2_256;
-    pub const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = ENC_RSA_OAEP;
+    pub const ASYMMETRIC_ENCRYPTION_ALGORITHM: &str = ENC_RSA_OAEP_SHA256;
     pub const DERIVED_SIGNATURE_KEY_LENGTH: usize = 256;
     pub const ASYMMETRIC_KEY_LENGTH: (usize, usize) = (2048, 4096);
 }

--- a/opcua-crypto/src/security_policy.rs
+++ b/opcua-crypto/src/security_policy.rs
@@ -7,14 +7,14 @@
 use std::fmt;
 use std::str::FromStr;
 
-use log::{error, trace};
+use log::error;
 
 use opcua_types::{constants, status_code::StatusCode, ByteString, Error};
 
 use super::{
     aeskey::AesKey,
     hash,
-    pkey::{KeySize, PrivateKey, PublicKey, RsaPadding},
+    pkey::{PrivateKey, PublicKey, RsaPadding},
     random, SHA1_SIZE, SHA256_SIZE,
 };
 
@@ -565,7 +565,7 @@ impl SecurityPolicy {
         verification_key: &PublicKey,
         data: &[u8],
         signature: &[u8],
-        their_private_key: Option<PrivateKey>,
+        #[allow(unused)] their_private_key: Option<PrivateKey>,
     ) -> Result<(), Error> {
         // Asymmetric verify signature against supplied certificate
         let result = match self {
@@ -588,6 +588,8 @@ impl SecurityPolicy {
             // For debugging / unit testing purposes we might have a their_key to see the source of the error
             #[cfg(debug_assertions)]
             if let Some(their_key) = their_private_key {
+                use crate::pkey::KeySize;
+                use log::trace;
                 // Calculate the signature using their key, see what we were expecting versus theirs
                 let mut their_signature = vec![0u8; their_key.size()];
                 self.asymmetric_sign(&their_key, data, their_signature.as_mut_slice())?;

--- a/opcua-server/src/address_space/utils.rs
+++ b/opcua-server/src/address_space/utils.rs
@@ -128,7 +128,6 @@ pub fn validate_value_to_write(
         let Some(data_type) = value_data_type.try_resolve(type_tree.namespaces()) else {
             return Err(StatusCode::BadTypeMismatch);
         };
-        println!("{data_type:?}");
         // Value is scalar, check if the data type matches
         let data_type_matches = type_tree.is_subtype_of(&data_type, &node_data_type);
 

--- a/opcua.sln
+++ b/opcua.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dotnet-tests", "dotnet-tests", "{5A1CD3FB-335F-46D9-8B5A-60365CFC44ED}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestServer", "dotnet-tests\TestServer\TestServer.csproj", "{899388F4-0D20-43F8-A523-960BDD2B2649}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "dotnet-tests\Common\Common.csproj", "{5B70AE64-4242-4767-91EA-0CC3DAF97147}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{899388F4-0D20-43F8-A523-960BDD2B2649}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{899388F4-0D20-43F8-A523-960BDD2B2649}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{899388F4-0D20-43F8-A523-960BDD2B2649}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{899388F4-0D20-43F8-A523-960BDD2B2649}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B70AE64-4242-4767-91EA-0CC3DAF97147}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B70AE64-4242-4767-91EA-0CC3DAF97147}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B70AE64-4242-4767-91EA-0CC3DAF97147}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B70AE64-4242-4767-91EA-0CC3DAF97147}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{899388F4-0D20-43F8-A523-960BDD2B2649} = {5A1CD3FB-335F-46D9-8B5A-60365CFC44ED}
+		{5B70AE64-4242-4767-91EA-0CC3DAF97147} = {5A1CD3FB-335F-46D9-8B5A-60365CFC44ED}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F20C0547-E99A-4920-872A-385DBABEFE73}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Framework for running tests against an external server, in this case written in .NET.

Rust and .NET communicates over stdio, by just writing JSON to stdin/stdout. Right now we don't use it for a lot, but it's pretty much a necessity to have communication if we want to write tests that run a .NET client against an OPC-UA server.

Only a few tests are written for now, but there is plenty of room to expand. The tests I wrote here actually immediately found a bug in the crypto module!