### PR TITLE
More ext tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 This is a list of things that are known to be missing, or ideas that could be implemented. Feel free to pick up any of these if you wish to contribute.
 
+ - Optimize the `Chunker`. It currently allocates too much, and it has some other inefficiencies.
  - Flesh out the server and client SDK with tooling for ease if use.
    - Make it even easier to implement custom node managers.
    - Write a generic `Browser` for the client, to make it easier to recursively browse node hierarchies. This should be made super flexible, perhaps a trait based approach where the browser is generic over something that handles the response from a browse request and returns what nodes to browse next...

--- a/dotnet-tests/Common/In.cs
+++ b/dotnet-tests/Common/In.cs
@@ -12,9 +12,18 @@ public class ShutdownMessage : IInMessage
     public InMessageType Type { get; set; } = InMessageType.Shutdown;
 }
 
+public class ChangeValueMessage : IInMessage
+{
+    public InMessageType Type { get; set; } = InMessageType.ChangeValue;
+
+    public string? NodeId { get; set; }
+    public string? Value { get; set; }
+}
+
 public enum InMessageType
 {
     Shutdown,
+    ChangeValue,
 }
 
 class InMessageConverter : TaggedUnionConverter<IInMessage, InMessageType>
@@ -26,6 +35,7 @@ class InMessageConverter : TaggedUnionConverter<IInMessage, InMessageType>
         return type switch
         {
             InMessageType.Shutdown => document.Deserialize<ShutdownMessage>(options),
+            InMessageType.ChangeValue => document.Deserialize<ChangeValueMessage>(options),
             _ => throw new JsonException("Unknown type variant")
         };
     }

--- a/dotnet-tests/Common/TaggedUnionConverter.cs
+++ b/dotnet-tests/Common/TaggedUnionConverter.cs
@@ -28,7 +28,7 @@ public abstract class TaggedUnionConverter<TInterface, TEnum> : JsonConverter<TI
         }
         if (!Enum.TryParse<TEnum>(prop, true, out var type))
         {
-            throw new JsonException($"Invalid tag \"{TagName}\"");
+            throw new JsonException($"Invalid tag \"{prop}\"");
         }
         return FromEnum(doc, options, type);
     }

--- a/dotnet-tests/TestServer/Program.cs
+++ b/dotnet-tests/TestServer/Program.cs
@@ -1,8 +1,29 @@
 ﻿using Common;
+using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Configuration;
 
 namespace TestServer;
+
+class CommsLogger : ILogger
+{
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        var toLog = formatter(state, exception);
+        Comms.LogToRust(toLog);
+    }
+}
+
 
 internal sealed class Program
 {

--- a/dotnet-tests/TestServer/Program.cs
+++ b/dotnet-tests/TestServer/Program.cs
@@ -71,6 +71,21 @@ internal sealed class Program
                 {
                     source.Cancel();
                 }
+                else if (message is ChangeValueMessage ch)
+                {
+                    try
+                    {
+                        server.NodeManager.UpdateValue(ch);
+                    }
+                    catch (Exception ex)
+                    {
+                        Comms.Send(new ErrorMessage
+                        {
+                            Message = $"Fatal error setting value: {ex}"
+                        });
+                        return 1;
+                    }
+                }
             }
         }
 

--- a/dotnet-tests/TestServer/Server.cs
+++ b/dotnet-tests/TestServer/Server.cs
@@ -9,6 +9,8 @@ public class TestServer : StandardServer
 {
     TestNodeManager custom = null!;
 
+    public TestNodeManager NodeManager => custom;
+
     protected override void OnServerStarting(ApplicationConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
@@ -19,8 +21,6 @@ public class TestServer : StandardServer
             Utils.SetLogLevel(LogLevel.Trace);
             Utils.SetLogger(new CommsLogger());
         }
-
-
 
         base.OnServerStarting(configuration);
     }

--- a/dotnet-tests/TestServer/Server.cs
+++ b/dotnet-tests/TestServer/Server.cs
@@ -1,4 +1,5 @@
 using Common;
+using Microsoft.Extensions.Logging;
 using Opc.Ua;
 using Opc.Ua.Server;
 
@@ -11,6 +12,15 @@ public class TestServer : StandardServer
     protected override void OnServerStarting(ApplicationConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
+
+        if (Environment.GetEnvironmentVariable("OPCUA_NET_TEST_SERVER_TRACE") == "true")
+        {
+            Utils.SetTraceMask(Utils.TraceMasks.All);
+            Utils.SetLogLevel(LogLevel.Trace);
+            Utils.SetLogger(new CommsLogger());
+        }
+
+
 
         base.OnServerStarting(configuration);
     }

--- a/dotnet-tests/TestServer/TestNodeManager.cs
+++ b/dotnet-tests/TestServer/TestNodeManager.cs
@@ -71,6 +71,8 @@ public class TestNodeManager : CustomNodeManager2
 
             return ServiceResult.Good;
         };
+        AddNodeRelation(mHello, root, ReferenceTypeIds.HasComponent);
+
         AddPredefinedNode(SystemContext, mHello);
     }
 

--- a/dotnet-tests/TestServer/TestNodeManager.cs
+++ b/dotnet-tests/TestServer/TestNodeManager.cs
@@ -1,3 +1,5 @@
+using System.Buffers.Text;
+using Common;
 using Opc.Ua;
 using Opc.Ua.Server;
 
@@ -18,6 +20,21 @@ public class TestNodeManager : CustomNodeManager2
         }
 
         base.CreateAddressSpace(externalReferences);
+    }
+
+    public void UpdateValue(ChangeValueMessage message)
+    {
+        var nodeId = NodeId.Parse(message.NodeId);
+        var bytes = Convert.FromBase64String(message.Value!);
+
+        var variant = new BinaryDecoder(bytes, Server.MessageContext).ReadVariant("");
+
+        var vb = PredefinedNodes[nodeId];
+        if (vb is not BaseDataVariableState state) throw new Exception("Not a variable");
+        state.Value = variant.Value;
+        state.Timestamp = DateTime.UtcNow;
+        state.StatusCode = StatusCodes.Good;
+        state.ClearChangeMasks(SystemContext, false);
     }
 
     private void PopulateCore(IDictionary<NodeId, IList<IReference>> externalReferences)

--- a/dotnet-tests/external-tests/src/client/mod.rs
+++ b/dotnet-tests/external-tests/src/client/mod.rs
@@ -3,9 +3,12 @@ use std::{
     time::Duration,
 };
 
-use opcua::client::ClientBuilder;
+use opcua::{
+    client::{ClientBuilder, Session},
+    types::{NodeId, Variant},
+};
 
-use crate::common::{spawn_proc, ProcessWrapper};
+use crate::common::{spawn_proc, InMessage, ProcessWrapper, UpdateValueMessage};
 
 pub struct ClientTestState {
     pub server: ProcessWrapper,
@@ -21,6 +24,18 @@ impl ClientTestState {
         let handle = tokio::task::spawn(server_loop.run());
 
         Self { server, handle }
+    }
+
+    pub async fn send_change_message(&self, session: &Session, node_id: NodeId, value: Variant) {
+        let context = session.context();
+        let ctx_r = context.read();
+        self.server
+            .send_message(InMessage::ChangeValue(UpdateValueMessage::new(
+                node_id,
+                value,
+                &ctx_r.context(),
+            )))
+            .await;
     }
 }
 

--- a/dotnet-tests/external-tests/src/client/mod.rs
+++ b/dotnet-tests/external-tests/src/client/mod.rs
@@ -27,15 +27,13 @@ impl ClientTestState {
     }
 
     pub async fn send_change_message(&self, session: &Session, node_id: NodeId, value: Variant) {
-        let context = session.context();
-        let ctx_r = context.read();
-        self.server
-            .send_message(InMessage::ChangeValue(UpdateValueMessage::new(
-                node_id,
-                value,
-                &ctx_r.context(),
-            )))
-            .await;
+        let msg = {
+            let context = session.context();
+            let ctx_r = context.read();
+            InMessage::ChangeValue(UpdateValueMessage::new(node_id, value, &ctx_r.context()))
+        };
+
+        self.server.send_message(msg).await;
     }
 }
 

--- a/dotnet-tests/external-tests/src/common/comms.rs
+++ b/dotnet-tests/external-tests/src/common/comms.rs
@@ -1,5 +1,6 @@
 use std::process::Stdio;
 
+use opcua::types::{BinaryEncodable, ByteString, Context, NodeId, Variant};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::{
@@ -78,9 +79,26 @@ pub struct GeneralMessage {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "snake_case", tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub struct UpdateValueMessage {
+    pub node_id: String,
+    pub value: String,
+}
+
+impl UpdateValueMessage {
+    pub fn new(node_id: NodeId, value: Variant, ctx: &Context) -> Self {
+        Self {
+            node_id: node_id.to_string(),
+            value: ByteString::from(value.encode_to_vec(&ctx)).as_base64(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase", tag = "type")]
 pub enum InMessage {
     Shutdown {},
+    ChangeValue(UpdateValueMessage),
 }
 
 impl ProcessLoop {

--- a/dotnet-tests/external-tests/src/common/comms.rs
+++ b/dotnet-tests/external-tests/src/common/comms.rs
@@ -89,7 +89,7 @@ impl UpdateValueMessage {
     pub fn new(node_id: NodeId, value: Variant, ctx: &Context) -> Self {
         Self {
             node_id: node_id.to_string(),
-            value: ByteString::from(value.encode_to_vec(&ctx)).as_base64(),
+            value: ByteString::from(value.encode_to_vec(ctx)).as_base64(),
         }
     }
 }

--- a/dotnet-tests/external-tests/src/main.rs
+++ b/dotnet-tests/external-tests/src/main.rs
@@ -11,6 +11,8 @@ mod tests;
 
 #[tokio::main]
 pub async fn main() {
+    opcua::console_logging::init();
+
     let runner = Runner::new();
     run_client_tests(&runner).await
 }

--- a/dotnet-tests/external-tests/src/tests/client/connect.rs
+++ b/dotnet-tests/external-tests/src/tests/client/connect.rs
@@ -1,0 +1,82 @@
+use opcua::{
+    client::IdentityToken,
+    crypto::SecurityPolicy,
+    types::{
+        AttributeId, MessageSecurityMode, ReadValueId, ServerState, TimestampsToReturn, VariableId,
+    },
+};
+
+use crate::{client::ClientTestState, tests::client::with_session, Runner};
+
+async fn test_connect(policy: SecurityPolicy, mode: MessageSecurityMode) {
+    with_session(
+        |session| async move {
+            let read = session
+                .read(
+                    &[ReadValueId {
+                        node_id: VariableId::Server_ServerStatus_State.into(),
+                        attribute_id: AttributeId::Value as u32,
+                        ..Default::default()
+                    }],
+                    TimestampsToReturn::Both,
+                    0.0,
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                read[0].value.clone().unwrap().try_cast_to::<i32>().unwrap(),
+                ServerState::Running as i32
+            );
+        },
+        policy,
+        mode,
+        IdentityToken::UserName("test".to_owned(), "pass".to_owned()),
+    )
+    .await;
+}
+
+pub async fn run_connect_tests(runner: &Runner, _tester: &mut ClientTestState) {
+    for (policy, mode) in [
+        (SecurityPolicy::None, MessageSecurityMode::None),
+        (SecurityPolicy::Basic256Sha256, MessageSecurityMode::Sign),
+        (
+            SecurityPolicy::Basic256Sha256,
+            MessageSecurityMode::SignAndEncrypt,
+        ),
+        (
+            SecurityPolicy::Aes128Sha256RsaOaep,
+            MessageSecurityMode::Sign,
+        ),
+        (
+            SecurityPolicy::Aes128Sha256RsaOaep,
+            MessageSecurityMode::SignAndEncrypt,
+        ),
+        (
+            SecurityPolicy::Aes256Sha256RsaPss,
+            MessageSecurityMode::Sign,
+        ),
+        (
+            SecurityPolicy::Aes256Sha256RsaPss,
+            MessageSecurityMode::SignAndEncrypt,
+        ),
+        // The .NET SDK is hard to use with these, since its configuration around minimum
+        // required nonce length is really weird.
+        /*(SecurityPolicy::Basic128Rsa15, MessageSecurityMode::Sign),
+        (
+            SecurityPolicy::Basic128Rsa15,
+            MessageSecurityMode::SignAndEncrypt,
+        ), */
+        (SecurityPolicy::Basic256, MessageSecurityMode::Sign),
+        (
+            SecurityPolicy::Basic256,
+            MessageSecurityMode::SignAndEncrypt,
+        ),
+    ] {
+        runner
+            .run_test(
+                &format!("Connect {policy}:{mode}"),
+                test_connect(policy, mode),
+            )
+            .await;
+    }
+}

--- a/dotnet-tests/external-tests/src/tests/client/connect.rs
+++ b/dotnet-tests/external-tests/src/tests/client/connect.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use opcua::{
-    client::IdentityToken,
+    client::{IdentityToken, Session},
     crypto::SecurityPolicy,
     types::{
         AttributeId, MessageSecurityMode, ReadValueId, ServerState, TimestampsToReturn, VariableId,
@@ -8,34 +10,41 @@ use opcua::{
 
 use crate::{client::ClientTestState, tests::client::with_session, Runner};
 
-async fn test_connect(policy: SecurityPolicy, mode: MessageSecurityMode) {
+async fn test_connect_inner(session: Arc<Session>, _ctx: &mut ClientTestState) {
+    let read = session
+        .read(
+            &[ReadValueId {
+                node_id: VariableId::Server_ServerStatus_State.into(),
+                attribute_id: AttributeId::Value as u32,
+                ..Default::default()
+            }],
+            TimestampsToReturn::Both,
+            0.0,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        read[0].value.clone().unwrap().try_cast_to::<i32>().unwrap(),
+        ServerState::Running as i32
+    );
+}
+
+async fn test_connect(
+    policy: SecurityPolicy,
+    mode: MessageSecurityMode,
+    ctx: &mut ClientTestState,
+) {
     with_session(
-        |session| async move {
-            let read = session
-                .read(
-                    &[ReadValueId {
-                        node_id: VariableId::Server_ServerStatus_State.into(),
-                        attribute_id: AttributeId::Value as u32,
-                        ..Default::default()
-                    }],
-                    TimestampsToReturn::Both,
-                    0.0,
-                )
-                .await
-                .unwrap();
-            assert_eq!(
-                read[0].value.clone().unwrap().try_cast_to::<i32>().unwrap(),
-                ServerState::Running as i32
-            );
-        },
+        test_connect_inner,
         policy,
         mode,
         IdentityToken::UserName("test".to_owned(), "pass".to_owned()),
+        ctx,
     )
     .await;
 }
 
-pub async fn run_connect_tests(runner: &Runner, _tester: &mut ClientTestState) {
+pub async fn run_connect_tests(runner: &Runner, ctx: &mut ClientTestState) {
     for (policy, mode) in [
         (SecurityPolicy::None, MessageSecurityMode::None),
         (SecurityPolicy::Basic256Sha256, MessageSecurityMode::Sign),
@@ -75,7 +84,7 @@ pub async fn run_connect_tests(runner: &Runner, _tester: &mut ClientTestState) {
         runner
             .run_test(
                 &format!("Connect {policy}:{mode}"),
-                test_connect(policy, mode),
+                test_connect(policy, mode, ctx),
             )
             .await;
     }

--- a/dotnet-tests/external-tests/src/tests/client/services.rs
+++ b/dotnet-tests/external-tests/src/tests/client/services.rs
@@ -1,0 +1,143 @@
+use std::{collections::HashMap, sync::Arc};
+
+use opcua::{
+    client::Session,
+    types::{
+        BrowseDescription, BrowseResultMask, CallMethodRequest, EUInformation, NodeClass, NodeId,
+        QualifiedName, ReadValueId, ReferenceTypeId, StatusCode, VariableTypeId,
+    },
+};
+
+pub async fn test_read(session: Arc<Session>) {
+    let r = session
+        .read(
+            &[
+                ReadValueId::new_value(NodeId::new(2, "VarDouble")),
+                ReadValueId::new_value(NodeId::new(2, "VarString")),
+                ReadValueId::new_value(NodeId::new(2, "VarEuInfo")),
+            ],
+            opcua::types::TimestampsToReturn::Both,
+            0.0,
+        )
+        .await
+        .unwrap();
+    assert_eq!(3, r.len());
+    assert_eq!(
+        r[0].value.clone().unwrap().try_cast_to::<f64>().unwrap(),
+        0.0f64
+    );
+    assert_eq!(
+        r[1].value.clone().unwrap().try_cast_to::<String>().unwrap(),
+        "test 0"
+    );
+    assert_eq!(
+        r[2].value
+            .clone()
+            .unwrap()
+            .try_cast_to::<EUInformation>()
+            .unwrap(),
+        EUInformation {
+            namespace_uri: "opc.tcp://test.localhost".into(),
+            unit_id: 0,
+            display_name: "Degrees C".into(),
+            description: "Temperature degrees Celsius".into()
+        }
+    );
+}
+
+pub async fn test_browse(session: Arc<Session>) {
+    let r = session
+        .browse(
+            &[BrowseDescription {
+                node_id: NodeId::new(2, "CoreBase"),
+                browse_direction: opcua::types::BrowseDirection::Forward,
+                reference_type_id: ReferenceTypeId::HierarchicalReferences.into(),
+                include_subtypes: true,
+                node_class_mask: 0,
+                result_mask: BrowseResultMask::All as u32,
+            }],
+            100,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(1, r.len());
+    let refs = r.into_iter().next().unwrap().references.unwrap();
+    assert_eq!(4, refs.len());
+    let mut by_id: HashMap<_, _> = refs
+        .into_iter()
+        .map(|r| (r.node_id.node_id.clone(), r))
+        .collect();
+
+    let n = by_id.remove(&NodeId::new(2, "VarDouble")).unwrap();
+    assert_eq!(n.browse_name, QualifiedName::new(2, "VarDouble"));
+    assert_eq!(n.display_name, "VarDouble".into());
+    assert_eq!(n.reference_type_id, ReferenceTypeId::HasComponent);
+    assert!(n.is_forward);
+    assert_eq!(
+        n.type_definition.node_id,
+        VariableTypeId::BaseDataVariableType
+    );
+    assert_eq!(n.node_class, NodeClass::Variable);
+
+    let n = by_id.remove(&NodeId::new(2, "VarString")).unwrap();
+    assert_eq!(n.browse_name, QualifiedName::new(2, "VarString"));
+    assert_eq!(n.display_name, "VarString".into());
+    assert_eq!(n.reference_type_id, ReferenceTypeId::HasComponent);
+    assert!(n.is_forward);
+    assert_eq!(
+        n.type_definition.node_id,
+        VariableTypeId::BaseDataVariableType
+    );
+    assert_eq!(n.node_class, NodeClass::Variable);
+
+    let n = by_id.remove(&NodeId::new(2, "VarEuInfo")).unwrap();
+    assert_eq!(n.browse_name, QualifiedName::new(2, "VarEuInfo"));
+    assert_eq!(n.display_name, "VarEuInfo".into());
+    assert_eq!(n.reference_type_id, ReferenceTypeId::HasComponent);
+    assert!(n.is_forward);
+    assert_eq!(n.type_definition.node_id, VariableTypeId::PropertyType);
+    assert_eq!(n.node_class, NodeClass::Variable);
+
+    let n = by_id.remove(&NodeId::new(2, "EchoMethod")).unwrap();
+    assert_eq!(n.browse_name, QualifiedName::new(2, "EchoMethod"));
+    assert_eq!(n.display_name, "EchoMethod".into());
+    assert_eq!(n.reference_type_id, ReferenceTypeId::HasComponent);
+    assert!(n.is_forward);
+    assert_eq!(n.node_class, NodeClass::Method);
+}
+
+pub async fn test_call(session: Arc<Session>) {
+    let r = session
+        .call_one(CallMethodRequest {
+            object_id: NodeId::new(2, "CoreBase"),
+            method_id: NodeId::new(2, "EchoMethod"),
+            input_arguments: Some(vec!["Hello there".into()]),
+        })
+        .await
+        .unwrap();
+
+    assert!(r.status_code.is_good());
+    let out = r.output_arguments.unwrap();
+    assert_eq!(1, out.len());
+    assert_eq!(
+        out[0].clone().try_cast_to::<String>().unwrap(),
+        "Echo: Hello there"
+    );
+}
+
+pub async fn test_big_request(session: Arc<Session>) {
+    let items: Vec<_> = (0..1000)
+        .map(|n| ReadValueId::new_value(NodeId::new(2, format!("{n}{}", "c".repeat(100)))))
+        .collect();
+
+    let r = session
+        .read(&items, opcua::types::TimestampsToReturn::Both, 0.0)
+        .await
+        .unwrap();
+
+    for n in r {
+        assert_eq!(n.status, Some(StatusCode::BadNodeIdUnknown));
+    }
+}

--- a/dotnet-tests/external-tests/src/tests/client/services.rs
+++ b/dotnet-tests/external-tests/src/tests/client/services.rs
@@ -1,14 +1,19 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use opcua::{
-    client::Session,
+    client::{OnSubscriptionNotification, Session},
     types::{
-        BrowseDescription, BrowseResultMask, CallMethodRequest, EUInformation, NodeClass, NodeId,
-        QualifiedName, ReadValueId, ReferenceTypeId, StatusCode, VariableTypeId,
+        AttributeId, BrowseDescription, BrowseResultMask, CallMethodRequest, DataValue,
+        EUInformation, MonitoredItemCreateRequest, MonitoringParameters, NodeClass, NodeId,
+        QualifiedName, ReadValueId, ReferenceTypeId, StatusCode, TimestampsToReturn,
+        VariableTypeId, Variant,
     },
 };
+use tokio::{sync::mpsc::UnboundedReceiver, time::timeout};
 
-pub async fn test_read(session: Arc<Session>) {
+use crate::client::ClientTestState;
+
+pub async fn test_read(session: Arc<Session>, _ctx: &mut ClientTestState) {
     let r = session
         .read(
             &[
@@ -45,7 +50,7 @@ pub async fn test_read(session: Arc<Session>) {
     );
 }
 
-pub async fn test_browse(session: Arc<Session>) {
+pub async fn test_browse(session: Arc<Session>, _ctx: &mut ClientTestState) {
     let r = session
         .browse(
             &[BrowseDescription {
@@ -108,7 +113,7 @@ pub async fn test_browse(session: Arc<Session>) {
     assert_eq!(n.node_class, NodeClass::Method);
 }
 
-pub async fn test_call(session: Arc<Session>) {
+pub async fn test_call(session: Arc<Session>, _ctx: &mut ClientTestState) {
     let r = session
         .call_one(CallMethodRequest {
             object_id: NodeId::new(2, "CoreBase"),
@@ -127,7 +132,7 @@ pub async fn test_call(session: Arc<Session>) {
     );
 }
 
-pub async fn test_big_request(session: Arc<Session>) {
+pub async fn test_big_request(session: Arc<Session>, _ctx: &mut ClientTestState) {
     let items: Vec<_> = (0..1000)
         .map(|n| ReadValueId::new_value(NodeId::new(2, format!("{n}{}", "c".repeat(100)))))
         .collect();
@@ -140,4 +145,113 @@ pub async fn test_big_request(session: Arc<Session>) {
     for n in r {
         assert_eq!(n.status, Some(StatusCode::BadNodeIdUnknown));
     }
+}
+
+#[derive(Clone)]
+pub struct ChannelNotifications {
+    data_values: tokio::sync::mpsc::UnboundedSender<(ReadValueId, DataValue)>,
+    events: tokio::sync::mpsc::UnboundedSender<(ReadValueId, Option<Vec<Variant>>)>,
+}
+
+impl ChannelNotifications {
+    #[allow(clippy::type_complexity)]
+    pub fn new() -> (
+        Self,
+        UnboundedReceiver<(ReadValueId, DataValue)>,
+        UnboundedReceiver<(ReadValueId, Option<Vec<Variant>>)>,
+    ) {
+        let (data_values, data_recv) = tokio::sync::mpsc::unbounded_channel();
+        let (events, events_recv) = tokio::sync::mpsc::unbounded_channel();
+        (
+            Self {
+                data_values,
+                events,
+            },
+            data_recv,
+            events_recv,
+        )
+    }
+}
+
+impl OnSubscriptionNotification for ChannelNotifications {
+    fn on_data_value(&mut self, notification: DataValue, item: &opcua::client::MonitoredItem) {
+        let _ = self
+            .data_values
+            .send((item.item_to_monitor().clone(), notification));
+    }
+
+    fn on_event(
+        &mut self,
+        event_fields: Option<Vec<Variant>>,
+        item: &opcua::client::MonitoredItem,
+    ) {
+        let _ = self
+            .events
+            .send((item.item_to_monitor().clone(), event_fields));
+    }
+}
+
+pub async fn test_subscriptions(session: Arc<Session>, ctx: &mut ClientTestState) {
+    let (notifs, mut data, _) = ChannelNotifications::new();
+
+    let sub_id = session
+        .create_subscription(Duration::from_millis(100), 100, 100, 1000, 0, true, notifs)
+        .await
+        .unwrap();
+
+    // Create a monitored item on that subscription
+    let res = session
+        .create_monitored_items(
+            sub_id,
+            TimestampsToReturn::Both,
+            vec![MonitoredItemCreateRequest {
+                item_to_monitor: ReadValueId {
+                    node_id: NodeId::new(2, "VarDouble"),
+                    attribute_id: AttributeId::Value as u32,
+                    ..Default::default()
+                },
+                monitoring_mode: opcua::types::MonitoringMode::Reporting,
+                requested_parameters: MonitoringParameters {
+                    sampling_interval: 0.0,
+                    queue_size: 10,
+                    discard_oldest: true,
+                    ..Default::default()
+                },
+            }],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.len(), 1);
+    let it = &res[0];
+    assert_eq!(it.status_code, StatusCode::Good);
+
+    // We should quickly get a data value, this is due to the initial queued publish request.
+    let (_, v) = timeout(Duration::from_millis(2000), data.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let val = match v.value {
+        Some(Variant::Double(v)) => v,
+        _ => panic!("Expected double value"),
+    };
+    assert_eq!(0.0, val);
+
+    ctx.send_change_message(&session, NodeId::new(2, "VarDouble"), 1.0.into())
+        .await;
+
+    // We should get a new update
+    let (_, v) = timeout(Duration::from_millis(2000), data.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let val = match v.value {
+        Some(Variant::Double(v)) => v,
+        _ => panic!("Expected double value"),
+    };
+    assert_eq!(1.0, val);
+
+    // Reset the value on the server before stopping
+    ctx.send_change_message(&session, NodeId::new(2, "VarDouble"), 0.0.into())
+        .await;
 }

--- a/dotnet-tests/external-tests/src/tests/mod.rs
+++ b/dotnet-tests/external-tests/src/tests/mod.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use client::{
     run_connect_tests,
-    services::{test_big_request, test_browse, test_call, test_read},
+    services::{test_big_request, test_browse, test_call, test_read, test_subscriptions},
     with_basic_session, with_session,
 };
 
@@ -15,15 +15,15 @@ use opcua::types::MessageSecurityMode;
 mod client;
 
 macro_rules! run_test {
-    ($runner:ident, $test:ident) => {
+    ($runner:ident, $ctx:ident, $test:ident) => {
         $runner
-            .run_test(stringify!($test), with_basic_session($test))
+            .run_test(stringify!($test), with_basic_session($test, &mut $ctx))
             .await;
     };
 }
 
 macro_rules! run_encrypted_test {
-    ($runner:ident, $test:ident) => {
+    ($runner:ident, $ctx:ident, $test:ident) => {
         $runner
             .run_test(
                 concat!("encrypted_", stringify!($test)),
@@ -32,6 +32,7 @@ macro_rules! run_encrypted_test {
                     SecurityPolicy::Aes256Sha256RsaPss,
                     MessageSecurityMode::SignAndEncrypt,
                     IdentityToken::UserName("test".to_owned(), "pass".to_owned()),
+                    &mut $ctx,
                 ),
             )
             .await;
@@ -47,10 +48,11 @@ pub async fn run_client_tests(runner: &Runner) {
     println!("Server is live, starting tests");
 
     run_connect_tests(runner, &mut state).await;
-    run_test!(runner, test_read);
-    run_test!(runner, test_browse);
-    run_test!(runner, test_call);
-    run_encrypted_test!(runner, test_big_request);
+    run_test!(runner, state, test_read);
+    run_test!(runner, state, test_browse);
+    run_test!(runner, state, test_call);
+    run_encrypted_test!(runner, state, test_big_request);
+    run_test!(runner, state, test_subscriptions);
 
     state
         .server

--- a/dotnet-tests/external-tests/src/tests/mod.rs
+++ b/dotnet-tests/external-tests/src/tests/mod.rs
@@ -1,10 +1,42 @@
 use std::time::Duration;
 
-use client::run_connect_tests;
+use client::{
+    run_connect_tests,
+    services::{test_big_request, test_browse, test_call, test_read},
+    with_basic_session, with_session,
+};
 
 use crate::{client::ClientTestState, common::OutMessage, Runner};
 
+use opcua::client::IdentityToken;
+use opcua::crypto::SecurityPolicy;
+use opcua::types::MessageSecurityMode;
+
 mod client;
+
+macro_rules! run_test {
+    ($runner:ident, $test:ident) => {
+        $runner
+            .run_test(stringify!($test), with_basic_session($test))
+            .await;
+    };
+}
+
+macro_rules! run_encrypted_test {
+    ($runner:ident, $test:ident) => {
+        $runner
+            .run_test(
+                concat!("encrypted_", stringify!($test)),
+                with_session(
+                    $test,
+                    SecurityPolicy::Aes256Sha256RsaPss,
+                    MessageSecurityMode::SignAndEncrypt,
+                    IdentityToken::UserName("test".to_owned(), "pass".to_owned()),
+                ),
+            )
+            .await;
+    };
+}
 
 pub async fn run_client_tests(runner: &Runner) {
     let mut state = ClientTestState::new().await;
@@ -12,8 +44,14 @@ pub async fn run_client_tests(runner: &Runner) {
     let Some(OutMessage::Ready {}) = &msg else {
         panic!("Expected ready message, got {msg:?}");
     };
-    println!("Server is live, starting connection tests");
+    println!("Server is live, starting tests");
+
     run_connect_tests(runner, &mut state).await;
+    run_test!(runner, test_read);
+    run_test!(runner, test_browse);
+    run_test!(runner, test_call);
+    run_encrypted_test!(runner, test_big_request);
+
     state
         .server
         .send_message(crate::common::InMessage::Shutdown {})

--- a/opcua-client/src/session/implementation.rs
+++ b/opcua-client/src/session/implementation.rs
@@ -291,4 +291,9 @@ impl Session {
     pub fn add_type_loader(&mut self, type_loader: Arc<dyn TypeLoader>) {
         self.encoding_context.write().loaders_mut().add(type_loader);
     }
+
+    /// Get a reference to the encoding
+    pub fn context(&self) -> Arc<RwLock<ContextOwned>> {
+        self.channel.secure_channel.read().context_arc()
+    }
 }

--- a/opcua-core/src/comms/message_chunk.rs
+++ b/opcua-core/src/comms/message_chunk.rs
@@ -270,37 +270,60 @@ impl MessageChunk {
     pub fn body_size_from_message_size(
         message_type: MessageChunkType,
         secure_channel: &SecureChannel,
-        message_size: usize,
+        max_chunk_size: usize,
     ) -> Result<usize, MessageChunkTooSmall> {
-        if message_size < MIN_CHUNK_SIZE {
+        if max_chunk_size < MIN_CHUNK_SIZE {
             error!(
-                "message size {} is less than minimum allowed by the spec",
-                message_size
+                "chunk size {} is less than minimum allowed by the spec",
+                max_chunk_size
             );
             return Err(MessageChunkTooSmall);
         }
-
+        // First, get the size of the various message chunk headers.
         let security_header = secure_channel.make_security_header(message_type);
 
-        let signature_size = secure_channel.signature_size(&security_header);
-        let (plain_text_block_size, _) =
-            secure_channel.get_padding_block_sizes(&security_header, signature_size, message_type);
-
-        let mut data_size = MESSAGE_CHUNK_HEADER_SIZE;
-        data_size += security_header.byte_len();
-        data_size += (SequenceHeader {
+        let mut header_size = MESSAGE_CHUNK_HEADER_SIZE;
+        header_size += security_header.byte_len();
+        header_size += (SequenceHeader {
             sequence_number: 0,
             request_id: 0,
         })
         .byte_len();
 
-        data_size += signature_size;
-        // The plain text block size is the maximum possible padding, so we need to
-        // subtract that to avoid overflowing buffers later.
-        data_size += plain_text_block_size;
+        // Next, get the size of the signature, which may be zero if the
+        // header isn't signed.
+        let signature_size = secure_channel.signature_size(&security_header);
 
-        // Message size is what's left
-        Ok(message_size - data_size)
+        // Get the encryption block size, and the minimum padding length.
+        // The minimum padding depends on the key length.
+        let (plain_text_block_size, minimum_padding) =
+            secure_channel.get_padding_block_sizes(&security_header, signature_size, message_type);
+
+        // Compute the max chunk size aligned to an encryption block.
+        // When encrypting, the size must be a whole multiple of `plain_text_block_size`,
+        // we round the max chunk size down to the nearest such chunk.
+        let aligned_max_chunk_size = if plain_text_block_size > 0 {
+            max_chunk_size - (max_chunk_size % plain_text_block_size)
+        } else {
+            max_chunk_size
+        };
+        // So, the total maximum chunk body size is
+        // - the aligned chunk size,
+        // - minus the size of the message chunk headers.
+        // - minus the size of the signature.
+        // - minus the minimum padding.
+
+        // This means that if the chunk size is 8191, with 32 bytes header and 32 bytes signature,
+        // 1 minimum padding and 16 bytes block size,
+        // we get a chunk size of 8111. Add the header, 8143, add the signature
+        // 8175, pad with a minimum padding of 1 -> 8176.
+
+        // Note that if we used a chunk size of 8112 instead, we would end up with
+        // 8176 bytes after header and signature, and we would need to pad _16_ bytes,
+        // which would put us at 8192, which exceeds the configured limit.
+        // So 8111 is the largest the chunk can possibly be with this chunk size.
+
+        Ok(aligned_max_chunk_size - header_size - signature_size - minimum_padding)
     }
 
     /// Decode the message header from the inner data.

--- a/opcua-core/src/comms/secure_channel.rs
+++ b/opcua-core/src/comms/secure_channel.rs
@@ -483,6 +483,42 @@ impl SecureChannel {
         }
     }
 
+    /// Get the plain text block size and key length for this channel.
+    /// Only makes sense if security policy is not None, and security mode is
+    /// SignAndEncrypt
+    pub fn get_padding_block_sizes(
+        &self,
+        security_header: &SecurityHeader,
+        signature_size: usize,
+        message_type: MessageChunkType,
+    ) -> (usize, usize) {
+        if self.security_policy == SecurityPolicy::None
+            || self.security_mode != MessageSecurityMode::SignAndEncrypt
+                && !message_type.is_open_secure_channel()
+        {
+            return (0, 0);
+        }
+
+        match security_header {
+            SecurityHeader::Asymmetric(security_header) => {
+                if security_header.sender_certificate.is_null() {
+                    error!("Sender has not supplied a certificate so it is doubtful that this will work");
+                    (self.security_policy.plain_block_size(), signature_size)
+                } else {
+                    // Padding requires we look at the remote certificate and security policy
+                    let padding = self.security_policy.asymmetric_encryption_padding();
+                    let x509 = self.remote_cert().unwrap();
+                    let pk = x509.public_key().unwrap();
+                    (pk.plain_text_block_size(padding), pk.size())
+                }
+            }
+            SecurityHeader::Symmetric(_) => {
+                // Plain text block size comes from policy
+                (self.security_policy.plain_block_size(), signature_size)
+            }
+        }
+    }
+
     /// Calculate the padding size
     ///
     /// Padding adds bytes to the body to make it a multiple of the block size so it can be encrypted.
@@ -493,43 +529,23 @@ impl SecureChannel {
         signature_size: usize,
         message_type: MessageChunkType,
     ) -> (usize, usize) {
-        if self.security_policy != SecurityPolicy::None
-            && (self.security_mode == MessageSecurityMode::SignAndEncrypt
-                || message_type.is_open_secure_channel())
-        {
-            // Signature size in bytes
-            let (plain_text_block_size, key_length) = match security_header {
-                SecurityHeader::Asymmetric(security_header) => {
-                    if security_header.sender_certificate.is_null() {
-                        error!("Sender has not supplied a certificate so it is doubtful that this will work");
-                        (self.security_policy.plain_block_size(), signature_size)
-                    } else {
-                        // Padding requires we look at the remote certificate and security policy
-                        let padding = self.security_policy.asymmetric_encryption_padding();
-                        let x509 = self.remote_cert().unwrap();
-                        let pk = x509.public_key().unwrap();
-                        (pk.plain_text_block_size(padding), pk.size())
-                    }
-                }
-                SecurityHeader::Symmetric(_) => {
-                    // Plain text block size comes from policy
-                    (self.security_policy.plain_block_size(), signature_size)
-                }
-            };
+        let (plain_text_block_size, key_length) =
+            self.get_padding_block_sizes(security_header, signature_size, message_type);
 
-            // PaddingSize = PlainTextBlockSize – ((BytesToWrite + SignatureSize + 1) % PlainTextBlockSize);
-            let minimum_padding = Self::minimum_padding(key_length);
-            let encrypt_size = 8 + body_size + signature_size + minimum_padding;
-            let padding_size = if encrypt_size % plain_text_block_size != 0 {
-                plain_text_block_size - (encrypt_size % plain_text_block_size)
-            } else {
-                0
-            };
-            trace!("sequence_header(8) + body({}) + signature ({}) = plain text size = {} / with padding {} = {}, plain_text_block_size = {}", body_size, signature_size, encrypt_size, padding_size, encrypt_size + padding_size, plain_text_block_size);
-            (minimum_padding + padding_size, minimum_padding)
-        } else {
-            (0, 0)
+        if key_length == 0 {
+            return (0, 0);
         }
+
+        // PaddingSize = PlainTextBlockSize – ((BytesToWrite + SignatureSize + 1) % PlainTextBlockSize);
+        let minimum_padding = Self::minimum_padding(key_length);
+        let encrypt_size = 8 + body_size + signature_size + minimum_padding;
+        let padding_size = if encrypt_size % plain_text_block_size != 0 {
+            plain_text_block_size - (encrypt_size % plain_text_block_size)
+        } else {
+            0
+        };
+        trace!("sequence_header(8) + body({}) + signature ({}) = plain text size = {} / with padding {} = {}, plain_text_block_size = {}", body_size, signature_size, encrypt_size, padding_size, encrypt_size + padding_size, plain_text_block_size);
+        (minimum_padding + padding_size, minimum_padding)
     }
 
     // Takes an unpadded message chunk and adds padding as well as space to the end to accomodate a signature.

--- a/opcua-core/src/comms/secure_channel.rs
+++ b/opcua-core/src/comms/secure_channel.rs
@@ -276,6 +276,11 @@ impl SecureChannel {
         self.encoding_context.read()
     }
 
+    /// Get a reference counted reference to the encoding context.
+    pub fn context_arc(&self) -> Arc<RwLock<ContextOwned>> {
+        self.encoding_context.clone()
+    }
+
     /// Set the namespace map.
     pub fn set_namespaces(&self, namespaces: NamespaceMap) {
         *self.encoding_context.write().namespaces_mut() = namespaces;

--- a/opcua-crypto/src/security_policy.rs
+++ b/opcua-crypto/src/security_policy.rs
@@ -353,7 +353,7 @@ impl SecurityPolicy {
 
     /// Signature size in bytes.
     ///
-    /// This will panic if the security policy is `Unknown` or `None`.
+    /// This will panic if the security policy is `Unknown`.
     pub fn symmetric_signature_size(&self) -> usize {
         match self {
             SecurityPolicy::None => 0,

--- a/opcua-types/src/impls.rs
+++ b/opcua-types/src/impls.rs
@@ -192,6 +192,26 @@ impl<'a> From<(u16, &'a str)> for ReadValueId {
     }
 }
 
+impl ReadValueId {
+    /// Create a new simple read value ID.
+    pub fn new(node_id: NodeId, attribute_id: AttributeId) -> Self {
+        Self {
+            node_id,
+            attribute_id: attribute_id as u32,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new read value ID for values.
+    pub fn new_value(node_id: NodeId) -> Self {
+        Self {
+            node_id,
+            attribute_id: AttributeId::Value as u32,
+            ..Default::default()
+        }
+    }
+}
+
 impl Default for AnonymousIdentityToken {
     fn default() -> Self {
         AnonymousIdentityToken {


### PR DESCRIPTION
Some tests for a few core services against the .NET server, and a better system for running tests.

Also fixes a pretty subtle bug in the chunker that would produce too large chunks. This code really could use some work, since I believe the data chunk size is constant for symmetric messages in a given channel, but it's fine.