### PR TITLE
Redo chunking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,20 +2,11 @@
 resolver = "2"
 members = [
     "lib",
-    "samples/demo-server",
-    "samples/simple-client",
-    "samples/mqtt-client",
-    "samples/simple-server",
-    "samples/chess-server",
-    "samples/discovery-client",
-    "samples/event-client",
+    "samples/*",
+    "opcua-*",
     "tools/certificate-creator",
-    "samples/async-server",
-    "opcua-codegen",
-    "opcua-macros",
-    "opcua-xml",
-    "opcua-types"
-, "opcua-crypto", "opcua-core", "opcua-client", "opcua-server", "opcua-nodes", "opcua-core-namespace", "samples/custom-codegen", "dotnet-tests/external-tests"]
+    "dotnet-tests/external-tests",
+]
 
 [workspace.dependencies]
 async-trait = "0.1.79"
@@ -46,14 +37,14 @@ url = "1.6"
 
 
 hmac = "0.12.1"
-sha2 = {version = "0.10.8", features = ["oid"]}
-sha1 = {version = "0.10.6", features = ["oid"]}
-cbc  = "0.1.2"
-aes  = "0.8.4"
-rsa = {version = "0.9.6", features = ["sha2","sha1","pem"]}
+sha2 = { version = "0.10.8", features = ["oid"] }
+sha1 = { version = "0.10.6", features = ["oid"] }
+cbc = "0.1.2"
+aes = "0.8.4"
+rsa = { version = "0.9.6", features = ["sha2", "sha1", "pem"] }
 rand = "0.8.5"
-x509-cert = {version="0.2.5",features=["builder","hazmat"]}
-const-oid = {version="0.9.3",features=["db"]}
+x509-cert = { version = "0.2.5", features = ["builder", "hazmat"] }
+const-oid = { version = "0.9.3", features = ["db"] }
 
 
 # Compile the crypto dependencies in release even in debug, to make test performance tolerable

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 This is a list of things that are known to be missing, or ideas that could be implemented. Feel free to pick up any of these if you wish to contribute.
 
- - Optimize the `Chunker`. It currently allocates too much, and it has some other inefficiencies.
  - Flesh out the server and client SDK with tooling for ease if use.
    - Make it even easier to implement custom node managers.
    - Write a generic `Browser` for the client, to make it easier to recursively browse node hierarchies. This should be made super flexible, perhaps a trait based approach where the browser is generic over something that handles the response from a browse request and returns what nodes to browse next...

--- a/opcua-codegen/src/types/gen.rs
+++ b/opcua-codegen/src/types/gen.rs
@@ -324,7 +324,7 @@ impl CodeGenerator {
                     #size
                 }
 
-                fn encode<S: std::io::Write + ?Sized>(&self, stream: &mut S, _ctx: &opcua::types::Context<'_>) -> opcua::types::EncodingResult<usize> {
+                fn encode<S: std::io::Write + ?Sized>(&self, stream: &mut S, _ctx: &opcua::types::Context<'_>) -> opcua::types::EncodingResult<()> {
                     opcua::types::#write_method(stream, self.bits())
                 }
             }
@@ -616,7 +616,7 @@ impl CodeGenerator {
                     #size
                 }
 
-                fn encode<S: std::io::Write + ?Sized>(&self, stream: &mut S, _ctx: &opcua::types::Context<'_>) -> opcua::types::EncodingResult<usize> {
+                fn encode<S: std::io::Write + ?Sized>(&self, stream: &mut S, _ctx: &opcua::types::Context<'_>) -> opcua::types::EncodingResult<()> {
                     opcua::types::#write_method(stream, *self as #ty)
                 }
             }

--- a/opcua-core/src/comms/buffer.rs
+++ b/opcua-core/src/comms/buffer.rs
@@ -84,8 +84,14 @@ impl SendBuffer {
         trace!("Sending chunk {:?}", next_chunk);
         let size = match next_chunk {
             PendingPayload::Chunk(c) => secure_channel.apply_security(&c, self.buffer.get_mut())?,
-            PendingPayload::Ack(a) => a.encode(&mut self.buffer)?,
-            PendingPayload::Error(e) => e.encode(&mut self.buffer)?,
+            PendingPayload::Ack(a) => {
+                a.encode(&mut self.buffer)?;
+                self.buffer.position() as usize
+            }
+            PendingPayload::Error(e) => {
+                e.encode(&mut self.buffer)?;
+                self.buffer.position() as usize
+            }
         };
         self.buffer.set_position(0);
         self.state = SendBufferState::Reading(size);

--- a/opcua-core/src/comms/chunker.rs
+++ b/opcua-core/src/comms/chunker.rs
@@ -4,7 +4,7 @@
 
 //! Contains code for turning messages into chunks and chunks into messages.
 
-use std::io::{Cursor, Read, Write};
+use std::io::{Read, Write};
 
 use crate::{
     comms::{
@@ -17,9 +17,11 @@ use crate::{
 use log::{debug, error, trace};
 use opcua_crypto::SecurityPolicy;
 use opcua_types::{
-    encoding::BinaryEncodable, node_id::NodeId, status_code::StatusCode, BinaryDecodable, Error,
-    ObjectId,
+    encoding::BinaryEncodable, node_id::NodeId, status_code::StatusCode, BinaryDecodable,
+    EncodingResult, Error, ObjectId,
 };
+
+use super::message_chunk::MessageChunkType;
 
 /// Read implementation for a sequence of message chunks.
 /// This lets us avoid allocating a buffer for the message.
@@ -96,6 +98,162 @@ impl<'a, T: Iterator<Item = &'a MessageChunk>> Read for ReceiveStream<'a, T> {
         let written = buf.write(&self.buffer[self.pos..])?;
         self.pos += written;
         Ok(written)
+    }
+}
+
+struct ChunkingStream<'a> {
+    secure_channel: &'a SecureChannel,
+    chunks: Vec<MessageChunk>,
+    expected_chunk_count: usize,
+    max_body_per_chunk: usize,
+    next_buf: Vec<u8>,
+    buf_position: usize,
+    is_closed: bool,
+    sequence_number: u32,
+    request_id: u32,
+    message_size: usize,
+    message_type: MessageChunkType,
+}
+
+impl<'a> ChunkingStream<'a> {
+    pub fn new(
+        message_type: MessageChunkType,
+        secure_channel: &'a SecureChannel,
+        max_chunk_size: usize,
+        message_size: usize,
+        request_id: u32,
+        request_handle: u32,
+        sequence_number: u32,
+    ) -> Result<Self, Error> {
+        if max_chunk_size > 0 {
+            let max_body_per_chunk = MessageChunk::body_size_from_message_size(
+                message_type,
+                secure_channel,
+                max_chunk_size,
+            )
+            .map_err(|_| {
+                Error::new(
+                    StatusCode::BadTcpInternalError,
+                    format!(
+                        "body_size_from_message_size error for max_chunk_size = {}",
+                        max_chunk_size
+                    ),
+                )
+                .with_context(
+                    Some(request_id),
+                    if request_handle > 0 {
+                        Some(request_handle)
+                    } else {
+                        None
+                    },
+                )
+            })?;
+            let expected_chunk_count = message_size / max_body_per_chunk + 1;
+            let next_buf_size = if expected_chunk_count == 1 {
+                message_size
+            } else {
+                max_body_per_chunk
+            };
+
+            Ok(Self {
+                secure_channel,
+                chunks: Vec::with_capacity(expected_chunk_count),
+                expected_chunk_count,
+                max_body_per_chunk,
+                next_buf: vec![0; next_buf_size],
+                buf_position: 0,
+                is_closed: false,
+                sequence_number,
+                request_id,
+                message_type,
+                message_size,
+            })
+        } else {
+            let expected_chunk_count = 1;
+            let max_body_per_chunk = 0;
+            let next_buf_size = message_size;
+            Ok(Self {
+                secure_channel,
+                chunks: Vec::with_capacity(expected_chunk_count),
+                expected_chunk_count,
+                max_body_per_chunk,
+                next_buf: vec![0; next_buf_size],
+                buf_position: 0,
+                is_closed: false,
+                sequence_number,
+                request_id,
+                message_type,
+                message_size,
+            })
+        }
+    }
+
+    fn flush_chunk(&mut self) -> EncodingResult<()> {
+        if self.is_closed {
+            return Ok(());
+        }
+
+        let buf = std::mem::take(&mut self.next_buf);
+        let is_final = if self.chunks.len() == self.expected_chunk_count - 1 {
+            self.is_closed = true;
+            MessageIsFinalType::Final
+        } else {
+            MessageIsFinalType::Intermediate
+        };
+
+        let chunk = MessageChunk::new(
+            self.sequence_number + self.chunks.len() as u32,
+            self.request_id,
+            self.message_type,
+            is_final,
+            self.secure_channel,
+            &buf,
+        )?;
+        self.chunks.push(chunk);
+
+        if !self.is_closed {
+            let next_buf_size = if self.chunks.len() == self.expected_chunk_count - 1 {
+                self.message_size % self.max_body_per_chunk
+            } else {
+                self.max_body_per_chunk
+            };
+            self.next_buf = vec![0; next_buf_size];
+            self.buf_position = 0;
+        }
+
+        Ok(())
+    }
+
+    fn finish(self) -> EncodingResult<Vec<MessageChunk>> {
+        if !self.is_closed {
+            return Err(Error::encoding(
+                "Message did not encode to the expected size",
+            ));
+        }
+        Ok(self.chunks)
+    }
+}
+
+impl<'a> Write for ChunkingStream<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if self.is_closed {
+            return Ok(0);
+        }
+
+        let to_read = buf.len().min(self.next_buf.len() - self.buf_position);
+        self.next_buf[self.buf_position..(self.buf_position + to_read)]
+            .copy_from_slice(&buf[..to_read]);
+        self.buf_position += to_read;
+        if self.buf_position == self.next_buf.len() {
+            self.flush_chunk()?;
+        }
+
+        Ok(to_read)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.flush_chunk()?;
+        Ok(())
     }
 }
 
@@ -210,7 +368,7 @@ impl Chunker {
                 max_message_size, message_size
             );
             // Client stack should report a BadRequestTooLarge, server BadResponseTooLarge
-            Err(Error::new(
+            return Err(Error::new(
                 if secure_channel.is_client_role() {
                     StatusCode::BadRequestTooLarge
                 } else {
@@ -221,78 +379,32 @@ impl Chunker {
                     max_message_size, message_size
                 ),
             )
-            .with_context(ctx_id, ctx_handle))
-        } else {
-            let node_id = supported_message.type_id();
-            message_size += node_id.byte_len(&ctx);
-
-            let message_type = supported_message.message_type();
-            let mut stream = Cursor::new(vec![0u8; message_size]);
-
-            trace!("Encoding node id {:?}", node_id);
-            let _ = node_id.encode(&mut stream, &ctx);
-            let _ = supported_message
-                .encode(&mut stream, &ctx)
-                .map_err(|e| e.with_context(ctx_id, ctx_handle))?;
-            let data = stream.into_inner();
-
-            let result = if max_chunk_size > 0 {
-                let max_body_per_chunk = MessageChunk::body_size_from_message_size(
-                    message_type,
-                    secure_channel,
-                    max_chunk_size,
-                )
-                .map_err(|_| {
-                    Error::new(
-                        StatusCode::BadTcpInternalError,
-                        format!(
-                            "body_size_from_message_size error for max_chunk_size = {}",
-                            max_chunk_size
-                        ),
-                    )
-                    .with_context(ctx_id, ctx_handle)
-                })?;
-
-                // Multiple chunks means breaking the data up into sections. Fortunately
-                // Rust has a nice function to do just that.
-                let data_chunks = data.chunks(max_body_per_chunk);
-                let data_chunks_len = data_chunks.len();
-                trace!(
-                    "Split message into {} chunks of {} length max",
-                    data_chunks_len,
-                    max_body_per_chunk
-                );
-                let mut chunks = Vec::with_capacity(data_chunks_len);
-                for (i, data_chunk) in data_chunks.enumerate() {
-                    let is_final = if i == data_chunks_len - 1 {
-                        MessageIsFinalType::Final
-                    } else {
-                        MessageIsFinalType::Intermediate
-                    };
-                    let chunk = MessageChunk::new(
-                        sequence_number + i as u32,
-                        request_id,
-                        message_type,
-                        is_final,
-                        secure_channel,
-                        data_chunk,
-                    )?;
-                    chunks.push(chunk);
-                }
-                chunks
-            } else {
-                let chunk = MessageChunk::new(
-                    sequence_number,
-                    request_id,
-                    message_type,
-                    MessageIsFinalType::Final,
-                    secure_channel,
-                    &data,
-                )?;
-                vec![chunk]
-            };
-            Ok(result)
+            .with_context(ctx_id, ctx_handle));
         }
+
+        let node_id = supported_message.type_id();
+        message_size += node_id.byte_len(&ctx);
+
+        let message_type = supported_message.message_type();
+
+        let mut stream = ChunkingStream::new(
+            message_type,
+            secure_channel,
+            max_chunk_size,
+            message_size,
+            request_id,
+            handle,
+            sequence_number,
+        )?;
+
+        node_id.encode(&mut stream, &ctx)?;
+        supported_message
+            .encode(&mut stream, &ctx)
+            .map_err(|e| e.with_context(ctx_id, ctx_handle))?;
+
+        stream.flush()?;
+
+        stream.finish()
     }
 
     /// Decodes a series of chunks to create a message. The message must be of a `SupportedMessage`

--- a/opcua-core/src/comms/chunker.rs
+++ b/opcua-core/src/comms/chunker.rs
@@ -234,7 +234,7 @@ impl<'a> ChunkingStream<'a> {
     }
 }
 
-impl<'a> Write for ChunkingStream<'a> {
+impl Write for ChunkingStream<'_> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if self.is_closed {
             return Ok(0);

--- a/opcua-core/src/comms/message_chunk.rs
+++ b/opcua-core/src/comms/message_chunk.rs
@@ -254,7 +254,7 @@ impl MessageChunk {
         // write sequence header
         sequence_header.encode(&mut stream)?;
         // write message
-        stream.write(data)?;
+        stream.write_all(data)?;
 
         Ok(MessageChunk { data: buf })
     }

--- a/opcua-core/src/comms/secure_channel.rs
+++ b/opcua-core/src/comms/secure_channel.rs
@@ -900,7 +900,7 @@ impl SecureChannel {
 
         // Sign the message header, security header, sequence header, body, padding
         let (l, r) = src.split_at_mut(signed_range.end);
-        security_policy.asymmetric_sign(signing_key, &l, &mut r[0..signing_key_size])?;
+        security_policy.asymmetric_sign(signing_key, l, &mut r[0..signing_key_size])?;
 
         // tmp[signature_range.clone()].copy_from_slice(&signature);
         assert_eq!(encrypted_range.end, signature_range.end);

--- a/opcua-core/src/comms/secure_channel.rs
+++ b/opcua-core/src/comms/secure_channel.rs
@@ -12,6 +12,7 @@ use std::{
     time::Instant,
 };
 
+use bytes::Buf;
 use chrono::Duration;
 use log::{error, trace};
 
@@ -23,14 +24,14 @@ use opcua_crypto::{
     CertificateStore, SecurityPolicy,
 };
 use opcua_types::{
-    status_code::StatusCode, write_bytes, write_u8, ByteString, ChannelSecurityToken, ContextOwned,
-    DateTime, DecodingOptions, Error, MessageSecurityMode, NamespaceMap, SimpleBinaryDecodable,
-    SimpleBinaryEncodable,
+    status_code::StatusCode, write_bytes, write_u32, write_u8, ByteString, ChannelSecurityToken,
+    ContextOwned, DateTime, DecodingOptions, Error, MessageSecurityMode, NamespaceMap,
+    SimpleBinaryDecodable,
 };
 use parking_lot::RwLock;
 
 use super::{
-    message_chunk::{MessageChunk, MessageChunkHeader, MessageChunkType},
+    message_chunk::{MessageChunk, MessageChunkHeader, MessageChunkType, MESSAGE_SIZE_OFFSET},
     security_header::{AsymmetricSecurityHeader, SecurityHeader, SymmetricSecurityHeader},
 };
 
@@ -569,12 +570,6 @@ impl SecureChannel {
 
         let security_header = chunk_info.security_header;
 
-        let buffer = Vec::with_capacity(message_chunk.data.len() + 4096);
-        let mut stream = Cursor::new(buffer);
-
-        // First off just write out the src to the buffer. The message header, security header, sequence header and payload
-        let _ = stream.write(data);
-
         // Signature size (if required)
         let signature_size = self.signature_size(&security_header);
 
@@ -587,6 +582,13 @@ impl SecureChannel {
             signature_size,
             chunk_info.message_header.message_type,
         );
+
+        let buffer = Vec::with_capacity(message_chunk.data.len() + padding_size + signature_size);
+        let mut stream = Cursor::new(buffer);
+
+        // First off just write out the src to the buffer. The message header, security header, sequence header and payload
+        stream.write(data)?;
+
         if padding_size > 0 {
             // A number of bytes are written out equal to the padding size.
             // Each byte is the padding size. So if padding size is 15 then
@@ -613,40 +615,22 @@ impl SecureChannel {
 
         // Update message header to reflect size with padding + signature
         let message_size = data.len() + padding_size + signature_size;
-        Self::update_message_size_and_truncate(
-            stream.into_inner(),
-            message_size,
-            &self.decoding_options(),
-        )
+        Self::update_message_size_and_truncate(stream.into_inner(), message_size)
     }
 
-    fn update_message_size(
-        data: &mut [u8],
-        message_size: usize,
-        decoding_options: &DecodingOptions,
-    ) -> Result<(), Error> {
+    fn update_message_size(data: &mut [u8], message_size: usize) -> Result<(), Error> {
         // Read and rewrite the message_size in the header
         let mut stream = Cursor::new(data);
-        let mut message_header = MessageChunkHeader::decode(&mut stream, decoding_options)?;
-        stream.set_position(0);
-        let old_message_size = message_header.message_size;
-        message_header.message_size = message_size as u32;
-        message_header.encode(&mut stream)?;
-        trace!(
-            "Message header message size being modified from {} to {}",
-            old_message_size,
-            message_size
-        );
-        Ok(())
+        stream.advance(MESSAGE_SIZE_OFFSET);
+        write_u32(&mut stream, message_size as u32)
     }
 
     /// Writes message size and truncates the message to fit.
     pub fn update_message_size_and_truncate(
         mut data: Vec<u8>,
         message_size: usize,
-        decoding_options: &DecodingOptions,
     ) -> Result<Vec<u8>, Error> {
-        Self::update_message_size(&mut data[..], message_size, decoding_options)?;
+        Self::update_message_size(&mut data[..], message_size)?;
         // Truncate vector to the size
         data.truncate(message_size);
         Ok(data)
@@ -666,7 +650,8 @@ impl SecureChannel {
             && (self.security_mode == MessageSecurityMode::Sign
                 || self.security_mode == MessageSecurityMode::SignAndEncrypt)
         {
-            let chunk_info = message_chunk.chunk_info(self)?;
+            let encrypted_data_offset =
+                message_chunk.encrypted_data_offset(&self.decoding_options())?;
 
             // S - Message Header
             // S - Security Header
@@ -675,21 +660,26 @@ impl SecureChannel {
             // S - Padding         - E
             //     Signature       - E
 
-            let data = self.add_space_for_padding_and_signature(message_chunk)?;
+            let mut data = self.add_space_for_padding_and_signature(message_chunk)?;
             Self::log_crypto_data("Chunk before padding", &message_chunk.data[..]);
             Self::log_crypto_data("Chunk after padding", &data[..]);
 
             // Encrypted range is from the sequence header to the end
-            let encrypted_range = chunk_info.sequence_header_offset..data.len();
+            let encrypted_range = encrypted_data_offset..data.len();
 
             // Encrypt and sign - open secure channel
             let encrypted_size = if message_chunk.is_open_secure_channel(&self.decoding_options()) {
-                self.asymmetric_sign_and_encrypt(self.security_policy, &data, encrypted_range, dst)?
+                self.asymmetric_sign_and_encrypt(
+                    self.security_policy,
+                    &mut data,
+                    encrypted_range,
+                    dst,
+                )?
             } else {
                 // Symmetric encrypt and sign
                 let signed_range =
                     0..(data.len() - self.security_policy.symmetric_signature_size());
-                self.symmetric_sign_and_encrypt(&data, signed_range, encrypted_range, dst)?
+                self.symmetric_sign_and_encrypt(&mut data, signed_range, encrypted_range, dst)?
             };
 
             Self::log_crypto_data("Chunk after encryption", &dst[..encrypted_size]);
@@ -726,17 +716,11 @@ impl SecureChannel {
         let (message_header, security_header, encrypted_data_offset) = {
             let mut stream = Cursor::new(&src);
             let message_header = MessageChunkHeader::decode(&mut stream, &decoding_options)?;
-            let security_header = if message_header.message_type.is_open_secure_channel() {
-                SecurityHeader::Asymmetric(AsymmetricSecurityHeader::decode(
-                    &mut stream,
-                    &decoding_options,
-                )?)
-            } else {
-                SecurityHeader::Symmetric(SymmetricSecurityHeader::decode(
-                    &mut stream,
-                    &decoding_options,
-                )?)
-            };
+            let security_header = SecurityHeader::decode_from_stream(
+                &mut stream,
+                message_header.message_type.is_open_secure_channel(),
+                &decoding_options,
+            )?;
             let encrypted_data_offset = stream.position() as usize;
             (message_header, security_header, encrypted_data_offset)
         };
@@ -833,11 +817,7 @@ impl SecureChannel {
                 &mut decrypted_data,
             )?;
 
-            Self::update_message_size_and_truncate(
-                decrypted_data,
-                decrypted_size,
-                &decoding_options,
-            )?
+            Self::update_message_size_and_truncate(decrypted_data, decrypted_size)?
         } else if self.security_policy != SecurityPolicy::None
             && (self.security_mode == MessageSecurityMode::Sign
                 || self.security_mode == MessageSecurityMode::SignAndEncrypt)
@@ -872,11 +852,7 @@ impl SecureChannel {
             )?;
 
             // Value returned from symmetric_decrypt_and_verify is the end of the actual decrypted data.
-            Self::update_message_size_and_truncate(
-                decrypted_data,
-                decrypted_size,
-                &decoding_options,
-            )?
+            Self::update_message_size_and_truncate(decrypted_data, decrypted_size)?
         } else {
             src.to_vec()
         };
@@ -884,11 +860,12 @@ impl SecureChannel {
         Ok(MessageChunk { data })
     }
 
-    /// Use the security policy to asymmetric encrypt and sign the specified chunk of data
+    /// Use the security policy to asymmetric encrypt and sign the specified chunk of data.
+    /// Signs the source data in place.
     fn asymmetric_sign_and_encrypt(
         &self,
         security_policy: SecurityPolicy,
-        src: &[u8],
+        src: &mut [u8],
         encrypted_range: Range<usize>,
         dst: &mut [u8],
     ) -> Result<usize, StatusCode> {
@@ -902,11 +879,7 @@ impl SecureChannel {
 
         trace!("Header size = {}, Encrypted range = {:?}, Signed range = {:?}, Signature range = {:?}, signature size = {}", header_size, encrypted_range, signed_range, signature_range, signing_key_size);
 
-        let mut signature = vec![0u8; signing_key_size];
         let encryption_key = self.remote_cert.as_ref().unwrap().public_key()?;
-
-        let mut tmp = vec![0u8; encrypted_range.end];
-        tmp[signed_range.clone()].copy_from_slice(&src[signed_range.clone()]);
 
         // Encryption will change the size of the chunk. Since we sign before encrypting, we need to
         // compute that size and change the message header to be that new size
@@ -922,26 +895,22 @@ impl SecureChannel {
             );
             cipher_text_size
         };
-        Self::update_message_size(
-            &mut tmp[..],
-            header_size + cipher_text_size,
-            &self.decoding_options(),
-        )?;
+        Self::update_message_size(src, header_size + cipher_text_size)?;
+        dst[0..encrypted_range.start].copy_from_slice(&src[0..encrypted_range.start]);
 
         // Sign the message header, security header, sequence header, body, padding
-        security_policy.asymmetric_sign(signing_key, &tmp[signed_range], &mut signature)?;
-        tmp[signature_range.clone()].copy_from_slice(&signature);
+        let (l, r) = src.split_at_mut(signed_range.end);
+        security_policy.asymmetric_sign(signing_key, &l, &mut r[0..signing_key_size])?;
+
+        // tmp[signature_range.clone()].copy_from_slice(&signature);
         assert_eq!(encrypted_range.end, signature_range.end);
 
-        Self::log_crypto_data("Chunk after signing", &tmp[..signature_range.end]);
-
-        // Copy the unencrypted message header / security header portion to dst
-        dst[..encrypted_range.start].copy_from_slice(&tmp[..encrypted_range.start]);
+        Self::log_crypto_data("Chunk after signing", &dst[..signature_range.end]);
 
         // Encrypt the sequence header, payload, signature portion into dst
         let encrypted_size = security_policy.asymmetric_encrypt(
             &encryption_key,
-            &tmp[encrypted_range.clone()],
+            &src[encrypted_range.clone()],
             &mut dst[encrypted_range.start..],
         )?;
 
@@ -1240,7 +1209,7 @@ impl SecureChannel {
     ///     Signature       - E
     pub fn symmetric_sign_and_encrypt(
         &self,
-        src: &[u8],
+        src: &mut [u8],
         signed_range: Range<usize>,
         encrypted_range: Range<usize>,
         dst: &mut [u8],
@@ -1256,27 +1225,27 @@ impl SecureChannel {
             MessageSecurityMode::Sign => {
                 trace!("encrypt_and_sign security mode == Sign");
                 self.expect_supported_security_policy();
-                self.symmetric_sign(src, signed_range, dst)?
+                let size = self.symmetric_sign_in_place(src, signed_range)?;
+                dst[0..size].copy_from_slice(&src[0..size]);
+                size
             }
             MessageSecurityMode::SignAndEncrypt => {
                 trace!("encrypt_and_sign security mode == SignAndEncrypt, signed_range = {:?}, encrypted_range = {:?}", signed_range, encrypted_range);
                 self.expect_supported_security_policy();
 
-                let mut dst_tmp = vec![0u8; dst.len() + 16]; // tmp includes +16 for blocksize
-
                 // Sign the block
-                let _ = self.symmetric_sign(src, signed_range, &mut dst_tmp)?;
+                self.symmetric_sign_in_place(src, signed_range)?;
 
                 // Encrypt the sequence header, payload, signature
                 let (key, iv) = self.encryption_keys();
                 let encrypted_size = self.security_policy.symmetric_encrypt(
                     key,
                     iv,
-                    &dst_tmp[encrypted_range.clone()],
-                    &mut dst[encrypted_range.start..(encrypted_range.end + 16)],
+                    &src[encrypted_range.clone()],
+                    &mut dst[encrypted_range.start..],
                 )?;
                 // Copy the message header / security header
-                dst[..encrypted_range.start].copy_from_slice(&dst_tmp[..encrypted_range.start]);
+                dst[..encrypted_range.start].copy_from_slice(&src[..encrypted_range.start]);
 
                 encrypted_range.start + encrypted_size
             }
@@ -1287,37 +1256,25 @@ impl SecureChannel {
         Ok(encrypted_size)
     }
 
-    fn symmetric_sign(
+    fn symmetric_sign_in_place(
         &self,
-        src: &[u8],
+        buf: &mut [u8],
         signed_range: Range<usize>,
-        dst: &mut [u8],
     ) -> Result<usize, StatusCode> {
         let signature_size = self.security_policy.symmetric_signature_size();
-        let mut signature = vec![0u8; signature_size];
-        let signature_range = signed_range.end..(signed_range.end + signature_size);
         trace!(
-            "signed_range = {:?}, signature range = {:?}, signature len = {}",
+            "signed_range = {:?}, signature len = {}",
             signed_range,
-            signature_range,
             signature_size
         );
 
         // Sign the message header, security header, sequence header, body, padding
         let signing_key = self.signing_key();
-        self.security_policy.symmetric_sign(
-            signing_key,
-            &src[signed_range.clone()],
-            &mut signature,
-        )?;
+        let (l, r) = buf.split_at_mut(signed_range.end);
+        self.security_policy
+            .symmetric_sign(signing_key, l, &mut r[0..signature_size])?;
 
-        trace!("Signature, len {} = {:?}", signature.len(), signature);
-
-        // Copy the signed portion and the signature to the destination
-        dst[signed_range.clone()].copy_from_slice(&src[signed_range]);
-        dst[signature_range.clone()].copy_from_slice(&signature);
-
-        Ok(signature_range.end)
+        Ok(signed_range.end + signature_size)
     }
 
     /// Decrypts and verifies data.

--- a/opcua-core/src/comms/secure_channel.rs
+++ b/opcua-core/src/comms/secure_channel.rs
@@ -587,7 +587,7 @@ impl SecureChannel {
         let mut stream = Cursor::new(buffer);
 
         // First off just write out the src to the buffer. The message header, security header, sequence header and payload
-        stream.write(data)?;
+        stream.write_all(data)?;
 
         if padding_size > 0 {
             // A number of bytes are written out equal to the padding size.

--- a/opcua-core/src/comms/security_header.rs
+++ b/opcua-core/src/comms/security_header.rs
@@ -36,7 +36,7 @@ impl SimpleBinaryEncodable for SecurityHeader {
         }
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         match self {
             SecurityHeader::Asymmetric(value) => value.encode(stream),
             SecurityHeader::Symmetric(value) => value.encode(stream),
@@ -56,7 +56,7 @@ impl SimpleBinaryEncodable for SymmetricSecurityHeader {
         4
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         self.token_id.encode(stream)
     }
 }
@@ -91,13 +91,11 @@ impl SimpleBinaryEncodable for AsymmetricSecurityHeader {
         size
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
-        let mut size = 0;
-        size += self.security_policy_uri.encode(stream)?;
-        size += self.sender_certificate.encode(stream)?;
-        size += self.receiver_certificate_thumbprint.encode(stream)?;
-        assert_eq!(size, self.byte_len());
-        Ok(size)
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
+        self.security_policy_uri.encode(stream)?;
+        self.sender_certificate.encode(stream)?;
+        self.receiver_certificate_thumbprint.encode(stream)?;
+        Ok(())
     }
 }
 
@@ -198,11 +196,10 @@ impl SimpleBinaryEncodable for SequenceHeader {
         8
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
-        let mut size: usize = 0;
-        size += self.sequence_number.encode(stream)?;
-        size += self.request_id.encode(stream)?;
-        Ok(size)
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
+        self.sequence_number.encode(stream)?;
+        self.request_id.encode(stream)?;
+        Ok(())
     }
 }
 

--- a/opcua-core/src/comms/security_header.rs
+++ b/opcua-core/src/comms/security_header.rs
@@ -53,7 +53,7 @@ impl SecurityHeader {
         decoding_options: &DecodingOptions,
     ) -> EncodingResult<Self> {
         if is_open_secure_channel {
-            let security_header = AsymmetricSecurityHeader::decode(stream, &decoding_options)?;
+            let security_header = AsymmetricSecurityHeader::decode(stream, decoding_options)?;
 
             let security_policy = if security_header.security_policy_uri.is_null() {
                 SecurityPolicy::None
@@ -73,7 +73,7 @@ impl SecurityHeader {
 
             Ok(SecurityHeader::Asymmetric(security_header))
         } else {
-            let security_header = SymmetricSecurityHeader::decode(stream, &decoding_options)?;
+            let security_header = SymmetricSecurityHeader::decode(stream, decoding_options)?;
             Ok(SecurityHeader::Symmetric(security_header))
         }
     }

--- a/opcua-core/src/comms/tcp_types.rs
+++ b/opcua-core/src/comms/tcp_types.rs
@@ -133,7 +133,7 @@ impl MessageHeader {
 
         // Write header to stream
         let mut out = Cursor::new(Vec::with_capacity(message_size as usize));
-        let result = out.write(&header);
+        let result = out.write_all(&header);
         if result.is_err() {
             return Err(Error::new(
                 ErrorKind::Other,

--- a/opcua-core/src/comms/tcp_types.rs
+++ b/opcua-core/src/comms/tcp_types.rs
@@ -70,12 +70,11 @@ impl SimpleBinaryEncodable for MessageHeader {
         MESSAGE_HEADER_LEN
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
-        let mut size: usize = 0;
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         let result = match self.message_type {
-            MessageType::Hello => stream.write(HELLO_MESSAGE),
-            MessageType::Acknowledge => stream.write(ACKNOWLEDGE_MESSAGE),
-            MessageType::Error => stream.write(ERROR_MESSAGE),
+            MessageType::Hello => stream.write_all(HELLO_MESSAGE),
+            MessageType::Acknowledge => stream.write_all(ACKNOWLEDGE_MESSAGE),
+            MessageType::Error => stream.write_all(ERROR_MESSAGE),
             MessageType::Chunk => {
                 panic!("Don't write chunks to stream with this call, use Chunk and Chunker");
             }
@@ -83,10 +82,10 @@ impl SimpleBinaryEncodable for MessageHeader {
                 panic!("Unrecognized type");
             }
         };
-        size += process_encode_io_result(result)?;
-        size += write_u8(stream, b'F')?;
-        size += write_u32(stream, self.message_size)?;
-        Ok(size)
+        process_encode_io_result(result)?;
+        write_u8(stream, b'F')?;
+        write_u32(stream, self.message_size)?;
+        Ok(())
     }
 }
 
@@ -218,16 +217,14 @@ impl SimpleBinaryEncodable for HelloMessage {
         self.message_header.byte_len() + 20 + self.endpoint_url.byte_len()
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
-        let mut size = 0;
-        size += self.message_header.encode(stream)?;
-        size += self.protocol_version.encode(stream)?;
-        size += self.receive_buffer_size.encode(stream)?;
-        size += self.send_buffer_size.encode(stream)?;
-        size += self.max_message_size.encode(stream)?;
-        size += self.max_chunk_count.encode(stream)?;
-        size += self.endpoint_url.encode(stream)?;
-        Ok(size)
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
+        self.message_header.encode(stream)?;
+        self.protocol_version.encode(stream)?;
+        self.receive_buffer_size.encode(stream)?;
+        self.send_buffer_size.encode(stream)?;
+        self.max_message_size.encode(stream)?;
+        self.max_chunk_count.encode(stream)?;
+        self.endpoint_url.encode(stream)
     }
 }
 
@@ -339,15 +336,13 @@ impl SimpleBinaryEncodable for AcknowledgeMessage {
         self.message_header.byte_len() + 20
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
-        let mut size: usize = 0;
-        size += self.message_header.encode(stream)?;
-        size += self.protocol_version.encode(stream)?;
-        size += self.receive_buffer_size.encode(stream)?;
-        size += self.send_buffer_size.encode(stream)?;
-        size += self.max_message_size.encode(stream)?;
-        size += self.max_chunk_count.encode(stream)?;
-        Ok(size)
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
+        self.message_header.encode(stream)?;
+        self.protocol_version.encode(stream)?;
+        self.receive_buffer_size.encode(stream)?;
+        self.send_buffer_size.encode(stream)?;
+        self.max_message_size.encode(stream)?;
+        self.max_chunk_count.encode(stream)
     }
 }
 
@@ -410,12 +405,10 @@ impl SimpleBinaryEncodable for ErrorMessage {
         self.message_header.byte_len() + self.error.byte_len() + self.reason.byte_len()
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
-        let mut size: usize = 0;
-        size += self.message_header.encode(stream)?;
-        size += self.error.encode(stream)?;
-        size += self.reason.encode(stream)?;
-        Ok(size)
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
+        self.message_header.encode(stream)?;
+        self.error.encode(stream)?;
+        self.reason.encode(stream)
     }
 }
 

--- a/opcua-core/src/messages/request.rs
+++ b/opcua-core/src/messages/request.rs
@@ -28,7 +28,7 @@ macro_rules! request_enum {
                 }
             }
 
-            fn encode<S: Write + ?Sized>(&self, stream: &mut S, ctx: &opcua_types::Context<'_>) -> EncodingResult<usize> {
+            fn encode<S: Write + ?Sized>(&self, stream: &mut S, ctx: &opcua_types::Context<'_>) -> EncodingResult<()> {
                 match self {
                     $( Self::$name(value) => value.encode(stream, ctx), )*
                 }

--- a/opcua-core/src/messages/response.rs
+++ b/opcua-core/src/messages/response.rs
@@ -28,7 +28,7 @@ macro_rules! response_enum {
                 }
             }
 
-            fn encode<S: Write + ?Sized>(&self, stream: &mut S, ctx: &opcua_types::Context<'_>) -> EncodingResult<usize> {
+            fn encode<S: Write + ?Sized>(&self, stream: &mut S, ctx: &opcua_types::Context<'_>) -> EncodingResult<()> {
                 match self {
                     $( Self::$name(value) => value.encode(stream, ctx), )*
                 }

--- a/opcua-core/src/tests/chunk.rs
+++ b/opcua-core/src/tests/chunk.rs
@@ -477,11 +477,11 @@ fn security_policy_symmetric_encrypt_decrypt() {
         SecurityPolicy::Basic128Rsa15,
     );
 
-    let src = vec![0u8; 100];
+    let mut src = vec![0u8; 100];
     let mut dst = vec![0u8; 200];
 
     let encrypted_len = secure_channel1
-        .symmetric_sign_and_encrypt(&src, 0..80, 20..100, &mut dst)
+        .symmetric_sign_and_encrypt(&mut src, 0..80, 20..100, &mut dst)
         .unwrap();
     assert_eq!(encrypted_len, 100);
 

--- a/opcua-core/src/tests/chunk.rs
+++ b/opcua-core/src/tests/chunk.rs
@@ -36,7 +36,7 @@ fn sample_secure_channel_request_data_security_none() -> MessageChunk {
         secure_channel_id: 1,
     }
     .encode(&mut stream, &ctx);
-    let _ = stream.write(&sample_data);
+    stream.write_all(&sample_data).unwrap();
 
     // Decode chunk from stream
     stream.set_position(0);

--- a/opcua-core/src/tests/mod.rs
+++ b/opcua-core/src/tests/mod.rs
@@ -28,12 +28,8 @@ where
 
     // Encode to stream
     let start_pos = stream.position();
-    let result = value.encode(&mut stream, &ctx);
+    value.encode(&mut stream, &ctx).expect("Encoding failed");
     let end_pos = stream.position();
-    assert!(result.is_ok());
-
-    // This ensures the size reported is the same as the byte length impl
-    assert_eq!(result.unwrap(), byte_len);
 
     // Test that the position matches the byte_len
     assert_eq!((end_pos - start_pos) as usize, byte_len);

--- a/opcua-macros/src/binary/gen.rs
+++ b/opcua-macros/src/binary/gen.rs
@@ -24,7 +24,7 @@ pub fn generate_binary_encode_impl(strct: BinaryStruct) -> syn::Result<TokenStre
             size += self.#ident.byte_len(ctx);
         });
         encode_body.extend(quote! {
-            size += self.#ident.encode(stream, ctx)?;
+            self.#ident.encode(stream, ctx)?;
         });
     }
     let ident = strct.ident;
@@ -42,10 +42,9 @@ pub fn generate_binary_encode_impl(strct: BinaryStruct) -> syn::Result<TokenStre
                 &self,
                 stream: &mut S,
                 ctx: &opcua::types::Context<'_>,
-            ) -> opcua::types::EncodingResult<usize> {
-                let mut size = 0usize;
+            ) -> opcua::types::EncodingResult<()> {
                 #encode_body
-                Ok(size)
+                Ok(())
             }
         }
     })

--- a/opcua-types/src/argument.rs
+++ b/opcua-types/src/argument.rs
@@ -74,15 +74,10 @@ impl BinaryEncodable for Argument {
         size
     }
 
-    fn encode<S: Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        ctx: &Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size = 0;
-        size += self.name.encode(stream, ctx)?;
-        size += self.data_type.encode(stream, ctx)?;
-        size += self.value_rank.encode(stream, ctx)?;
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S, ctx: &Context<'_>) -> EncodingResult<()> {
+        self.name.encode(stream, ctx)?;
+        self.data_type.encode(stream, ctx)?;
+        self.value_rank.encode(stream, ctx)?;
         // Encode the array dimensions
         if self.value_rank > 0 {
             if let Some(ref array_dimensions) = self.array_dimensions {
@@ -90,16 +85,16 @@ impl BinaryEncodable for Argument {
                     return Err(Error::encoding(
                         format!("The array dimensions {} of the Argument should match value rank {} and they don't", array_dimensions.len(), self.value_rank)));
                 }
-                size += self.array_dimensions.encode(stream, ctx)?;
+                self.array_dimensions.encode(stream, ctx)?;
             } else {
                 return Err(Error::encoding(format!("The array dimensions are expected in the Argument matching value rank {} and they aren't", self.value_rank)));
             }
         } else {
-            size += write_u32(stream, 0u32)?;
+            write_u32(stream, 0u32)?;
         }
 
-        size += self.description.encode(stream, ctx)?;
-        Ok(size)
+        self.description.encode(stream, ctx)?;
+        Ok(())
     }
 }
 

--- a/opcua-types/src/basic_types.rs
+++ b/opcua-types/src/basic_types.rs
@@ -28,7 +28,7 @@ impl SimpleBinaryEncodable for bool {
         1
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         // 0, or 1 for true or false, single byte
         write_u8(stream, if *self { 1 } else { 0 })
     }
@@ -48,7 +48,7 @@ impl SimpleBinaryEncodable for i8 {
         1
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_u8(stream, *self as u8)
     }
 }
@@ -68,7 +68,7 @@ impl SimpleBinaryEncodable for u8 {
         1
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_u8(stream, *self)
     }
 }
@@ -88,7 +88,7 @@ impl SimpleBinaryEncodable for i16 {
         2
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_i16(stream, *self)
     }
 }
@@ -108,7 +108,7 @@ impl SimpleBinaryEncodable for u16 {
         2
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_u16(stream, *self)
     }
 }
@@ -128,7 +128,7 @@ impl SimpleBinaryEncodable for i32 {
         4
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_i32(stream, *self)
     }
 }
@@ -148,7 +148,7 @@ impl SimpleBinaryEncodable for u32 {
         4
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_u32(stream, *self)
     }
 }
@@ -167,7 +167,7 @@ impl SimpleBinaryEncodable for i64 {
         8
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_i64(stream, *self)
     }
 }
@@ -187,7 +187,7 @@ impl SimpleBinaryEncodable for u64 {
         8
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_u64(stream, *self)
     }
 }
@@ -207,7 +207,7 @@ impl SimpleBinaryEncodable for f32 {
         4
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_f32(stream, *self)
     }
 }
@@ -227,7 +227,7 @@ impl SimpleBinaryEncodable for f64 {
         8
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_f64(stream, *self)
     }
 }

--- a/opcua-types/src/byte_string.rs
+++ b/opcua-types/src/byte_string.rs
@@ -83,16 +83,14 @@ impl SimpleBinaryEncodable for ByteString {
         }
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         // Strings are uncoded as UTF8 chars preceded by an Int32 length. A -1 indicates a null string
         if self.value.is_none() {
             write_i32(stream, -1)
         } else {
-            let mut size: usize = 0;
             let value = self.value.as_ref().unwrap();
-            size += write_i32(stream, value.len() as i32)?;
-            size += process_encode_io_result(stream.write(value))?;
-            Ok(size)
+            write_i32(stream, value.len() as i32)?;
+            process_encode_io_result(stream.write_all(value))
         }
     }
 }

--- a/opcua-types/src/data_value.rs
+++ b/opcua-types/src/data_value.rs
@@ -91,51 +91,41 @@ impl BinaryEncodable for DataValue {
         size
     }
 
-    fn encode<S: Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        ctx: &Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size = 0;
-
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S, ctx: &Context<'_>) -> EncodingResult<()> {
         let encoding_mask = self.encoding_mask();
-        size += encoding_mask.bits().encode(stream, ctx)?;
+        encoding_mask.bits().encode(stream, ctx)?;
 
         if encoding_mask.contains(DataValueFlags::HAS_VALUE) {
-            size += self.value.as_ref().unwrap().encode(stream, ctx)?;
+            self.value.as_ref().unwrap().encode(stream, ctx)?;
         }
         if encoding_mask.contains(DataValueFlags::HAS_STATUS) {
-            size += self.status.as_ref().unwrap().bits().encode(stream, ctx)?;
+            self.status.as_ref().unwrap().bits().encode(stream, ctx)?;
         }
         if encoding_mask.contains(DataValueFlags::HAS_SOURCE_TIMESTAMP) {
-            size += self
-                .source_timestamp
+            self.source_timestamp
                 .as_ref()
                 .unwrap()
                 .encode(stream, ctx)?;
             if encoding_mask.contains(DataValueFlags::HAS_SOURCE_PICOSECONDS) {
-                size += self
-                    .source_picoseconds
+                self.source_picoseconds
                     .as_ref()
                     .unwrap()
                     .encode(stream, ctx)?;
             }
         }
         if encoding_mask.contains(DataValueFlags::HAS_SERVER_TIMESTAMP) {
-            size += self
-                .server_timestamp
+            self.server_timestamp
                 .as_ref()
                 .unwrap()
                 .encode(stream, ctx)?;
             if encoding_mask.contains(DataValueFlags::HAS_SERVER_PICOSECONDS) {
-                size += self
-                    .server_picoseconds
+                self.server_picoseconds
                     .as_ref()
                     .unwrap()
                     .encode(stream, ctx)?;
             }
         }
-        Ok(size)
+        Ok(())
     }
 }
 

--- a/opcua-types/src/date_time.rs
+++ b/opcua-types/src/date_time.rs
@@ -69,11 +69,7 @@ impl BinaryEncodable for DateTime {
         8
     }
 
-    fn encode<S: Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        _ctx: &Context<'_>,
-    ) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S, _ctx: &Context<'_>) -> EncodingResult<()> {
         let ticks = self.checked_ticks();
         write_i64(stream, ticks)
     }

--- a/opcua-types/src/diagnostic_info.rs
+++ b/opcua-types/src/diagnostic_info.rs
@@ -164,42 +164,37 @@ impl BinaryEncodable for DiagnosticInfo {
         size
     }
 
-    fn encode<S: Write + ?Sized>(
-        &self,
-        stream: &mut S,
-        ctx: &Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size: usize = 0;
-        size += write_u8(stream, self.encoding_mask().bits())?;
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S, ctx: &Context<'_>) -> EncodingResult<()> {
+        write_u8(stream, self.encoding_mask().bits())?;
         if let Some(ref symbolic_id) = self.symbolic_id {
             // Write symbolic id
-            size += write_i32(stream, *symbolic_id)?;
+            write_i32(stream, *symbolic_id)?;
         }
         if let Some(ref namespace_uri) = self.namespace_uri {
             // Write namespace
-            size += namespace_uri.encode(stream, ctx)?;
+            namespace_uri.encode(stream, ctx)?;
         }
         if let Some(ref locale) = self.locale {
             // Write locale
-            size += locale.encode(stream, ctx)?;
+            locale.encode(stream, ctx)?;
         }
         if let Some(ref localized_text) = self.localized_text {
             // Write localized text
-            size += localized_text.encode(stream, ctx)?;
+            localized_text.encode(stream, ctx)?;
         }
         if let Some(ref additional_info) = self.additional_info {
             // Write Additional info
-            size += additional_info.encode(stream, ctx)?;
+            additional_info.encode(stream, ctx)?;
         }
         if let Some(ref inner_status_code) = self.inner_status_code {
             // Write inner status code
-            size += inner_status_code.encode(stream, ctx)?;
+            inner_status_code.encode(stream, ctx)?;
         }
         if let Some(ref inner_diagnostic_info) = self.inner_diagnostic_info {
             // Write inner diagnostic info
-            size += inner_diagnostic_info.clone().encode(stream, ctx)?;
+            inner_diagnostic_info.clone().encode(stream, ctx)?;
         }
-        Ok(size)
+        Ok(())
     }
 }
 

--- a/opcua-types/src/encoding.rs
+++ b/opcua-types/src/encoding.rs
@@ -313,6 +313,18 @@ impl DecodingOptions {
 /// OPC UA Binary Encoding interface. Anything that encodes to binary must implement this. It provides
 /// functions to calculate the size in bytes of the struct (for allocating memory), encoding to a stream
 /// and decoding from a stream.
+///
+/// # Implementing
+///
+/// The majority of implementers should just use the `derive(BinaryEncodable)` macro,
+/// if you need to implement this yourself for some reason, the following _must_ be satisfied:
+///
+///  - `byte_len` must return a length exactly equal to what `encode` will write, or `encode`
+///    must be guaranteed to fail. Since `byte_len` is infallible, you are allowed to
+///    return some invalid value there, then fail later when calling `encode`. This should be avoided.
+///  - `encode` must use `write_all` on the stream, not just `write`, to ensure that all the data
+///    is written, even if the stream is interrupted. Prefer calling `encode` on inner types
+///    instead.
 pub trait BinaryEncodable {
     /// Returns the exact byte length of the structure as it would be if `encode` were called.
     /// This may be called prior to writing to ensure the correct amount of space is available.

--- a/opcua-types/src/extension_object.rs
+++ b/opcua-types/src/extension_object.rs
@@ -334,7 +334,7 @@ impl BinaryEncodable for ExtensionObject {
         // Just default to null here, we'll fail later.
         let mut size = id.map(|n| n.byte_len(ctx)).unwrap_or(2usize);
         size += match &self.body {
-            Some(b) => 4 + b.byte_len_dyn(ctx),
+            Some(b) => 5 + b.byte_len_dyn(ctx),
             None => 1,
         };
 

--- a/opcua-types/src/extension_object.rs
+++ b/opcua-types/src/extension_object.rs
@@ -45,7 +45,7 @@ pub trait DynEncodable: Any + Send + Sync + std::fmt::Debug {
         &self,
         stream: &mut dyn std::io::Write,
         ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize>;
+    ) -> EncodingResult<()>;
 
     #[cfg(feature = "json")]
     /// Encode the struct using reversible OPC-UA JSON encoding.
@@ -96,7 +96,7 @@ macro_rules! blanket_dyn_encodable {
         where
             T: $bound  $(+ $others)* + ExpandedMessageInfo + Any + std::fmt::Debug + Send + Sync + Clone + PartialEq,
         {
-            fn encode_binary(&self, stream: &mut dyn std::io::Write, ctx: &crate::Context<'_>) -> EncodingResult<usize> {
+            fn encode_binary(&self, stream: &mut dyn std::io::Write, ctx: &crate::Context<'_>) -> EncodingResult<()> {
                 BinaryEncodable::encode(self, stream, ctx)
             }
 
@@ -345,27 +345,23 @@ impl BinaryEncodable for ExtensionObject {
         &self,
         mut stream: &mut S,
         ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size = 0;
+    ) -> EncodingResult<()> {
         let type_id = self.binary_type_id();
         let id = type_id.try_resolve(ctx.namespaces());
         let Some(id) = id else {
             return Err(Error::encoding(format!("Unknown encoding ID: {type_id}")));
         };
 
-        size += BinaryEncodable::encode(id.as_ref(), stream, ctx)?;
+        BinaryEncodable::encode(id.as_ref(), stream, ctx)?;
 
         match &self.body {
             Some(b) => {
-                size += write_u8(stream, 0x1)?;
-                size += write_i32(stream, b.byte_len_dyn(ctx) as i32)?;
-                size += b.encode_binary(&mut stream as &mut dyn Write, ctx)?;
+                write_u8(stream, 0x1)?;
+                write_i32(stream, b.byte_len_dyn(ctx) as i32)?;
+                b.encode_binary(&mut stream as &mut dyn Write, ctx)
             }
-            None => {
-                size += write_u8(stream, 0x0)?;
-            }
+            None => write_u8(stream, 0x0),
         }
-        Ok(size)
     }
 }
 impl BinaryDecodable for ExtensionObject {

--- a/opcua-types/src/generated/types/enums.rs
+++ b/opcua-types/src/generated/types/enums.rs
@@ -25,7 +25,7 @@ impl opcua::types::BinaryEncodable for AccessLevelExType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, self.bits())
     }
 }
@@ -93,7 +93,7 @@ impl opcua::types::BinaryEncodable for AccessLevelType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_u8(stream, self.bits())
     }
 }
@@ -160,7 +160,7 @@ impl opcua::types::BinaryEncodable for AccessRestrictionType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i16(stream, self.bits())
     }
 }
@@ -298,7 +298,7 @@ impl opcua::types::BinaryEncodable for ApplicationType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -332,7 +332,7 @@ impl opcua::types::BinaryEncodable for AttributeWriteMask {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, self.bits())
     }
 }
@@ -468,7 +468,7 @@ impl opcua::types::BinaryEncodable for AxisScaleEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -571,7 +571,7 @@ impl opcua::types::BinaryEncodable for BrokerTransportQualityOfService {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -669,7 +669,7 @@ impl opcua::types::BinaryEncodable for BrowseDirection {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -778,7 +778,7 @@ impl opcua::types::BinaryEncodable for BrowseResultMask {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -873,7 +873,7 @@ impl opcua::types::BinaryEncodable for DataChangeTrigger {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -900,7 +900,7 @@ impl opcua::types::BinaryEncodable for DataSetFieldContentMask {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, self.bits())
     }
 }
@@ -966,7 +966,7 @@ impl opcua::types::BinaryEncodable for DataSetFieldFlags {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i16(stream, self.bits())
     }
 }
@@ -1102,7 +1102,7 @@ impl opcua::types::BinaryEncodable for DataSetOrderingType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1197,7 +1197,7 @@ impl opcua::types::BinaryEncodable for DeadbandType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1296,7 +1296,7 @@ impl opcua::types::BinaryEncodable for DiagnosticsLevel {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1322,7 +1322,7 @@ impl opcua::types::BinaryEncodable for EventNotifierType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_u8(stream, self.bits())
     }
 }
@@ -1466,7 +1466,7 @@ impl opcua::types::BinaryEncodable for ExceptionDeviationFormat {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1591,7 +1591,7 @@ impl opcua::types::BinaryEncodable for FilterOperator {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1683,7 +1683,7 @@ impl opcua::types::BinaryEncodable for HistoryUpdateType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1779,7 +1779,7 @@ impl opcua::types::BinaryEncodable for IdentityCriteriaType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1876,7 +1876,7 @@ impl opcua::types::BinaryEncodable for IdType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1902,7 +1902,7 @@ impl opcua::types::BinaryEncodable for JsonDataSetMessageContentMask {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, self.bits())
     }
 }
@@ -1970,7 +1970,7 @@ impl opcua::types::BinaryEncodable for JsonNetworkMessageContentMask {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, self.bits())
     }
 }
@@ -2109,7 +2109,7 @@ impl opcua::types::BinaryEncodable for MessageSecurityMode {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -2207,7 +2207,7 @@ impl opcua::types::BinaryEncodable for ModelChangeStructureVerbMask {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -2302,7 +2302,7 @@ impl opcua::types::BinaryEncodable for MonitoringMode {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -2392,7 +2392,7 @@ impl opcua::types::BinaryEncodable for NamingRuleType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -2551,7 +2551,7 @@ impl opcua::types::BinaryEncodable for NodeAttributesMask {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -2658,7 +2658,7 @@ impl opcua::types::BinaryEncodable for NodeClass {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -2760,7 +2760,7 @@ impl opcua::types::BinaryEncodable for NodeIdType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_u8(stream, *self as u8)
     }
 }
@@ -2852,7 +2852,7 @@ impl opcua::types::BinaryEncodable for OpenFileMode {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -2947,7 +2947,7 @@ impl opcua::types::BinaryEncodable for OverrideValueHandling {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -3039,7 +3039,7 @@ impl opcua::types::BinaryEncodable for PerformUpdateType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -3069,7 +3069,7 @@ impl opcua::types::BinaryEncodable for PermissionType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, self.bits())
     }
 }
@@ -3207,7 +3207,7 @@ impl opcua::types::BinaryEncodable for PubSubDiagnosticsCounterClassification {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -3304,7 +3304,7 @@ impl opcua::types::BinaryEncodable for PubSubState {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -3405,7 +3405,7 @@ impl opcua::types::BinaryEncodable for RedundancySupport {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -3502,7 +3502,7 @@ impl opcua::types::BinaryEncodable for SecurityTokenRequestType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -3607,7 +3607,7 @@ impl opcua::types::BinaryEncodable for ServerState {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -3702,7 +3702,7 @@ impl opcua::types::BinaryEncodable for StructureType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -3802,7 +3802,7 @@ impl opcua::types::BinaryEncodable for TimestampsToReturn {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -3903,7 +3903,7 @@ impl opcua::types::BinaryEncodable for TrustListMasks {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -3930,7 +3930,7 @@ impl opcua::types::BinaryEncodable for UadpDataSetMessageContentMask {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, self.bits())
     }
 }
@@ -4000,7 +4000,7 @@ impl opcua::types::BinaryEncodable for UadpNetworkMessageContentMask {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, self.bits())
     }
 }
@@ -4138,7 +4138,7 @@ impl opcua::types::BinaryEncodable for UserTokenType {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }

--- a/opcua-types/src/guid.rs
+++ b/opcua-types/src/guid.rs
@@ -78,10 +78,8 @@ impl BinaryEncodable for Guid {
         &self,
         stream: &mut S,
         _ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size: usize = 0;
-        size += process_encode_io_result(stream.write(self.uuid.as_bytes()))?;
-        Ok(size)
+    ) -> EncodingResult<()> {
+        process_encode_io_result(stream.write_all(self.uuid.as_bytes()))
     }
 }
 

--- a/opcua-types/src/localized_text.rs
+++ b/opcua-types/src/localized_text.rs
@@ -79,8 +79,7 @@ impl BinaryEncodable for LocalizedText {
         &self,
         stream: &mut S,
         ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size = 0;
+    ) -> EncodingResult<()> {
         // A bit mask that indicates which fields are present in the stream.
         // The mask has the following bits:
         // 0x01    Locale
@@ -92,14 +91,14 @@ impl BinaryEncodable for LocalizedText {
         if !self.text.is_empty() {
             encoding_mask |= 0x2;
         }
-        size += encoding_mask.encode(stream, ctx)?;
+        encoding_mask.encode(stream, ctx)?;
         if !self.locale.is_empty() {
-            size += self.locale.encode(stream, ctx)?;
+            self.locale.encode(stream, ctx)?;
         }
         if !self.text.is_empty() {
-            size += self.text.encode(stream, ctx)?;
+            self.text.encode(stream, ctx)?;
         }
-        Ok(size)
+        Ok(())
     }
 }
 

--- a/opcua-types/src/node_id.rs
+++ b/opcua-types/src/node_id.rs
@@ -348,45 +348,42 @@ impl BinaryEncodable for NodeId {
         &self,
         stream: &mut S,
         ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size: usize = 0;
+    ) -> EncodingResult<()> {
         // Type determines the byte code
         match &self.identifier {
             Identifier::Numeric(value) => {
                 if self.namespace == 0 && *value <= 255 {
                     // node id fits into 2 bytes when the namespace is 0 and the value <= 255
-                    size += write_u8(stream, 0x0)?;
-                    size += write_u8(stream, *value as u8)?;
+                    write_u8(stream, 0x0)?;
+                    write_u8(stream, *value as u8)
                 } else if self.namespace <= 255 && *value <= 65535 {
                     // node id fits into 4 bytes when namespace <= 255 and value <= 65535
-                    size += write_u8(stream, 0x1)?;
-                    size += write_u8(stream, self.namespace as u8)?;
-                    size += write_u16(stream, *value as u16)?;
+                    write_u8(stream, 0x1)?;
+                    write_u8(stream, self.namespace as u8)?;
+                    write_u16(stream, *value as u16)
                 } else {
                     // full node id
-                    size += write_u8(stream, 0x2)?;
-                    size += write_u16(stream, self.namespace)?;
-                    size += write_u32(stream, *value)?;
+                    write_u8(stream, 0x2)?;
+                    write_u16(stream, self.namespace)?;
+                    write_u32(stream, *value)
                 }
             }
             Identifier::String(value) => {
-                size += write_u8(stream, 0x3)?;
-                size += write_u16(stream, self.namespace)?;
-                size += value.encode(stream, ctx)?;
+                write_u8(stream, 0x3)?;
+                write_u16(stream, self.namespace)?;
+                value.encode(stream, ctx)
             }
             Identifier::Guid(value) => {
-                size += write_u8(stream, 0x4)?;
-                size += write_u16(stream, self.namespace)?;
-                size += value.encode(stream, ctx)?;
+                write_u8(stream, 0x4)?;
+                write_u16(stream, self.namespace)?;
+                value.encode(stream, ctx)
             }
             Identifier::ByteString(value) => {
-                size += write_u8(stream, 0x5)?;
-                size += write_u16(stream, self.namespace)?;
-                size += value.encode(stream, ctx)?;
+                write_u8(stream, 0x5)?;
+                write_u16(stream, self.namespace)?;
+                value.encode(stream, ctx)
             }
         }
-        assert_eq!(size, self.byte_len(ctx));
-        Ok(size)
     }
 }
 

--- a/opcua-types/src/qualified_name.rs
+++ b/opcua-types/src/qualified_name.rs
@@ -88,11 +88,9 @@ impl BinaryEncodable for QualifiedName {
         &self,
         stream: &mut S,
         ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size: usize = 0;
-        size += self.namespace_index.encode(stream, ctx)?;
-        size += self.name.encode(stream, ctx)?;
-        Ok(size)
+    ) -> EncodingResult<()> {
+        self.namespace_index.encode(stream, ctx)?;
+        self.name.encode(stream, ctx)
     }
 }
 impl BinaryDecodable for QualifiedName {

--- a/opcua-types/src/request_header.rs
+++ b/opcua-types/src/request_header.rs
@@ -135,16 +135,14 @@ impl BinaryEncodable for RequestHeader {
         &self,
         stream: &mut S,
         ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size: usize = 0;
-        size += self.authentication_token.encode(stream, ctx)?;
-        size += self.timestamp.encode(stream, ctx)?;
-        size += self.request_handle.encode(stream, ctx)?;
-        size += self.return_diagnostics.bits().encode(stream, ctx)?;
-        size += self.audit_entry_id.encode(stream, ctx)?;
-        size += self.timeout_hint.encode(stream, ctx)?;
-        size += self.additional_header.encode(stream, ctx)?;
-        Ok(size)
+    ) -> EncodingResult<()> {
+        self.authentication_token.encode(stream, ctx)?;
+        self.timestamp.encode(stream, ctx)?;
+        self.request_handle.encode(stream, ctx)?;
+        self.return_diagnostics.bits().encode(stream, ctx)?;
+        self.audit_entry_id.encode(stream, ctx)?;
+        self.timeout_hint.encode(stream, ctx)?;
+        self.additional_header.encode(stream, ctx)
     }
 }
 

--- a/opcua-types/src/response_header.rs
+++ b/opcua-types/src/response_header.rs
@@ -64,15 +64,13 @@ impl BinaryEncodable for ResponseHeader {
         &self,
         stream: &mut S,
         ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size = 0;
-        size += self.timestamp.encode(stream, ctx)?;
-        size += self.request_handle.encode(stream, ctx)?;
-        size += self.service_result.encode(stream, ctx)?;
-        size += self.service_diagnostics.encode(stream, ctx)?;
-        size += self.string_table.encode(stream, ctx)?;
-        size += self.additional_header.encode(stream, ctx)?;
-        Ok(size)
+    ) -> EncodingResult<()> {
+        self.timestamp.encode(stream, ctx)?;
+        self.request_handle.encode(stream, ctx)?;
+        self.service_result.encode(stream, ctx)?;
+        self.service_diagnostics.encode(stream, ctx)?;
+        self.string_table.encode(stream, ctx)?;
+        self.additional_header.encode(stream, ctx)
     }
 }
 

--- a/opcua-types/src/status_code.rs
+++ b/opcua-types/src/status_code.rs
@@ -291,7 +291,7 @@ impl SimpleBinaryEncodable for StatusCode {
         4
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         write_u32(stream, self.bits())
     }
 }

--- a/opcua-types/src/string.rs
+++ b/opcua-types/src/string.rs
@@ -92,15 +92,13 @@ impl SimpleBinaryEncodable for UAString {
         }
     }
 
-    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<usize> {
+    fn encode<S: Write + ?Sized>(&self, stream: &mut S) -> EncodingResult<()> {
         // Strings are encoded as UTF8 chars preceded by an Int32 length. A -1 indicates a null string
         match &self.value {
             Some(s) => {
-                let mut size: usize = 0;
-                size += write_i32(stream, s.len() as i32)?;
+                write_i32(stream, s.len() as i32)?;
                 let buf = s.as_bytes();
-                size += process_encode_io_result(stream.write(buf))?;
-                Ok(size)
+                process_encode_io_result(stream.write_all(buf))
             }
             None => write_i32(stream, -1),
         }

--- a/opcua-types/src/tests/mod.rs
+++ b/opcua-types/src/tests/mod.rs
@@ -34,12 +34,8 @@ where
 
     // Encode to stream
     let start_pos = stream.position();
-    let result = value.encode(&mut stream, &ctx);
+    value.encode(&mut stream, &ctx).expect("Encoding failed");
     let end_pos = stream.position();
-    assert!(result.is_ok());
-
-    // This ensures the size reported is the same as the byte length impl
-    assert_eq!(result.unwrap(), byte_len);
 
     // Test that the position matches the byte_len
     assert_eq!((end_pos - start_pos) as usize, byte_len);
@@ -88,20 +84,14 @@ where
     let byte_len = value.byte_len(&ctx);
     let mut stream = Cursor::new(vec![0; byte_len]);
 
-    let result = value.encode(&mut stream, &ctx);
-    assert!(result.is_ok());
-
-    let size = result.unwrap();
-    assert_eq!(size, expected.len());
-    println!("Size of encoding = {}", size);
-    assert_eq!(size, byte_len);
+    value.encode(&mut stream, &ctx).expect("Encoding failed");
 
     let actual = stream.into_inner();
 
     println!("actual {:?}", actual);
     println!("expected {:?}", expected);
 
-    for i in 0..size {
+    for i in 0..expected.len() {
         assert_eq!(actual[i], expected[i])
     }
 }

--- a/opcua-types/src/variant/mod.rs
+++ b/opcua-types/src/variant/mod.rs
@@ -262,9 +262,9 @@ impl Variant {
         &self,
         stream: &mut S,
         ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize> {
+    ) -> EncodingResult<()> {
         match self {
-            Variant::Empty => Ok(0),
+            Variant::Empty => Ok(()),
             Variant::Boolean(value) => value.encode(stream, ctx),
             Variant::SByte(value) => value.encode(stream, ctx),
             Variant::Byte(value) => value.encode(stream, ctx),
@@ -291,22 +291,22 @@ impl Variant {
             Variant::Variant(value) => value.encode(stream, ctx),
             Variant::DiagnosticInfo(value) => value.encode(stream, ctx),
             Variant::Array(array) => {
-                let mut size = write_i32(stream, array.values.len() as i32)?;
+                write_i32(stream, array.values.len() as i32)?;
                 for value in array.values.iter() {
-                    size += Variant::encode_variant_value(stream, value, ctx)?;
+                    Variant::encode_variant_value(stream, value, ctx)?;
                 }
                 if let Some(ref dimensions) = array.dimensions {
                     // Note array dimensions are encoded as Int32 even though they are presented
                     // as UInt32 through attribute.
 
                     // Encode dimensions length
-                    size += write_i32(stream, dimensions.len() as i32)?;
+                    write_i32(stream, dimensions.len() as i32)?;
                     // Encode dimensions
                     for dimension in dimensions {
-                        size += write_i32(stream, *dimension as i32)?;
+                        write_i32(stream, *dimension as i32)?;
                     }
                 }
-                Ok(size)
+                Ok(())
             }
         }
     }
@@ -329,15 +329,12 @@ impl BinaryEncodable for Variant {
         &self,
         stream: &mut S,
         ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize> {
-        let mut size: usize = 0;
-
+    ) -> EncodingResult<()> {
         // Encoding mask will include the array bits if applicable for the type
         let encoding_mask = self.encoding_mask();
-        size += write_u8(stream, encoding_mask)?;
+        write_u8(stream, encoding_mask)?;
 
-        size += self.encode_value(stream, ctx)?;
-        Ok(size)
+        self.encode_value(stream, ctx)
     }
 }
 
@@ -527,9 +524,9 @@ impl Variant {
         stream: &mut S,
         value: &Variant,
         ctx: &crate::Context<'_>,
-    ) -> EncodingResult<usize> {
+    ) -> EncodingResult<()> {
         match value {
-            Variant::Empty => Ok(0),
+            Variant::Empty => Ok(()),
             Variant::Boolean(value) => value.encode(stream, ctx),
             Variant::SByte(value) => value.encode(stream, ctx),
             Variant::Byte(value) => value.encode(stream, ctx),

--- a/samples/custom-codegen/src/generated/types/enums.rs
+++ b/samples/custom-codegen/src/generated/types/enums.rs
@@ -93,7 +93,7 @@ impl opcua::types::BinaryEncodable for IMTagSelectorEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -192,7 +192,7 @@ impl opcua::types::BinaryEncodable for PnARStateEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -289,7 +289,7 @@ impl opcua::types::BinaryEncodable for PnARTypeEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -388,7 +388,7 @@ impl opcua::types::BinaryEncodable for PnAssetChangeEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -489,7 +489,7 @@ impl opcua::types::BinaryEncodable for PnAssetTypeEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -586,7 +586,7 @@ impl opcua::types::BinaryEncodable for PnChannelAccumulativeEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -687,7 +687,7 @@ impl opcua::types::BinaryEncodable for PnChannelDirectionEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -788,7 +788,7 @@ impl opcua::types::BinaryEncodable for PnChannelMaintenanceEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -889,7 +889,7 @@ impl opcua::types::BinaryEncodable for PnChannelSpecifierEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -998,7 +998,7 @@ impl opcua::types::BinaryEncodable for PnChannelTypeEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1099,7 +1099,7 @@ impl opcua::types::BinaryEncodable for PnDeviceStateEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1201,7 +1201,7 @@ impl opcua::types::BinaryEncodable for PnLinkStateEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1304,7 +1304,7 @@ impl opcua::types::BinaryEncodable for PnModuleStateEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1411,7 +1411,7 @@ impl opcua::types::BinaryEncodable for PnPortStateEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1508,7 +1508,7 @@ impl opcua::types::BinaryEncodable for PnSubmoduleAddInfoEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1611,7 +1611,7 @@ impl opcua::types::BinaryEncodable for PnSubmoduleARInfoEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }
@@ -1712,7 +1712,7 @@ impl opcua::types::BinaryEncodable for PnSubmoduleIdentInfoEnumeration {
         &self,
         stream: &mut S,
         _ctx: &opcua::types::Context<'_>,
-    ) -> opcua::types::EncodingResult<usize> {
+    ) -> opcua::types::EncodingResult<()> {
         opcua::types::write_i32(stream, *self as i32)
     }
 }


### PR DESCRIPTION
Optimization of chunk generation. Requires using `write_all` in `encode`, which is a good idea in general.